### PR TITLE
feat(git): remove redundant branch delete targets

### DIFF
--- a/build/make/git.mak
+++ b/build/make/git.mak
@@ -72,37 +72,6 @@ new-refactor: new-branch
 new-release: branch=release/$(NEW_BRANCH)
 new-release: new-branch
 
-delete-branch: branch latest
-	@git branch -D "$(USER)/$(branch)"
-
-# Delete a feature.
-delete-feature: branch=feat/$(NEW_BRANCH)
-delete-feature: delete-branch
-
-# Delete a fix.
-delete-fix: branch=fix/$(NEW_BRANCH)
-delete-fix: delete-branch
-
-# Delete a build.
-delete-build: branch=build/$(NEW_BRANCH)
-delete-build: delete-branch
-
-# Delete a test.
-delete-test: branch=test/$(NEW_BRANCH)
-delete-test: delete-branch
-
-# Delete a docs branch.
-delete-docs: branch=docs/$(NEW_BRANCH)
-delete-docs: delete-branch
-
-# Delete a refactor.
-delete-refactor: branch=refactor/$(NEW_BRANCH)
-delete-refactor: delete-branch
-
-# Delete a release.
-delete-release: branch=release/$(NEW_BRANCH)
-delete-release: delete-branch
-
 # Delete the current branch.
 delete:
 	@git branch -D $(BRANCH)


### PR DESCRIPTION
## What

- Remove `delete-branch` and the derived `delete-feature`, `delete-fix`, `delete-build`, `delete-test`, `delete-docs`, `delete-refactor`, and `delete-release` targets from `build/make/git.mak`.
- Keep `delete` as the single supported branch-deletion target.

## Why

- The derived delete targets do not add useful behavior over `delete`.
- They were also misleading, because they relied on generated branch naming that is not stable across separate `make` invocations.
- Removing them tightens the public make interface and avoids advertising broken workflows.

## Testing

- Ran `rg -n "delete-branch|delete-feature|delete-fix|delete-build|delete-test|delete-docs|delete-refactor|delete-release"` to confirm the removed targets no longer exist.
- Ran `make help` to verify the exposed command surface now only advertises `delete` for branch removal.
- Did not run broader lint or test suites because this change only removes redundant make targets.