### PR TITLE
feat(skills): refine coding standards skill and references

### DIFF
--- a/skills/coding-standards/SKILL.md
+++ b/skills/coding-standards/SKILL.md
@@ -1,72 +1,55 @@
 ---
 name: coding-standards
-description: Apply shared cross-repository engineering expectations when working in repositories that may use the shared ./bin submodule and Makefile fragments. Use when implementing features, fixing bugs, reviewing code, updating CI, changing tests, or making maintenance edits that need consistent repo inspection, minimal safe changes, validation strategy, and review format.
+description: Apply shared cross-repository engineering expectations for repo inspection, safe changes, validation, and review output.
 ---
 
 # Coding Standards
 
 ## Overview
 
-Follow repository-local instructions first, then use this skill to keep behavior consistent across related codebases. Build context before editing, infer available workflows from the repo's included make fragments and CI configuration, prefer the smallest safe change, validate with the narrowest relevant checks, and report clearly what was verified and what remains uncertain.
+Follow repository-local instructions first, then use this skill to keep behavior consistent across repositories that share this reusable `./bin` make-and-script workflow.
+Use the core workflow for general execution. Prefer the smallest safe change, validate with the narrowest relevant checks, and report clearly what was verified and what remains uncertain.
 
 ## Core Workflow
 
-- Read repository-local guidance before editing: `AGENTS.md`, `README.md`, root `Makefile`, and CI configuration.
-- Before doing deeper investigation or analysis, run `make dep` when the repository exposes it so the local dependency state is current. If `make dep` cannot be run, say so plainly and continue with that constraint in mind.
+### Understand The Repo
+
+- Read the relevant repository-local guidance that exists before editing, such as `AGENTS.md`, `README.md`, the root `Makefile`, and CI configuration.
+- In repositories that expose `make dep`, run it before validation, tests, lint, or code changes unless the task is purely read-only. In this ecosystem, dependency drift is common enough that skipping this step often produces misleading failures or stale tool behavior. If `make dep` cannot be run, say so plainly and continue with that constraint in mind.
 - Treat repository-local instructions as higher priority than this skill. Use this skill to fill gaps and standardize behavior across repos.
-- Treat CI configuration as the best source of truth for what must pass in the current repository.
-- Inspect the relevant codepaths and entrypoints before proposing or making changes.
+- For read-only tasks such as review or analysis, do not force edits, documentation changes, or validation steps that the task does not require.
+- For read-only tasks, gather the needed context, prioritize findings and notable coverage or validation gaps over summaries or implementation advice, and keep the output grounded in the inspected code and repository behavior.
+- Treat CI configuration as a strong signal for what the repository expects to pass, then confirm whether repository-local instructions or the task context imply additional checks.
+
+### Make The Change
+
 - Prefer the smallest change that solves the task end-to-end.
 - Preserve existing project patterns unless a deviation is necessary for correctness, safety, or maintainability.
 - If a decision has non-obvious consequences, pause and verify the direction with a short plan before committing to it.
 - Keep diffs tight. Avoid incidental refactors, large renames, or formatting churn unless they are required by the task.
-- Keep agent-facing Markdown compressed. Prefer concise rules, references, and examples over repeated prose in Markdown files that Codex may load.
-- After every change, check the applicable linting issues before moving on. Prefer the narrowest repo-defined lint command that covers the files you changed, and report clearly when linting could not be run.
 - If behavior changes, add or update tests unless the repository truly cannot support it. When tests are not added, state the reason explicitly.
+- Use the repo's actual test workflow and entrypoints. If the repository exposes named targets such as `specs` or `features`, use the one that matches the behavior under change instead of forcing a different test vocabulary.
 - Prefer the standard library and existing project dependencies before adding a new dependency. If a new dependency is required, keep it narrowly scoped and explain why it is necessary.
