### PR TITLE
feat(skills): clarify code review section formatting

### DIFF
--- a/skills/code-review/references/findings-format.md
+++ b/skills/code-review/references/findings-format.md
@@ -12,6 +12,7 @@ Use this reference when the user asks for a review.
 
 ## Output Format
 
+- Use Markdown headings for review sections, not bolded labels.
 - Present findings first.
 - Order findings by severity.
 - Include file and line references for each finding when possible.


### PR DESCRIPTION
## What

- Updated the code-review findings format guidance to require Markdown headings for review sections instead of bolded labels.

## Why

- Keeps review output consistent with the intended section structure.
- Avoids ambiguous formatting where section labels look like emphasized text instead of real headings.

## Testing

- Not run. Documentation-only change.