### PR TITLE
feat(skills): align go and ruby documentation guidance in coding-standards

### DIFF
--- a/skills/coding-standards/references/go.md
+++ b/skills/coding-standards/references/go.md
@@ -4,13 +4,15 @@ Use this reference when working in Go repositories.
 
 ## User-Facing APIs
 
-- Keep exported or documented Go APIs aligned with the repository's existing package shape and naming style.
+- Keep user-facing or documented Go packages, types, functions, and methods consistent with the repository's existing Go style and API shape.
 - Prefer straightforward package and type names over clever aliases or indirection.
 
 ## Documentation
 
+- User-facing or documented Go APIs need clear, accurate, and detailed GoDoc for packages, exported types, functions, methods, and other supported entrypoints.
 - Keep package-level GoDoc in `doc.go` files.
 - Do not leave package documentation comments on unrelated source files such as `main.go`, `client.go`, or `types.go`.
+- Keep examples aligned with the real public interface and expected calling style when the repository's documentation style supports them.
 - When package documentation needs to change, update `doc.go` rather than scattering package comments across implementation files.
 
 ## Imports And Naming

--- a/skills/coding-standards/references/ruby.md
+++ b/skills/coding-standards/references/ruby.md
@@ -4,13 +4,13 @@ Use this reference when working in Ruby repositories.
 
 ## User-Facing APIs
 
-- Keep user-facing or documented modules, classes, and methods consistent with the repository's existing Ruby style and API shape.
+- Keep user-facing or documented Ruby modules, classes, and methods consistent with the repository's existing Ruby style and API shape.
 - Prefer straightforward Ruby over clever metaprogramming unless the repository already uses that pattern or the task clearly requires it.
 - Avoid monkey patches unless the repository explicitly relies on them.
 
 ## Documentation
 
-- User-facing or documented Ruby APIs need accurate RDoc for modules, classes, methods, and other supported entrypoints.
+- User-facing or documented Ruby APIs need clear, accurate, and detailed RDoc for modules, classes, methods, and other supported entrypoints.
 - When a user-facing or documented API is non-trivial, include examples if the repository's documentation style supports them.
 - Keep examples aligned with the real public interface and expected calling style.
 


### PR DESCRIPTION
## What
- Updated the Go documentation guidance to require clear, accurate, and detailed GoDoc for user-facing or documented APIs.
- Updated the Ruby documentation guidance to require clear, accurate, and detailed RDoc for user-facing or documented APIs.

## Why
- The skill now explicitly reflects the expectation that library docs should do more than be correct: they should explain the API well enough for downstream users.
- Keeping the Go and Ruby guidance aligned makes the shared standard clearer and more consistent.

## Testing
- Ran `make dep`
- Ran `make lint`
- Ran `make scripts-lint`
- Ran `make docker-lint`