-- In Go code, do not alias imports unless there is a real collision or required disambiguation. If the project defines a package whose name overlaps with a standard-library package, prefer the project package as the natural unaliased import and alias only the standard-library import or referenced stdlib identifiers needed to make the code work cleanly and keep imports minimal.
-- In Go code, keep package-level GoDoc in `doc.go` files instead of attaching package documentation comments to other `.go` files.
-- Treat documentation for public code as required work, not optional polish. When public packages, modules, types, functions, methods, classes, or commands change, add or update accurate documentation in the repository's native style, such as GoDoc comments or RDoc, and include examples when the public API is non-trivial and the repository's doc style supports them.
+
+### Protect Users And Interfaces
+
+- Treat documentation for user-facing or documented interfaces as required work, not optional polish.
+- When a change alters the behavior, usage, or contract of a documented interface, update the relevant documentation in the repository's native style and include examples when the interface is non-trivial and the doc style supports them.
 - Prefer updating existing documentation over creating new documentation files unless the repository clearly expects a new document.
-- Do not silently break public APIs, flags, env vars, config, file formats, or Make targets that downstream users may depend on. Preserve backward compatibility when feasible, and call out intentional breaking changes explicitly.
-- If a breaking or behavior-changing rollout needs migration steps, deprecation handling, or staged adoption, include that work as part of the change instead of leaving it implicit.
-- For performance-sensitive paths or new operational behavior, consider benchmark impact, runtime cost, and the observability needed to understand the feature in production.
+- Do not silently break user-facing or documented APIs, flags, env vars, config, file formats, or Make targets that downstream users may depend on. Preserve backward compatibility when feasible, and call out intentional breaking changes explicitly.
+- If a change to existing behavior or interfaces needs migration or deprecation work, include that work when it is relevant instead of leaving it implicit.
+- If a change introduces or materially reshapes runtime-critical or hard-to-diagnose behavior, such as hot paths, background jobs, retries, polling, or concurrency, consider benchmark impact, runtime cost, and the observability needed to understand the feature in production.
 - Avoid committing secrets, weakening security controls, or introducing unsafe handling of shell commands, file paths, auth, or untrusted input.
 - Do not hand-edit generated code, vendored code, or lockfiles unless the task specifically requires it or regeneration is part of the intended workflow.
 - Do not leave temporary code behind without calling it out. Remove debug prints, temporary instrumentation, dead code, throwaway TODOs, and short-term compatibility shims unless they are intentionally part of the change with a clear rationale.
-- Do not assume tools exist. Confirm commands from the repository's Makefiles, scripts, CI, or documentation.
-- Infer likely commands from included `bin/build/make/*.mak` fragments, then verify which targets are exposed by the repo's root `Makefile`.
-- If the repository includes `./bin`, inspect which shared make fragments and targets are actually used by the consuming repo before relying on them.
-- Do not force a repository into a single workflow type. A project may intentionally expose `features`, `specs`, or both, and that combination is by design.
-- When adding or updating tests, use the repo's actual test workflow. If a project exposes only `specs`, write and run `specs`; if it exposes only `features`, write and run `features`; if it exposes both, choose the one that matches the behavior under change.
-- Prefer `make` targets such as `help`, `dep`, `lint`, `specs`, `features`, `benchmarks`, `coverage`, or `sec` when the repo exposes them.
-- When the user asks for a PR, always prepare:
-  - a single-line commit message written entirely in lowercase plain text
-  - the commit message first, by itself
-  - a PR summary based on both relevant committed changes and current working-tree changes when both exist
-  - a markdown PR summary after the commit message with exactly these section titles: `What`, `Why`, and `Testing`
-- Do not run destructive or remote-effect git helpers such as reset, purge, branch deletion, force-push, merge, or amend flows unless the user explicitly asks for that action.
-- Do not revert or overwrite unrelated user changes.
+
+### Validate And Report
+
+- Do not assume tools exist. Discover likely commands from the repository's Makefiles, scripts, CI, documentation, and any shared make fragments the repository actually uses.
+- Prefer the narrowest verified entrypoint for the task, whether that is a repo-exposed `make` target or a direct command the repository's workflow expects.
+- Before wrapping up code changes, run the applicable lint checks. Prefer the narrowest repo-defined lint command that covers the files you changed, and report clearly when linting could not be run.
 
 ## Use The References
 
