### PR TITLE
feat(go): preserve gocovmerge exit status

### DIFF
--- a/quality/go/covmerge
+++ b/quality/go/covmerge
@@ -20,7 +20,7 @@ Dir['test/reports/*.cov'].each do |f|
 end
 
 # https://github.com/alexfalkowski/gocovmerge
-cmd = "gocovmerge -d #{path} -o test/reports/final.cov"
-pid = spawn({}, cmd, %i[out err] => [File.join(path, 'gocovmerge.log'), 'a'])
+log_file = File.join(path, 'gocovmerge.log')
 
-Process.waitpid2 pid
+system('gocovmerge', '-d', path, '-o', 'test/reports/final.cov', out: [log_file, 'a'], err: [log_file, 'a'])
+exit(Process.last_status&.exitstatus || 1)


### PR DESCRIPTION
## What

- Update `quality/go/covmerge` to run `gocovmerge` with `system(...)` instead of building a shell command string.
- Keep stdout and stderr going to `test/reports/filter/gocovmerge.log`.
- Exit the wrapper with `Process.last_status&.exitstatus || 1` so callers receive the underlying merge failure code.

## Why

- The previous wrapper waited for the child process but never checked its exit status.
- That meant coverage merge failures could be reported as success, which makes downstream coverage and CI results misleading.

## Testing

- Ran `make dep`.
- Ran `make lint` and it passed.
- Ran `make scripts-lint` and it passed.
- Ran `make docker-lint` and it passed.
- Ran a focused repro with a stub `gocovmerge` binary that exits `9`; `ruby /Users/alejandro/code/bin/quality/go/covmerge` now returns `exit=9`.