### PR TITLE
feat(skills): pr reference precedence for repo-local conventions

### DIFF
--- a/skills/coding-standards/references/pr.md
+++ b/skills/coding-standards/references/pr.md
@@ -6,7 +6,7 @@ Use this reference when the user asks for a PR or wants a shareable change summa
 
 - Treat PR output as task output, not optional polish.
 - Include both relevant committed work and current working-tree changes when both are part of the requested result.
-- Use this reference as the house style for commit messages and PR summaries.
+- Use this reference as the default style for commit messages and PR summaries only when repository-local guidance does not define a different house style.
 
 ## Required Format
 


### PR DESCRIPTION
## What

Updated the shared PR guidance in [pr.md](/Users/alejandro/code/bin/skills/coding-standards/references/pr.md#L9) so it only acts as the default format for commit messages and PR summaries when repository-local guidance does not define a different house style.

## Why

The previous wording made the shared reference override repository-local conventions, which conflicted with the precedence rules in [SKILL.md](/Users/alejandro/code/bin/skills/coding-standards/SKILL.md#L10) and [SKILL.md](/Users/alejandro/code/bin/skills/coding-standards/SKILL.md#L19), and with the repo-specific companion guidance in [AGENTS.md](/Users/alejandro/code/bin/AGENTS.md#L13). This restores the intended contract that local repo instructions win and the shared reference fills gaps.

## Testing

Ran `make dep`

Ran `make lint`

Ran `make scripts-lint`

Ran `make docker-lint`