-- Read `references/workflow.md` when you need help interpreting repo structure, `./bin` usage, target discovery, or the right investigation sequence.
-- Read `references/verification.md` when deciding what to run, how to scope validation, or how to report checks honestly.
-- Read `references/make-fragments.md` when the repository includes the shared `./bin` make fragments and you need to infer which commands, wrappers, or gotchas likely apply.
-- Read `references/change-safety.md` when deciding how to handle tests, dependencies, compatibility, generated files, security-sensitive changes, or broader documentation updates.
-- Read `references/go.md` when working in Go repositories and making import, naming, or package-collision decisions.
-- Read `references/ruby.md` when working in Ruby repositories and making public API, documentation, or style decisions.
-- Read `references/review.md` when the user asks for a review or wants risk-focused feedback on a change.
-
-## Done Criteria
-
-- The requested change or analysis is complete.
-- Public-facing code introduced or changed by the work has detailed and accurate documentation in the project's native style.
-- Non-trivial public APIs include examples when the repository's documentation style supports them.
-- Behavior changes are covered by tests, or the reason tests were not added is stated explicitly.
-- Applicable linting was checked after changes and passed, or the reason it could not be checked is stated explicitly.
-- Relevant validation was run and passed, or the reason it could not be run is stated explicitly.
-- Migration, deprecation, performance, and observability impacts are addressed when they are relevant to the change.
-- Temporary code and debug scaffolding are removed or intentionally called out.
-- Important assumptions, tradeoffs, and residual risks are called out.
-- The final response is concise and points to the most important files, checks, or findings.
+- Consult only the specific reference you need for the current task.
+- Each reference focuses on a single concern, so open the one that matches the decision you are making.

--- a/skills/coding-standards/references/change-safety.md
+++ b/skills/coding-standards/references/change-safety.md
@@ -1,37 +1,18 @@
 # Change Safety Reference
 
-Use this reference when deciding how far a change should go and what must accompany it.
-
-## Tests
-
-- If behavior changes, add or update tests unless the repository truly cannot support it.
-- Prefer the narrowest tests that prove the new or changed behavior.
-- If tests are not added, state why plainly in the final response.
-
-## Dependencies
-
-- Prefer the standard library and dependencies that are already in the repository before adding a new one.
-- Add or update dependencies only when they clearly reduce risk, complexity, or maintenance cost.
-- Keep dependency changes narrowly scoped and explain why they are needed.
+Use this reference when deciding how to handle compatibility, documentation, security, and other safety-sensitive edges of a change.
 
 ## Backward Compatibility
 
-- Avoid silently breaking public APIs, exported symbols, commands, flags, env vars, config keys, file formats, and Make targets.
+- Avoid silently breaking user-facing or documented APIs, exported symbols, commands, flags, env vars, config keys, file formats, and Make targets.
 - Preserve existing behavior for downstream consumers when feasible.
 - If a breaking change is necessary, call it out explicitly and document the migration impact.
 
 ## Migration And Deprecation
 
-- If a change needs consumer action, include a migration path as part of the work.
-- Prefer deprecation and staged rollout over abrupt removal when downstream users may be affected.
+- If a change needs consumer action, document the migration path as part of the work.
+- When downstream users are affected, prefer compatibility-preserving transitions over abrupt removal.
 - Document replacement guidance and cleanup expectations for temporary compatibility paths.
-
-## Performance And Observability
-
-- For hot paths, high-volume flows, or potentially expensive operations, consider performance impact before shipping.
-- Add or update benchmarks when performance is material and the repository supports them.
-- Keep new runtime behavior observable through the repo's existing logging, metrics, tracing, or error-reporting patterns.
-- Prefer observability that helps explain production behavior over silent internal complexity.
 
 ## Security Defaults
 
@@ -46,17 +27,10 @@ Use this reference when deciding how far a change should go and what must accomp
 - Update lockfiles only when dependency changes actually require it.
 - When regeneration is needed, prefer the repository's documented generation command.
 
-## Temporary Code Hygiene
-
-- Remove debug prints, temporary instrumentation, dead code, and throwaway TODOs before finishing the change.
-- Keep temporary compatibility shims only when they are part of the intended rollout and call out their cleanup expectations.
-- Do not leave behind scaffolding that obscures the steady-state design unless it is clearly intentional.
-
 ## Documentation Scope
 
-- Public code needs accurate GoDoc, RDoc, or the repository's native API docs.
-- Non-trivial public APIs should include examples when the repository's documentation style supports them.
+- When behavior or operator-facing usage changes, update the corresponding docs in the repository's established locations.
 - Prefer updating existing documentation files over creating new ones unless the repository clearly expects a new document.
