### PR TITLE
feat(git): normalize purge branch filtering

### DIFF
--- a/build/make/git.mak
+++ b/build/make/git.mak
@@ -147,7 +147,7 @@ source-key:
 
 # Delete all local branches except master.
 purge:
-	@git branch | grep -v "master" | xargs git branch -D
+	@git branch | sed 's/^[* ]*//' | grep -vx 'master' | xargs git branch -D
 
 # Delete remote ref and local tag for version=<tag>.
 delete-version:


### PR DESCRIPTION
## What

- Update `build/make/git.mak` so `purge` normalizes `git branch` output with `sed 's/^[* ]*//'`.
- Exclude only the exact `master` branch with `grep -vx 'master'` before passing the remaining branch names to `git branch -D`.

## Why

- The previous implementation parsed raw `git branch` output, so the current branch marker and branch indentation could leak into the delete list.
- This keeps the existing `purge` behavior while making the branch filtering reliable and easier to reason about.

## Testing

- Ran `make dep`.
- Ran `make lint` and it passed.
- Ran `make scripts-lint` and it passed.
- Ran `make docker-lint` and it passed.
- Ran `printf '* feat/foo\n  master\n  feat/bar\n' | sed 's/^[* ]*//' | grep -vx 'master'` to confirm only non-`master` branches remain after filtering.