### PR TITLE
feat(ruby): support multi-word feature tags

### DIFF
--- a/build/make/ruby.mak
+++ b/build/make/ruby.mak
@@ -41,7 +41,7 @@ update-bundler: path
 
 # Run cucumber features (feature=<path> optional; excludes @benchmark; tags=<expr> optional).
 features:
-	@$(PWD)/bin/quality/ruby/feature $(feature) $(tags)
+	@$(PWD)/bin/quality/ruby/feature "$(feature)" "$(tags)"
 
 # Run cucumber benchmarks (features tagged @benchmark; feature=<path> optional).
 benchmarks:

--- a/quality/ruby/feature
+++ b/quality/ruby/feature
@@ -1,13 +1,20 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2086
 
 set -eo pipefail
 
 readonly feature="$1"
 readonly tags="$2"
 
-if [ -n "$tags" ]; then
-  COVERAGE_NAME=features bundler exec cucumber --profile report $feature --tags "not @benchmark" --tags $tags
-else
-  COVERAGE_NAME=features bundler exec cucumber --profile report $feature --tags "not @benchmark"
+args=(--profile report)
+
+if [ -n "$feature" ]; then
+  args+=("$feature")
 fi
+
+args+=(--tags "not @benchmark")
+
+if [ -n "$tags" ]; then
+  args+=(--tags "$tags")
+fi
+
+COVERAGE_NAME=features bundler exec cucumber "${args[@]}"


### PR DESCRIPTION
## What

- Update `build/make/ruby.mak` so the `features` target passes `feature` and `tags` as quoted positional arguments.
- Refactor `quality/ruby/feature` to build the cucumber invocation with a Bash array instead of interpolating unquoted shell arguments.
- Preserve the existing behavior of excluding `@benchmark`, while correctly supporting optional `feature` and multi-word `tags` values.

## Why

- The previous `features` path broke multi-word tag expressions such as `tags='@smoke and not @slow'`.
- Building the cucumber command with an argument array keeps the script simple and makes the argument handling reliable without relying on shell word-splitting behavior.

## Testing

- Ran `make dep`.
- Ran `make lint` and it passed.
- Ran `make scripts-lint` and it passed.
- Ran `make docker-lint` and it passed.
- Ran a focused `make` repro showing `feature='spec/path'` and `tags='@smoke and not @slow'` arrive as `arg1=<spec/path>` and `arg2=<@smoke and not @slow>`.
- Ran a stubbed wrapper repro showing the final cucumber argument remains exactly `@smoke and not @slow`.