-- Place examples in the repository's established locations, such as inline docs, example tests, or README snippets.
+- Place examples where the repository already expects them, such as inline docs, example tests, or README snippets.
 - If user-facing behavior changes, update README snippets, examples, changelog entries, or operator docs when the repository uses them.
 - Keep documentation aligned with the shipped behavior, not the intended behavior.

--- a/skills/coding-standards/references/go.md
+++ b/skills/coding-standards/references/go.md
@@ -2,31 +2,24 @@
 
 Use this reference when working in Go repositories.
 
-## Package Documentation
+## User-Facing APIs
+
+- Keep exported or documented Go APIs aligned with the repository's existing package shape and naming style.
+- Prefer straightforward package and type names over clever aliases or indirection.
+
+## Documentation
 
 - Keep package-level GoDoc in `doc.go` files.
 - Do not leave package documentation comments on unrelated source files such as `main.go`, `client.go`, or `types.go`.
 - When package documentation needs to change, update `doc.go` rather than scattering package comments across implementation files.
 
-## Package Name Collisions
+## Imports And Naming
 
 - Do not alias a Go import unless there is a real collision or required disambiguation.
 - If a project package has the same name as a Go standard-library package, prefer the project package as the natural import in local code.
 - Keep the project package unaliased when possible so the code reads in the repository's domain language.
 - Alias only the standard-library import instead of forcing an awkward alias onto the project package.
 - If the collision is at identifier level rather than import level, alias or rename only the referenced stdlib type, function, or variable needed to keep the code correct and readable.
-
-## Preferred Shape
-
-```go
-import (
-	stdjson "encoding/json"
-
-	"example.com/project/json"
-)
-```
-
-- Prefer this shape over aliasing the project package to something artificial like `projectjson` just to preserve the stdlib name.
 - Keep aliases short, obvious, and specific to the standard-library package they disambiguate.
 - If there is no collision, import the package without an alias.
 - When there is a collision, alias only what is needed on the stdlib side so the project's own package remains the default name in local code and the import block stays minimal.

--- a/skills/coding-standards/references/make-fragments.md
+++ b/skills/coding-standards/references/make-fragments.md
@@ -1,12 +1,12 @@
 # Make Fragments Reference
 
-Use this reference when a repository includes `bin/build/make/*.mak` and you need to infer likely commands or workflow expectations from the selected fragments.
+Use this reference after you have already identified which shared `bin/build/make/*.mak` fragments a repository includes and you need quick help interpreting their likely targets or gotchas.
 
-## Read The Root Makefile First
+## Scope
 
-- Treat the root `Makefile` as the actual interface.
-- Use included fragments to infer what targets probably exist, then confirm the repo exposes them.
-- Prefer `make` or `make help` when the repo includes `help.mak`.
+- Treat the root `Makefile` as the actual interface and the included fragments as supporting context.
+- Use this reference to interpret fragment behavior, not to replace checking which targets the repository really exposes.
+- Use `references/workflow.md` first when you still need to discover the command surface.
 
 ## Common Fragment Map
 
@@ -17,14 +17,12 @@ Use this reference when a repository includes `bin/build/make/*.mak` and you nee
 
 ### `ruby.mak`
 
-- Common targets cover deps, lint/format, features/benchmarks, reports, security, cost, and local environment helpers.
 - Especially relevant targets: `dep`, `lint`, `format`, `features`, `benchmarks`, `sec`, `start`, `stop`.
 - `features` and `benchmarks` call wrappers under `$(PWD)/bin/quality/ruby/...`, so they should be run from the consuming repo root.
 - `start` and `stop` delegate to `bin/build/docker/env`, which may require access to a sibling `../docker` checkout and SSH-based cloning if that repo is missing.
 
 ### `go.mak`
 
-- Common targets cover deps, cleanup, lint/format, tests, benchmarks, coverage, security, cost, and local environment helpers.
 - Especially relevant targets: `dep`, `lint`, `format`, `specs`, `benchmark`, `coverage`, `sec`, `start`, `stop`.
 - `specs` expects a downstream `test/reports/` layout.
 - `coverage` depends on coverage files under `test/reports/`.
