### PR TITLE
feat(go): support benchmark profile options

### DIFF
--- a/build/make/go.mak
+++ b/build/make/go.mak
@@ -5,6 +5,7 @@ MODULE:=$(shell head -n 1 go.mod | sed 's/module //')
 SOURCE:=$(shell find . -name '*.go' -not -path './bin*/*' -not -path './test*/*' -not -path './vendor/*' -type f | sort)
 PACKAGES=$(shell go list $(sort $(dir $(SOURCE))))
 COVER_PACKAGES=$(shell echo $(PACKAGES) | tr ' ' ',')
+BENCHMARK_PROFILE=test/reports/$(package).prof
 
 download:
 	@go mod download
@@ -72,13 +73,15 @@ format:
 specs:
 	@gotestsum --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
 
-# Run benchmarks for package=$(package) and write test/reports/mem.prof.
+# Run benchmarks for package=$(package) and write $(BENCHMARK_PROFILE).
+# Set benchtime=<duration-or-count> to pass -benchtime to go test.
 benchmark:
-	@go test -vet=off -mod vendor -bench=. -run=Benchmark -benchmem -memprofile test/reports/mem.prof ./$(package)
+	@mkdir -p $(dir $(BENCHMARK_PROFILE))
+	@go test -vet=off -mod vendor -bench=. -run=Benchmark -benchmem $(if $(benchtime),-benchtime=$(benchtime),) -memprofile $(BENCHMARK_PROFILE) ./$(package)
 
-# Inspect benchmark memprofile via pprof (test/reports/mem.prof).
+# Inspect benchmark memprofile via pprof ($(BENCHMARK_PROFILE)).
 benchmark-pprof:
-	@go tool pprof test/reports/mem.prof
+	@go tool pprof $(BENCHMARK_PROFILE)
 
 remove-generated-coverage:
 	@$(PWD)/bin/quality/go/covfilter


### PR DESCRIPTION
## What

- Add `BENCHMARK_PROFILE=test/reports/$(package).prof` to the shared Go make fragment.
- Make `benchmark` write package-specific memory profiles instead of always overwriting `test/reports/mem.prof`.
- Add optional `benchtime=<duration-or-count>` support for benchmark runs.
- Update `benchmark-pprof` to inspect the package-specific profile.

## Why

- Keeps memory profiles from multiple package benchmark runs separate.
- Allows consuming repos to stabilize benchmark runs with fixed counts like `benchtime=100x` without duplicating the whole `go test` command.
- Preserves the default benchmark behavior unless callers opt into `benchtime`.

## Testing

- Passed: `make -f /Users/alejandro/code/bin/build/make/go.mak -n package=transport/http benchtime=100x benchmark`
- Passed: `make -f /Users/alejandro/code/bin/build/make/go.mak package=bytes benchtime=1x benchmark`
- Not run: full `/Users/alejandro/code/bin` `make lint`, because it currently stops before linting on an existing `build/make/git.mak` parse issue.