### PR TITLE
feat(make): pass package to benchmark

### DIFF
--- a/build/make/go.mak
+++ b/build/make/go.mak
@@ -49,7 +49,11 @@ specs:
 
 # Run all benchmarks.
 benchmarks:
-	go test -vet=off -race -mod vendor -bench=. -run=Benchmark -benchmem ./...
+	go test -vet=off -race -mod vendor -bench=. -run=Benchmark -benchmem -memprofile test/reports/mem.prof ./$(package)
+
+# RUn pprod for the benchmarks.
+benchmarks-pprof:
+	go tool pprof test/reports/mem.prof
 
 remove-generated-coverage:
 	cat test/reports/profile.cov | grep -Ev "${COV}" > test/reports/final.cov


### PR DESCRIPTION
We can't have a mem profile for all packages, so we need to specify it.