@@ -33,7 +31,7 @@ Use this reference when a repository includes `bin/build/make/*.mak` and you nee
 
 ### `git.mak`
 
-- Common helpers cover branch creation, sync, commit/PR flows, reset/purge, and submodule commands.
+- Common helpers cover branch creation, sync, commit/PR flows, destructive cleanup, and submodule commands.
 - Treat these as convenience wrappers, not default actions.
 - Do not use targets that rewrite history, delete branches, discard changes, or push remotely unless the user explicitly asks.
 
@@ -41,7 +39,5 @@ Use this reference when a repository includes `bin/build/make/*.mak` and you nee
 
 - If the root `Makefile` includes `ruby.mak`, expect Ruby lint and cucumber-style feature flows.
 - If it includes `go.mak`, expect Go lint, test, coverage, and security flows.
-- If it exposes only one of `features` or `specs`, treat that as the repo's intended test entry point for new or updated tests in that area.
-- If it includes both, treat that as an intentional mixed workflow. A repo can validly expose `features`, `specs`, or both.
-- If it includes both, prefer the target that best matches the files you changed and widen validation only when the change crosses boundaries.
+- If the repo exposes both `features` and `specs`, choose the target that best matches the area under change.
 - If the repo overrides a target after including a fragment, trust the root `Makefile` behavior over the fragment default.

--- a/skills/coding-standards/references/pr.md
+++ b/skills/coding-standards/references/pr.md
@@ -1,0 +1,22 @@
+# PR Reference
+
+Use this reference when the user asks for a PR or wants a shareable change summary.
+
+## Scope
+
+- Treat PR output as task output, not optional polish.
+- Check whether repository-local instructions define a house style before applying a shared default.
+- Include both relevant committed work and current working-tree changes when both are part of the requested result.
+
+## Shared Default
+
+- Provide the commit message first, on its own line, when the user asks for one.
+- Keep the commit message plain text and easy to reuse.
+- When repository-local guidance does not say otherwise, organize the PR summary around `What`, `Why`, and `Testing`.
+- Keep the testing section honest about what ran, what passed, and what did not run.
+
+## Validation Notes
+
+- Include the actual commands run when they materially help the reader understand the verification.
+- If validation was intentionally scoped, say so plainly.
+- Do not imply that unrun or failing checks passed.

--- a/skills/coding-standards/references/review.md
+++ b/skills/coding-standards/references/review.md
@@ -5,21 +5,10 @@ Use this reference when the user asks for a review.
 ## Review Priorities
 
 - Prioritize bugs, behavioral regressions, risky assumptions, and missing coverage.
-- Flag poor public-facing docs as a real finding, including missing examples where the repo expects them.
-- In Go reviews, flag import naming that favors a colliding standard-library package over the repository's own package when that makes the local code less natural or harder to follow.
-- In Go reviews, flag unnecessary import aliases when there is no actual collision or readability need.
-- In Ruby reviews, flag public APIs that drift from the repository's established style or rely on unnecessary metaprogramming or monkey patches.
-- Flag missing tests for behavior changes as a real finding unless there is a clear reason they cannot be added.
-- Flag unnecessary dependencies, silent compatibility breaks, insecure defaults, unsafe generated-file edits, and leftover debug scaffolding as real findings.
-- Flag missing migration planning, benchmark consideration, or observability when the change makes them relevant.
+- Flag missing tests, compatibility breaks, unsafe defaults, and missing docs when they materially affect the change.
 - Focus on user-visible impact and maintenance risk before style nits.
 - Prefer concrete findings over broad summaries.
-
-## Severity
-
-- Treat correctness, security, data loss, compatibility regressions, and broken automation as high-severity findings.
-- Treat missing tests, weak docs, risky dependency additions, unclear migration impact, and insufficient operational visibility as medium-severity findings unless the impact is clearly minor.
-- Treat style issues and minor clarity suggestions as low-severity feedback.
+- Ground each finding in the inspected code and describe the consequence, not just the preference.
 
 ## Output Format
 
@@ -27,6 +16,7 @@ Use this reference when the user asks for a review.
 - Order findings by severity.
 - Include file and line references for each finding when possible.
 - Keep the summary brief and secondary to the findings.
