### PR TITLE
feat(go): preserve fieldalignment exit status

### DIFF
--- a/build/go/fa
+++ b/build/go/fa
@@ -2,7 +2,12 @@
 # frozen_string_literal: true
 
 file = '.gofa'
-packages = File.exist?(file) ? File.read(file).strip.split(',').map { |p| "./#{p}/..." }.join(' ') : './...'
-args = ARGV.join(' ')
+packages = if File.exist?(file)
+             configured = File.read(file).strip.split(',').reject(&:empty?).map { |package| "./#{package}/..." }
+             configured.empty? ? ['./...'] : configured
+           else
+             ['./...']
+           end
 
-`fieldalignment #{args} #{packages}`
+system('fieldalignment', *ARGV, *packages)
+exit(Process.last_status&.exitstatus || 1)


### PR DESCRIPTION
## What

- Update `build/go/fa` to invoke `fieldalignment` with `system(...)` instead of shell interpolation and backticks.
- Preserve the configured `.gofa` package filtering, but pass packages as explicit arguments instead of a joined string.
- Exit with `Process.last_status&.exitstatus || 1` so the wrapper returns the underlying tool's real failure code.

## Why

- The previous wrapper swallowed `fieldalignment` failures, which could make downstream `make lint` appear successful when the tool had actually failed.
- Passing explicit arguments is safer and simpler than building a shell command string.
- The current shape keeps the script small while making its failure behavior reliable for repos that include this helper.

## Testing

- Ran `make dep`.
- Ran `make lint` and it passed.
- Ran `make scripts-lint` during validation and it passed.
- Ran a focused repro with a stub `fieldalignment` binary that exits `7`; `ruby build/go/fa` now returns `exit=7`.
- Did not run broader downstream Go-project validation, since this repo only contains the shared wrapper and make fragments.