### PR TITLE
feat(skills): add go testing conventions to coding-standards

### DIFF
--- a/skills/coding-standards/references/go.md
+++ b/skills/coding-standards/references/go.md
@@ -15,6 +15,11 @@ Use this reference when working in Go repositories.
 - Keep examples aligned with the real public interface and expected calling style when the repository's documentation style supports them.
 - When package documentation needs to change, update `doc.go` rather than scattering package comments across implementation files.
 
+## Testing
+
+- Write Go tests using `github.com/stretchr/testify/require`.
+- Keep Go tests in external test packages named `<package>_test` so they exercise the public interface rather than package internals.
+
 ## Imports And Naming
 
 - Do not alias a Go import unless there is a real collision or required disambiguation.


### PR DESCRIPTION
## What
- Added a `Testing` section to the Go reference in `skills/coding-standards/references/go.md`.
- Required Go tests to use `github.com/stretchr/testify/require`.
- Required Go tests to live in external `<package>_test` packages so they exercise the public interface rather than package internals.

## Why
- This makes the shared Go testing expectations explicit instead of leaving them implicit.
- It steers tests toward public API coverage and a consistent assertion style across Go repositories using this skill.

## Testing
- Ran `make dep`
- Ran `make lint`
- Ran `make scripts-lint`
- Ran `make docker-lint`