+- When useful, state the condition or scenario that triggers the problem so the risk is easy to verify.
 
 ## If No Findings
 

--- a/skills/coding-standards/references/ruby.md
+++ b/skills/coding-standards/references/ruby.md
@@ -2,19 +2,21 @@
 
 Use this reference when working in Ruby repositories.
 
-## Public APIs
+## User-Facing APIs
 
-- Keep public modules, classes, and methods consistent with the repository's existing Ruby style and API shape.
+- Keep user-facing or documented modules, classes, and methods consistent with the repository's existing Ruby style and API shape.
 - Prefer straightforward Ruby over clever metaprogramming unless the repository already uses that pattern or the task clearly requires it.
 - Avoid monkey patches unless the repository explicitly relies on them.
 
 ## Documentation
 
-- Public Ruby APIs need accurate RDoc for modules, classes, and public methods.
-- When a public API is non-trivial, include examples if the repository's documentation style supports them.
+- User-facing or documented Ruby APIs need accurate RDoc for modules, classes, methods, and other supported entrypoints.
+- When a user-facing or documented API is non-trivial, include examples if the repository's documentation style supports them.
 - Keep examples aligned with the real public interface and expected calling style.
 
-## Dependencies And Style
+## Conventions
 
-- Prefer the standard library and existing project dependencies before adding new gems.
+- Keep method signatures, return shapes, exceptions, and side effects aligned with the repository's existing Ruby conventions.
+- Prefer explicit objects and methods over clever DSLs or implicit behavior unless the repository already uses that style.
+- When changing a documented command or task interface, update the corresponding docs and examples in the repo's established locations.
 - Match the repository's established naming, error-handling, and test idioms instead of imposing a global Ruby style.

--- a/skills/coding-standards/references/verification.md
+++ b/skills/coding-standards/references/verification.md
@@ -1,42 +1,33 @@
 # Verification Reference
 
-Use this reference when choosing which checks to run and how to describe verification in the final response.
+Use this reference when choosing which checks to run.
 
 ## Verification Principles
 
-- Treat linting as part of the edit loop, not just a final pass.
+- Before wrapping up code changes, run the applicable lint checks.
 - Run the narrowest check that gives credible confidence for the change.
 - Prefer repository-defined commands because they encode project conventions.
-- Use CI configuration as the strongest signal for which checks are truly required.
-- Verify that public-facing code changes include matching documentation updates, not just code and tests.
-- Verify that behavior changes include tests or a clearly stated reason they were not added.
-- Verify that migration or deprecation needs are addressed when consumers are affected.
-- Verify that performance-sensitive or operationally significant changes considered benchmark and observability impact.
+- Use direct commands when they are clearly narrower or better aligned with the task than a broader repo wrapper.
+- Use CI configuration as a strong signal for which checks matter most.
 - Expand from targeted checks to broader checks only when the task or risk justifies it.
 - Never imply a check ran if the wrapper no-op'd because a dependency was missing.
 
 ## Typical Validation Order
 
-1. After each edit, run the most targeted lint command that covers the changed files when the repo provides one.
-2. Run the most targeted test or lint command that exercises the changed behavior.
-3. Run the nearest repository entry point, often a `make` target, when that is the project's standard workflow.
+1. Run the most targeted lint or test command that exercises the changed behavior.
+2. Run the nearest repository entry point, often a `make` target, when that is the project's standard workflow.
+3. Run any additional repo-defined checks that are clearly relevant to the risk of the change.
 4. Run broader lint or test suites only when the change touches shared infrastructure, multiple packages, or release-sensitive behavior.
 
 ## Helpful Heuristics
 
 - For shell scripts, Dockerfiles, and Makefile glue, prefer the repo's lint targets when available.
-- For Markdown files, prefer `markdownlint-cli2` when it is available or when the repository already uses it.
 - For Go changes, prefer the repo's test and lint entry points before inventing ad hoc commands.
 - For Ruby changes, prefer the repo's lint and feature/benchmark entry points when they exist.
 - For CI or build changes, validate the closest local command that mirrors the affected pipeline step.
 - If the repository exposes `lint`, use it after relevant edits unless a narrower lint target is clearly better.
