### PR TITLE
build(ci): include source key in ruby cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,16 +9,17 @@ jobs:
           method: blobless
       - run: git submodule sync
       - run: git submodule update --init
+      - run: make source-key
       - restore_cache:
           name: restore deps
           keys:
-            - bin-ruby-cache-{{ checksum "Gemfile.lock" }}
+            - bin-ruby-cache-{{ checksum "Gemfile.lock" }}-{{ checksum "~/.ruby-version" }}-{{ checksum ".source-key" }}
             - bin-ruby-cache-
       - run: make dep
       - run: make clean-dep
       - save_cache:
           name: save deps
-          key: bin-ruby-cache-{{ checksum "Gemfile.lock" }}
+          key: bin-ruby-cache-{{ checksum "Gemfile.lock" }}-{{ checksum "~/.ruby-version" }}-{{ checksum ".source-key" }}
           paths:
             - vendor
       - run: make scripts-lint


### PR DESCRIPTION
## What

- Added `make source-key` before CircleCI cache restoration.
- Included `.source-key` and `~/.ruby-version` checksums in the Ruby dependency cache key.

## Why

- Keeps the dependency cache tied to the repository source and Ruby version, reducing stale cache reuse across incompatible CI inputs.

## Testing

- `make -n source-key`
- `make dep`
- `make clean-dep`
- `make lint`
- `make scripts-lint`
- `make docker-lint`
- `make sec-lint` failed because Trivy reported CVE-2026-34060 in ignored `.ruby-lsp/Gemfile.lock`; tracked `Gemfile.lock` reported 0 vulnerabilities.

AI-assisted-by: [Codex](https://openai.com/codex/)
