### PR TITLE
fix(make): add --packages flag required for retries

### DIFF
--- a/build/make/go.mak
+++ b/build/make/go.mak
@@ -34,7 +34,7 @@ format:
 
 # Run specs.
 specs:
-	gotestsum --rerun-fails --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -failfast -covermode=atomic -coverpkg=./... -coverprofile=test/reports/profile.cov ./...
+	gotestsum --rerun-fails --packages="./..." --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -failfast -covermode=atomic -coverpkg=./... -coverprofile=test/reports/profile.cov ./...
 
 remove-generated-coverage:
 	cat test/reports/profile.cov | grep -Ev "${COV}" > test/reports/final.cov

--- a/build/make/service.mak
+++ b/build/make/service.mak
@@ -104,7 +104,7 @@ features: build-test
 
 # Run all the specs.
 specs:
-	gotestsum --rerun-fails --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -failfast -covermode=atomic -coverpkg=./... -coverprofile=test/reports/profile.cov ./...
+	gotestsum --rerun-fails --packages="./..." --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -failfast -covermode=atomic -coverpkg=./... -coverprofile=test/reports/profile.cov ./...
 
 # Get go dep.
 go-get:


### PR DESCRIPTION
ERROR when go test args are used with --rerun-fails the list of packages to test must be specified by the --packages flag