-- If a repository exposes only `features` or only `specs`, use that existing test entry point for test changes and validation instead of assuming the missing one should exist.
-- If a repository exposes both `features` and `specs`, choose validation based on the affected behavior instead of assuming only one belongs in that repo.
-- If a public interface changes, include a compatibility check in your validation thinking, even if that check is partly manual.
-- If a change affects hot paths or throughput-sensitive code, include benchmark or performance reasoning when the repo supports it.
-- If a change adds runtime behavior that may need diagnosis in production, check whether logging, metrics, tracing, or error context should also be updated.
-- For exported or public Go code, verify package docs and doc comments remain accurate and complete, and confirm package-level GoDoc lives in `doc.go`.
-- For public Ruby APIs, classes, modules, and methods, verify the corresponding RDoc remains accurate and complete.
+- If the repository exposes named test entry points, use the one that matches the affected behavior instead of inventing a different test vocabulary.
+- If the repository exposes benchmark or coverage targets that are relevant to the change, prefer those entry points over ad hoc commands.
 - If a repo exposes `dep`, `lint`, `specs`, `features`, `benchmarks`, `coverage`, or `sec`, prefer those names over ad hoc tool invocations.
 - For this shared `bin` repo itself, CI currently treats `make scripts-lint`, `make docker-lint`, `make lint`, and `make sec-lint` as the authoritative checks.
 
@@ -45,17 +36,3 @@ Use this reference when choosing which checks to run and how to describe verific
 - If a repo vendors this shared `bin` project, run validation from the consuming repo when targets depend on `$(PWD)/bin/...`.
 - Do not assume a helper script proves anything unless the downstream wiring matches the way the repo actually executes it.
 - If a wrapper depends on optional tools such as `golangci-lint`, `shellcheck`, `hadolint`, or `govulncheck`, report clearly when the command could not provide full coverage.
-
-## Reporting Rules
-
-- State exactly what you ran.
-- State what passed, failed, or could not run.
-- State which lint checks were run after the changes.
-- State the exact test commands run when tests were executed.
-- If a PR summary includes committed work, make sure the summary reflects the
-  inspected committed changes and not only the uncommitted diff.
-- State whether public-facing documentation was updated or intentionally left unchanged.
-- State whether compatibility, migration, dependency, performance, observability, or security-sensitive concerns were relevant to the change.
-- Call out missing tools, sandbox limits, or environment constraints.
-- If validation was intentionally scoped, say so plainly.
-- Do not describe the work as complete if relevant tests or lint checks failed.

--- a/skills/coding-standards/references/workflow.md
+++ b/skills/coding-standards/references/workflow.md
@@ -1,26 +1,22 @@
 # Workflow Reference
 
-Use this reference when you need to establish context quickly and consistently in these repositories.
+Use this reference when you need to establish context quickly and discover how a repository is wired.
 
-## Build Context In This Order
+## Discover The Interface
 
 1. Read `AGENTS.md` if present.
 2. Read `README.md` and the root `Makefile`.
-3. Run `make dep` if the repository exposes it so local dependencies and tool wrappers are up to date before deeper investigation.
-4. Inspect which `bin/build/make/*.mak` fragments are included by the root `Makefile`.
-5. Inspect CI configuration to learn what must pass.
-6. Inspect only the files and scripts relevant to the requested change.
+3. Inspect CI configuration to learn what the repository expects to pass.
+4. Inspect which `bin/build/make/*.mak` fragments are included by the root `Makefile`, when relevant.
+5. Inspect only the files and scripts relevant to the requested task.
 
 ## Prefer Repository Entry Points
 
 - Prefer repository entry points such as `make` targets over calling tools directly.
 - Use direct tool invocations only when the repository does not provide a stable entry point or when a narrower check is clearly better for the task.
 - Confirm that a target or script is actually wired into the repo before relying on it.
-- If the repo exposes `make dep`, run it before deeper investigation or analysis unless the user asked you not to or the environment prevents it.
 - When `help.mak` is included, use `make` or `make help` as the quickest way to discover the command surface.
