### PR TITLE
feat(git): make purge return to master before deleting branches

### DIFF
--- a/build/make/git.mak
+++ b/build/make/git.mak
@@ -146,8 +146,8 @@ source-key:
 	@git ls-files | grep -v '^bin/' | xargs sha256sum | cut -d" " -f1 | sha256sum | cut -d" " -f1 > .source-key
 
 # Delete all local branches except master.
-purge:
-	@git branch | grep -v "master" | xargs git branch -D
+purge: master
+	@git branch | sed 's/^[* ]*//' | grep -vx 'master' | xargs git branch -D
 
 # Delete remote ref and local tag for version=<tag>.
 delete-version:


### PR DESCRIPTION
## What

- Update `build/make/git.mak` so `purge` depends on `master` before deleting branches.
- Normalize `git branch` output with `sed 's/^[* ]*//'` and exclude only the exact `master` branch with `grep -vx 'master'`.

## Why

- The previous implementation parsed `git branch` output directly, which could include the current-branch `*` marker and also tried to delete the checked out branch.
- This keeps the existing intent of `purge` while making the branch filtering explicit and reliable.

## Testing

- Ran `make dep`.
- Ran `make lint` and it passed.
- Ran `make scripts-lint` and it passed.
- Ran `make docker-lint` and it passed.
- Ran `printf '* feat/foo\n  master\n  feat/bar\n' | sed 's/^[* ]*//' | grep -vx 'master'` to confirm only non-`master` branches remain after filtering.