### PR TITLE
feat(git): limit source-key bin exclusion to the bin directory

### DIFF
--- a/build/make/git.mak
+++ b/build/make/git.mak
@@ -143,7 +143,7 @@ unstash:
 
 # Generate a repo source key (sha256 of tracked files excluding bin/) into .source-key.
 source-key:
-	@git ls-files | grep -v bin | xargs sha256sum | cut -d" " -f1 | sha256sum | cut -d" " -f1 > .source-key
+	@git ls-files | grep -v '^bin/' | xargs sha256sum | cut -d" " -f1 | sha256sum | cut -d" " -f1 > .source-key
 
 # Delete all local branches except master.
 purge:


### PR DESCRIPTION
## What

- Update `build/make/git.mak` so `source-key` uses `grep -v '^bin/'` instead of `grep -v bin`.
- Keep the existing behavior of excluding the vendored `bin/` directory while preserving tracked files whose names merely contain `bin`.

## Why

- The previous filter was too broad and dropped unrelated files such as `combine.txt` or `src/binder.go`.
- That made the generated `.source-key` incomplete and could miss real source changes.

## Testing

- Ran `make dep`.
- Ran `make lint` and it passed.
- Ran `make scripts-lint` and it passed.
- Ran `make docker-lint` and it passed.
- Ran `printf 'bin/file\ncombine.txt\nsrc/binder.go\n' | grep -v '^bin/'` to confirm the filter removes only paths under `bin/`.