### PR TITLE
feat(ai): tighten coding standards skill guidance

### DIFF
--- a/skills/coding-standards/SKILL.md
+++ b/skills/coding-standards/SKILL.md
@@ -12,6 +12,7 @@ Follow repository-local instructions first, then use this skill to keep behavior
 ## Core Workflow
 
 - Read repository-local guidance before editing: `AGENTS.md`, `README.md`, root `Makefile`, and CI configuration.
+- Before doing deeper investigation or analysis, run `make dep` when the repository exposes it so the local dependency state is current. If `make dep` cannot be run, say so plainly and continue with that constraint in mind.
 - Treat repository-local instructions as higher priority than this skill. Use this skill to fill gaps and standardize behavior across repos.
 - Treat CI configuration as the best source of truth for what must pass in the current repository.
 - Inspect the relevant codepaths and entrypoints before proposing or making changes.
@@ -24,6 +25,7 @@ Follow repository-local instructions first, then use this skill to keep behavior
 - If behavior changes, add or update tests unless the repository truly cannot support it. When tests are not added, state the reason explicitly.
 - Prefer the standard library and existing project dependencies before adding a new dependency. If a new dependency is required, keep it narrowly scoped and explain why it is necessary.
 - In Go code, do not alias imports unless there is a real collision or required disambiguation. If the project defines a package whose name overlaps with a standard-library package, prefer the project package as the natural unaliased import and alias only the standard-library import or referenced stdlib identifiers needed to make the code work cleanly and keep imports minimal.
+- In Go code, keep package-level GoDoc in `doc.go` files instead of attaching package documentation comments to other `.go` files.
 - Treat documentation for public code as required work, not optional polish. When public packages, modules, types, functions, methods, classes, or commands change, add or update accurate documentation in the repository's native style, such as GoDoc comments or RDoc, and include examples when the public API is non-trivial and the repository's doc style supports them.
 - Prefer updating existing documentation over creating new documentation files unless the repository clearly expects a new document.
 - Do not silently break public APIs, flags, env vars, config, file formats, or Make targets that downstream users may depend on. Preserve backward compatibility when feasible, and call out intentional breaking changes explicitly.

--- a/skills/coding-standards/references/go.md
+++ b/skills/coding-standards/references/go.md
@@ -2,6 +2,12 @@
 
 Use this reference when working in Go repositories.
 
+## Package Documentation
+
+- Keep package-level GoDoc in `doc.go` files.
+- Do not leave package documentation comments on unrelated source files such as `main.go`, `client.go`, or `types.go`.
+- When package documentation needs to change, update `doc.go` rather than scattering package comments across implementation files.
+
 ## Package Name Collisions
 
 - Do not alias a Go import unless there is a real collision or required disambiguation.

--- a/skills/coding-standards/references/verification.md
+++ b/skills/coding-standards/references/verification.md
@@ -35,7 +35,7 @@ Use this reference when choosing which checks to run and how to describe verific
 - If a public interface changes, include a compatibility check in your validation thinking, even if that check is partly manual.
 - If a change affects hot paths or throughput-sensitive code, include benchmark or performance reasoning when the repo supports it.
 - If a change adds runtime behavior that may need diagnosis in production, check whether logging, metrics, tracing, or error context should also be updated.
-- For exported or public Go code, verify package docs and doc comments remain accurate and complete.
+- For exported or public Go code, verify package docs and doc comments remain accurate and complete, and confirm package-level GoDoc lives in `doc.go`.
 - For public Ruby APIs, classes, modules, and methods, verify the corresponding RDoc remains accurate and complete.
 - If a repo exposes `dep`, `lint`, `specs`, `features`, `benchmarks`, `coverage`, or `sec`, prefer those names over ad hoc tool invocations.
 - For this shared `bin` repo itself, CI currently treats `make scripts-lint`, `make docker-lint`, `make lint`, and `make sec-lint` as the authoritative checks.

--- a/skills/coding-standards/references/workflow.md
+++ b/skills/coding-standards/references/workflow.md
@@ -6,15 +6,17 @@ Use this reference when you need to establish context quickly and consistently i
 
 1. Read `AGENTS.md` if present.
 2. Read `README.md` and the root `Makefile`.
-3. Inspect which `bin/build/make/*.mak` fragments are included by the root `Makefile`.
-4. Inspect CI configuration to learn what must pass.
-5. Inspect only the files and scripts relevant to the requested change.
+3. Run `make dep` if the repository exposes it so local dependencies and tool wrappers are up to date before deeper investigation.
+4. Inspect which `bin/build/make/*.mak` fragments are included by the root `Makefile`.
+5. Inspect CI configuration to learn what must pass.
+6. Inspect only the files and scripts relevant to the requested change.
 
 ## Prefer Repository Entry Points
 
 - Prefer repository entry points such as `make` targets over calling tools directly.
 - Use direct tool invocations only when the repository does not provide a stable entry point or when a narrower check is clearly better for the task.
 - Confirm that a target or script is actually wired into the repo before relying on it.
+- If the repo exposes `make dep`, run it before deeper investigation or analysis unless the user asked you not to or the environment prevents it.
 - When `help.mak` is included, use `make` or `make help` as the quickest way to discover the command surface.
 - When a repo includes `ruby.mak` or `go.mak`, use those fragments to infer likely workflows, but still trust the root `Makefile` as the final interface.
 - Do not assume `features` and `specs` identify mutually exclusive project types. A repository may intentionally expose either one or both.


### PR DESCRIPTION
## What

- Add a shared coding-standards rule that requires running `make dep` before deeper investigation or analysis when the repository exposes it, with explicit guidance to call out environment constraints when it cannot run.
- Add Go-specific documentation guidance requiring package-level GoDoc to live in `doc.go` files.
- Update the workflow, Go, and verification references so the investigation order and review expectations match those rules.

## Why

- This keeps agent investigations grounded in the latest dependency state instead of analyzing against a stale local environment.
- This makes the Go documentation convention explicit and consistent, so package docs are easier to find and maintain.
- This keeps the top-level skill and its supporting references aligned, which reduces drift in future agent behavior.

## Testing

- Ran `make dep` and it passed: dependencies were already satisfied.
- Ran `make lint` and it passed.
- No tests were added because this is a documentation-only skill update.