### PR TITLE
docs(readme): align docker gating and ci checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ These are used by `build/make/ruby.mak` targets `features` and `benchmarks`.
 
 - `build/docker/go/Dockerfile` is a multi-stage Dockerfile to build a Go binary and copy it into a distroless image.
 - `build/docker/build` builds a **test** image tagged `alexfalkowski/<name>:test.<platform>`.
-- `build/docker/push` and `build/docker/manifest` are gated: they only run if the last commit subject starts with `chore`.
+- `build/docker/push` and `build/docker/manifest` are gated: they only run if `APP_VERSION_FILE` exists (default: `/tmp/workspace/release-version.txt`).
 
 ### Local environment helper
 
@@ -124,6 +124,7 @@ make clean-dep
 make scripts-lint
 make docker-lint
 make lint
+make sec-lint
 ```
 
 ## CircleCI note


### PR DESCRIPTION
## What

- Update `README.md` to document that `build/docker/push` and `build/docker/manifest` are gated by `APP_VERSION_FILE` (defaulting to `/tmp/workspace/release-version.txt`).
- Add `make sec-lint` to the list of common CI checks.

## Why

- The README had drifted from the current implementation and CI configuration.
- These updates make the repo documentation match the actual Docker helper behavior and the checks run in `.circleci/config.yml`.

## Testing

- Ran `make dep`.
- Ran `make lint` and it passed.
- Ran `make scripts-lint` and it passed.
- Ran `make docker-lint` and it passed.