### PR TITLE
feat(skills): support multiline review descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ skill instead of one broad default:
 - `change-validation`: test, lint, CI, security, benchmark, and validation selection.
 - `code-review`: review findings, risk assessment, and missing coverage.
 - `pr-summary`: commit messages, PR descriptions, and shareable change summaries.
+- `review-pr`: create a commit, force-push, and open a draft PR using `pr-summary`.
 - `makefile-includes`: reusable `build/make/*.mak` behavior and downstream path
   semantics.
 - `shell-standards`: Bash scripting, ShellCheck, text processing, directory

--- a/build/make/git.mak
+++ b/build/make/git.mak
@@ -5,6 +5,8 @@ BRANCH:=$(shell git branch --show-current)
 NEW_BRANCH:=$(subst $() ,-,$(name))
 PREFIX:=$(shell ruby -e '_, t, n = (ARGV[0] || "").split("/"); print "#{t}(#{n}):" unless t.nil?' $(BRANCH))
 
+export msg desc
+
 # Checkout the master branch.
 master:
 	@git checkout master
@@ -94,7 +96,7 @@ edit-amend: add
 
 # Commit all changes with a prefix derived from the branch (set msg/desc).
 commit: add
-	@git commit -a -m "$(PREFIX) $(msg)" -m "$(desc)"
+	@printf '%s\n\n%s\n' "$(PREFIX) $${msg}" "$${desc}" | git commit -a -F -
 
 # Force-push the current branch to origin.
 push:

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: review-pr
+description: Commits the current change, force-pushes the branch, and opens a draft pull request by using pr-summary output with the repository review make target. Use when the user asks to prepare a PR for review, open a draft PR, run the review flow, or create a review PR from local changes.
+---
+
+# Review PR
+
+## Steps
+
+1. Use `$pr-summary` first to draft a lowercase commit message and Markdown PR summary from the current working tree.
+2. Keep the commit message plain text and lowercase.
+3. Keep the summary in the `$pr-summary` format, including honest testing details.
+4. When attribution is appropriate or requested, append this footer to the summary instead of a `Co-authored-by:` trailer:
+
+```text
+AI-assisted-by: Codex (https://openai.com/codex/)
+```
+
+5. Run the review target with the drafted values:
+
+```bash
+make msg="commit" desc="summary" review
+```
+
+6. Pass `desc` as the multiline Markdown summary from `$pr-summary`; do not flatten the summary into a single line.
+7. Report the commit message, whether the review target succeeded, and any command failure that needs user action.
+
+## Notes
+
+- The `review` target commits, force-pushes the current branch, and opens a draft PR.
+- Do not claim the PR exists if `make review` fails before the draft step.
+- Do not claim unrun checks passed.

--- a/skills/review-pr/agents/openai.yaml
+++ b/skills/review-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review PR"
+  short_description: "Commit, push, and draft a PR"
+  default_prompt: "Use $review-pr to commit this change and open a draft PR for review."


### PR DESCRIPTION
## What

- Changed the shared git make commit target to write commit messages through stdin so multiline desc values survive shell execution.
- Updated the review-pr skill to preserve the pr-summary Markdown body instead of flattening it.
- Added the review-pr skill, OpenAI metadata, and repository skill index entry.

## Why

- Allows review-pr to keep Markdown PR summaries intact when running the review flow.

## Testing

- make dep
- make lint
- make scripts-lint
- make docker-lint
- make -n with a multiline desc value
- Ruby structural check for the new skill files

AI-assisted-by: Codex (https://openai.com/codex/)