-- When a repo includes `ruby.mak` or `go.mak`, use those fragments to infer likely workflows, but still trust the root `Makefile` as the final interface.
-- Do not assume `features` and `specs` identify mutually exclusive project types. A repository may intentionally expose either one or both.
-- When planning tests, follow the workflow the repository actually exposes. If only one of `features` or `specs` exists, use that one and do not invent the other.
+- When planning work, note whether the repository exposes setup targets such as `dep` so you can use them later when the task moves from discovery to edits or validation.
 
 ## When The Repo Uses `./bin`
 
@@ -29,40 +25,3 @@ Use this reference when you need to establish context quickly and consistently i
 - Validate path-sensitive behavior from the consuming repository root, not from inside the `bin` submodule.
 - Be careful with targets that resolve helper paths through `$(PWD)/bin/...`; they may work in a downstream repo and fail inside the `bin` repo itself.
 - Be careful with `start` and `stop` helpers because they may depend on a sibling `../docker` checkout or SSH access.
-
-## Change Discipline
-
-- Prefer the smallest safe change.
-- Match existing naming, layout, formatting, and test style.
-- Avoid introducing new tools, abstractions, or dependencies unless the repository already points in that direction or the task requires it.
-- If behavior changes, plan the corresponding test update as part of the same change.
-- Prefer compatibility-preserving changes for public interfaces and shared build targets.
-- If a change affects consumers, plan the migration or deprecation path as part of the implementation.
-- If a change touches hot paths or operational behavior, decide early whether benchmarks or observability updates are needed.
-- If a decision has non-obvious consequences, pause and verify the direction with a short plan before committing to it.
-- Use the plan to surface the main options, the intended path, the relevant risks, and how the choice will be verified.
-- Treat destructive git helper targets as opt-in actions that require explicit user intent.
-
-## PR Requests
-
-- When the user asks for a PR, treat the output format as part of the task.
-- Provide the commit message first, on its own, as a single line of
-  all-lowercase plain text.
-- Check both the relevant committed changes and the current working-tree
-  changes before writing the summary when both may matter.
-- Provide a PR summary in markdown with these exact headings:
-
-```md
-## What
-
-## Why
-
-## Testing
-```
-
-- Do not wrap the commit message in bullets, code fences, labels, or extra
-  formatting.
-- Do not assume the PR only reflects the current uncommitted diff if recent
-  committed work is also part of the requested change.
-- Keep the `Testing` section honest about what ran, what passed, and what was not run.
-- Include the exact commands run in the `Testing` section when commands were executed.


### PR DESCRIPTION
## What

- Restructured [`skills/coding-standards/SKILL.md`](/Users/alejandro/code/bin/skills/coding-standards/SKILL.md) into clearer workflow sections and tightened several rules so they read more like an operational playbook than a checklist.
- Reduced duplication and sharpened scope across the supporting references in [`skills/coding-standards/references/change-safety.md`](/Users/alejandro/code/bin/skills/coding-standards/references/change-safety.md), [`skills/coding-standards/references/workflow.md`](/Users/alejandro/code/bin/skills/coding-standards/references/workflow.md), [`skills/coding-standards/references/verification.md`](/Users/alejandro/code/bin/skills/coding-standards/references/verification.md), [`skills/coding-standards/references/make-fragments.md`](/Users/alejandro/code/bin/skills/coding-standards/references/make-fragments.md), and [`skills/coding-standards/references/review.md`](/Users/alejandro/code/bin/skills/coding-standards/references/review.md).
- Aligned the language-specific references in [`skills/coding-standards/references/go.md`](/Users/alejandro/code/bin/skills/coding-standards/references/go.md) and [`skills/coding-standards/references/ruby.md`](/Users/alejandro/code/bin/skills/coding-standards/references/ruby.md) so they have a more parallel structure.
- Added a new shared PR guidance reference in [`skills/coding-standards/references/pr.md`](/Users/alejandro/code/bin/skills/coding-standards/references/pr.md).

## Why

- The skill had accumulated a lot of overlap, rigid wording, and mixed concerns, which made it heavier to apply than necessary.
- This change makes the main skill easier to scan, gives each reference a clearer job, and keeps the shared guidance opinionated where useful without turning it into a bloated process document.
- Adding a dedicated PR reference restores shared PR conventions without hardcoding them back into the main skill.

## Testing

- No repo validation commands were run beyond inspection because this is a documentation-only change.
- Verified by reading the updated Markdown files and checking the working tree with `git status --short` and `git diff --stat`.