### PR TITLE
feat(ai): clarify features and specs test selection

### DIFF
--- a/skills/coding-standards/SKILL.md
+++ b/skills/coding-standards/SKILL.md
@@ -35,6 +35,8 @@ Follow repository-local instructions first, then use this skill to keep behavior
 - Do not assume tools exist. Confirm commands from the repository's Makefiles, scripts, CI, or documentation.
 - Infer likely commands from included `bin/build/make/*.mak` fragments, then verify which targets are exposed by the repo's root `Makefile`.
 - If the repository includes `./bin`, inspect which shared make fragments and targets are actually used by the consuming repo before relying on them.
+- Do not force a repository into a single workflow type. A project may intentionally expose `features`, `specs`, or both, and that combination is by design.
+- When adding or updating tests, use the repo's actual test workflow. If a project exposes only `specs`, write and run `specs`; if it exposes only `features`, write and run `features`; if it exposes both, choose the one that matches the behavior under change.
 - Prefer `make` targets such as `help`, `dep`, `lint`, `specs`, `features`, `benchmarks`, `coverage`, or `sec` when the repo exposes them.
 - When the user asks for a PR, always prepare:
   - a single-line commit message written entirely in lowercase plain text

--- a/skills/coding-standards/references/make-fragments.md
+++ b/skills/coding-standards/references/make-fragments.md
@@ -41,5 +41,7 @@ Use this reference when a repository includes `bin/build/make/*.mak` and you nee
 
 - If the root `Makefile` includes `ruby.mak`, expect Ruby lint and cucumber-style feature flows.
 - If it includes `go.mak`, expect Go lint, test, coverage, and security flows.
+- If it exposes only one of `features` or `specs`, treat that as the repo's intended test entry point for new or updated tests in that area.
+- If it includes both, treat that as an intentional mixed workflow. A repo can validly expose `features`, `specs`, or both.
 - If it includes both, prefer the target that best matches the files you changed and widen validation only when the change crosses boundaries.
 - If the repo overrides a target after including a fragment, trust the root `Makefile` behavior over the fragment default.

--- a/skills/coding-standards/references/verification.md
+++ b/skills/coding-standards/references/verification.md
@@ -30,6 +30,8 @@ Use this reference when choosing which checks to run and how to describe verific
 - For Ruby changes, prefer the repo's lint and feature/benchmark entry points when they exist.
 - For CI or build changes, validate the closest local command that mirrors the affected pipeline step.
 - If the repository exposes `lint`, use it after relevant edits unless a narrower lint target is clearly better.
+- If a repository exposes only `features` or only `specs`, use that existing test entry point for test changes and validation instead of assuming the missing one should exist.
+- If a repository exposes both `features` and `specs`, choose validation based on the affected behavior instead of assuming only one belongs in that repo.
 - If a public interface changes, include a compatibility check in your validation thinking, even if that check is partly manual.
 - If a change affects hot paths or throughput-sensitive code, include benchmark or performance reasoning when the repo supports it.
 - If a change adds runtime behavior that may need diagnosis in production, check whether logging, metrics, tracing, or error context should also be updated.

--- a/skills/coding-standards/references/workflow.md
+++ b/skills/coding-standards/references/workflow.md
@@ -17,6 +17,8 @@ Use this reference when you need to establish context quickly and consistently i
 - Confirm that a target or script is actually wired into the repo before relying on it.
 - When `help.mak` is included, use `make` or `make help` as the quickest way to discover the command surface.
 - When a repo includes `ruby.mak` or `go.mak`, use those fragments to infer likely workflows, but still trust the root `Makefile` as the final interface.
+- Do not assume `features` and `specs` identify mutually exclusive project types. A repository may intentionally expose either one or both.
+- When planning tests, follow the workflow the repository actually exposes. If only one of `features` or `specs` exists, use that one and do not invent the other.
 
 ## When The Repo Uses `./bin`
 


### PR DESCRIPTION
## What

Updated the shared `coding-standards` skill and supporting references to make test workflow selection explicit:

- repos may intentionally expose `features`, `specs`, or both
- if only one of `features` or `specs` exists, agents should write and run tests through that existing entry point
- if both exist, agents should choose the test path that matches the behavior being changed

This guidance was added in:
- [skills/coding-standards/SKILL.md](/Users/alejandro/code/bin/skills/coding-standards/SKILL.md)
- [skills/coding-standards/references/workflow.md](/Users/alejandro/code/bin/skills/coding-standards/references/workflow.md)
- [skills/coding-standards/references/make-fragments.md](/Users/alejandro/code/bin/skills/coding-standards/references/make-fragments.md)
- [skills/coding-standards/references/verification.md](/Users/alejandro/code/bin/skills/coding-standards/references/verification.md)

## Why

This keeps agents from treating `features` and `specs` as mutually exclusive project identities and prevents them from inventing a missing test workflow. It makes mixed repos first-class and makes single-workflow repos behave predictably when agents add or validate tests.

## Testing

Ran:
- `markdownlint-cli2 skills/coding-standards/SKILL.md skills/coding-standards/references/workflow.md skills/coding-standards/references/make-fragments.md skills/coding-standards/references/verification.md`

Passed:
- targeted markdown lint on all updated files

Not run:
- broader repo checks, because this change only updates markdown guidance