### PR TITLE
feat(skills): document discovery for downstream repos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,9 @@ Most of the code here is small Bash/Ruby utilities plus reusable make fragments 
 ## Shared skill
 
 Use the shared `coding-standards` skill from `skills/coding-standards` for
-cross-repository coding, review, testing, documentation, and PR conventions.
+cross-repository code changes, bug fixes, refactors, reviews, tests, linting,
+documentation, PR summaries, commits, Makefile changes, CI validation, and
+verification.
 Treat this `AGENTS.md` as the repo-specific companion to that skill.
 
 ## Quick commands (this repo)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ git submodule add git@github.com:alexfalkowski/bin.git bin
 git submodule update --init
 ```
 
+### Agent skill setup
+
+This repo also ships shared agent guidance in `skills/coding-standards`. In downstream repositories, add a short note to the root `AGENTS.md` so agents discover the shared skill from the project root instead of only from the `./bin` submodule:
+
+```markdown
+## Shared skill
+
+Use the shared `coding-standards` skill from `bin/skills/coding-standards` for code changes, bug fixes, refactors, reviews, tests, linting, documentation, PR summaries, commits, Makefile changes, CI validation, and verification.
+```
+
+Keeping those common phrases in the root `AGENTS.md` helps agents map everyday requests like "review this", "fix lint", "update docs", or "write the PR summary" to the shared skill.
+
 ## Makefile includes (examples)
 
 ### Ruby-only project

--- a/skills/coding-standards/SKILL.md
+++ b/skills/coding-standards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coding-standards
-description: Apply shared cross-repository engineering expectations for repo inspection, safe changes, validation, and review output.
+description: Apply shared cross-repository engineering expectations for code changes, bug fixes, refactors, reviews, tests/testing, lint/linting, documentation/docs, PR summaries/descriptions, commits, Makefile/make fragments, CI validation, safe changes, repo inspection, and verification.
 ---
 
 # Coding Standards


### PR DESCRIPTION
## What

- Expanded the `coding-standards` skill description with common trigger phrases for commits, PR summaries, reviews, tests, linting, docs, Makefile changes, CI validation, and verification.
- Documented the recommended downstream `AGENTS.md` snippet so repos using this project as `./bin` can point agents at `bin/skills/coding-standards`.

## Why

Agents may not automatically inspect nested submodule skills from a downstream repo root. The added trigger phrases and root `AGENTS.md` guidance make everyday prompts like “Give me a commit and a PR summary” more likely to activate the shared skill.

## Testing

Not run. Documentation and skill metadata only.