### PR TITLE
feat(skills): avoid duplicate commit subject wording

### DIFF
--- a/skills/pr-summary/SKILL.md
+++ b/skills/pr-summary/SKILL.md
@@ -9,10 +9,11 @@ description: Drafts commit messages and pull request summaries from repository c
 
 1. Inspect the working-tree changes first.
 2. If the working tree is clean, inspect the latest commit instead.
-3. Read `references/format.md` before drafting the output.
-4. Keep the commit message plain text and lowercase when the user asks for one.
-5. Include what changed, why it changed, and honest testing details in the PR summary.
-6. Do not claim unrun checks passed.
+3. Inspect the current branch and commit workflow before drafting a commit message.
+4. Read `references/format.md` before drafting the output.
+5. Keep the commit message plain text and lowercase when the user asks for one.
+6. Include what changed, why it changed, and honest testing details in the PR summary.
+7. Do not claim unrun checks passed.
 
 ## References
 

--- a/skills/pr-summary/references/format.md
+++ b/skills/pr-summary/references/format.md
@@ -22,6 +22,15 @@ Use this reference when the user asks for a PR or wants a shareable change summa
 - Do not add extra sections or alternate titles.
 - Keep the testing section honest about what ran, what passed, and what did not run.
 
+## Commit Message Subject
+
+- Check whether the local commit workflow adds a conventional-commit prefix from the current branch.
+- In repositories using this shared `bin` workflow, `build/make/git.mak` derives `type(scope):` from branches shaped like `user/type/scope` and prepends it in `make commit`, `make review`, and related targets.
+- When the workflow will prepend that branch-derived prefix, output only the unprefixed subject intended for `msg`.
+- Do not include a conventional prefix such as `feat(scope):` in that subject.
+- Avoid repeating branch-derived type, scope, or name words in the subject unless they are essential to the meaning.
+- Prefer the concrete behavioral change over branch wording. For example, on `user/feat/skills`, use `avoid duplicate commit subject wording`, not `feat(skills): update skills pr summary`.
+
 ## Validation Notes
 
 - Include the actual commands run when they materially help the reader understand the verification.

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -9,21 +9,23 @@ description: Commits the current change, force-pushes the branch, and opens a dr
 
 1. Use `$pr-summary` first to draft a lowercase commit message and Markdown PR summary from the current working tree.
 2. Keep the commit message plain text and lowercase.
-3. Keep the summary in the `$pr-summary` format, including honest testing details.
-4. When attribution is appropriate or requested, append this footer to the summary instead of a `Co-authored-by:` trailer:
+3. Pass only the unprefixed subject as `msg`; `make review` adds the branch-derived `type(scope):` prefix.
+4. Avoid repeating branch-derived type, scope, or name words in `msg` unless they are essential to the meaning.
+5. Keep the summary in the `$pr-summary` format, including honest testing details.
+6. When attribution is appropriate or requested, append this footer to the summary instead of a `Co-authored-by:` trailer:
 
 ```text
 AI-assisted-by: [Codex](https://openai.com/codex/)
 ```
 
-5. Run the review target with the drafted values:
+7. Run the review target with the drafted values:
 
 ```bash
-make msg="commit" desc="summary" review
+make msg="unprefixed subject" desc="summary" review
 ```
 
-6. Pass `desc` as the multiline Markdown summary from `$pr-summary`; do not flatten the summary into a single line.
-7. Report the commit message, whether the review target succeeded, and any command failure that needs user action.
+8. Pass `desc` as the multiline Markdown summary from `$pr-summary`; do not flatten the summary into a single line.
+9. Report the commit message, whether the review target succeeded, and any command failure that needs user action.
 
 ## Notes
 


### PR DESCRIPTION
## What

- Updated the pr-summary skill to inspect branch-based commit workflows before drafting commit messages.
- Documented that shared bin review and commit targets prepend the branch-derived conventional prefix.
- Aligned the review-pr skill so it passes only the unprefixed subject through msg.

## Why

- Prevents generated commit messages from duplicating words already supplied by branch-derived conventional commit prefixes.

## Testing

- make lint

AI-assisted-by: [Codex](https://openai.com/codex/)
