### PR TITLE
feat(make): add mkcert root ca to generated cert fixtures

### DIFF
--- a/build/make/client.mak
+++ b/build/make/client.mak
@@ -213,6 +213,7 @@ encode-config:
 create-certs:
 	@mkcert -key-file test/certs/key.pem -cert-file test/certs/cert.pem localhost
 	@mkcert -client -key-file test/certs/client-key.pem -cert-file test/certs/client-cert.pem localhost
+	@cp "$$(mkcert -CAROOT)/rootCA.pem" test/certs/rootCA.pem
 
 # Generate a dependency graph PNG for package=$(package) into assets/.
 create-diagram:

--- a/build/make/go.mak
+++ b/build/make/go.mak
@@ -124,6 +124,7 @@ encode-config:
 create-certs:
 	@mkcert -key-file test/certs/key.pem -cert-file test/certs/cert.pem localhost
 	@mkcert -client -key-file test/certs/client-key.pem -cert-file test/certs/client-cert.pem localhost
+	@cp "$$(mkcert -CAROOT)/rootCA.pem" test/certs/rootCA.pem
 
 # Generate a dependency graph PNG for package=$(package) into assets/.
 create-diagram:

--- a/build/make/grpc.mak
+++ b/build/make/grpc.mak
@@ -245,6 +245,7 @@ encode-config:
 create-certs:
 	@mkcert -key-file test/certs/key.pem -cert-file test/certs/cert.pem localhost
 	@mkcert -client -key-file test/certs/client-key.pem -cert-file test/certs/client-cert.pem localhost
+	@cp "$$(mkcert -CAROOT)/rootCA.pem" test/certs/rootCA.pem
 
 # Generate a dependency graph PNG for package=$(package) into assets/.
 create-diagram:

--- a/build/make/http.mak
+++ b/build/make/http.mak
@@ -217,6 +217,7 @@ encode-config:
 create-certs:
 	@mkcert -key-file test/certs/key.pem -cert-file test/certs/cert.pem localhost
 	@mkcert -client -key-file test/certs/client-key.pem -cert-file test/certs/client-cert.pem localhost
+	@cp "$$(mkcert -CAROOT)/rootCA.pem" test/certs/rootCA.pem
 
 # Generate a dependency graph PNG for package=$(package) into assets/.
 create-diagram:


### PR DESCRIPTION
## What

- Updated shared `create-certs` targets to copy mkcert’s public `rootCA.pem` into `test/certs/rootCA.pem`.
- Applied the change across `go.mak`, `client.mak`, `http.mak`, and `grpc.mak`.

## Why

This gives downstream repos a stable local CA file for explicit TLS/mTLS config, such as `ca: file:test/certs/rootCA.pem`, without hardcoding each developer’s mkcert CA directory.

## Testing

- Ran `make -f /Users/alejandro/code/bin/build/make/go.mak create-certs` from `go-service`; it completed successfully.
- Verified generated certs with:
  - `openssl verify -CAfile test/certs/rootCA.pem test/certs/cert.pem`
  - `openssl verify -CAfile test/certs/rootCA.pem test/certs/client-cert.pem`
- Ran `git diff --check`.
- `make dep`, `make scripts-lint`, and `make lint` in `bin` did not run successfully because the repo currently fails while parsing `build/make/git.mak:3`.