### PR TITLE
feat(skills): tighten review wording and add force target

### DIFF
--- a/build/make/git.mak
+++ b/build/make/git.mak
@@ -103,6 +103,9 @@ commit: add
 push:
 	@git push -f origin $(BRANCH)
 
+# Amend the last commit and force-push.
+force: amend push
+
 # Create a draft PR for the current branch (gh pr create --draft).
 draft:
 	@gh pr create -d -a @me --fill-first --head $(BRANCH)

--- a/skills/pr-summary/SKILL.md
+++ b/skills/pr-summary/SKILL.md
@@ -11,9 +11,10 @@ description: Drafts commit messages and pull request summaries from repository c
 2. If the working tree is clean, inspect the latest commit instead.
 3. Inspect the current branch and commit workflow before drafting a commit message.
 4. Read `references/format.md` before drafting the output.
-5. Keep the commit message plain text and lowercase when the user asks for one.
-6. Include what changed, why it changed, and honest testing details in the PR summary.
-7. Do not claim unrun checks passed.
+5. When the workflow adds a branch-derived prefix, draft `msg` from the diff or latest commit only; do not use branch words as source material.
+6. Keep the commit message plain text and lowercase when the user asks for one.
+7. Include what changed, why it changed, and honest testing details in the PR summary.
+8. Do not claim unrun checks passed.
 
 ## References
 

--- a/skills/pr-summary/references/format.md
+++ b/skills/pr-summary/references/format.md
@@ -28,7 +28,10 @@ Use this reference when the user asks for a PR or wants a shareable change summa
 - In repositories using this shared `bin` workflow, `build/make/git.mak` derives `type(scope):` from branches shaped like `user/type/scope` and prepends it in `make commit`, `make review`, and related targets.
 - When the workflow will prepend that branch-derived prefix, output only the unprefixed subject intended for `msg`.
 - Do not include a conventional prefix such as `feat(scope):` in that subject.
-- Avoid repeating branch-derived type, scope, or name words in the subject unless they are essential to the meaning.
+- Treat the current branch as routing metadata, not summary source material.
+- Build a short exclusion list from every meaningful branch-path segment, including type, scope/name segments, and the hyphen- or slash-separated words inside those segments.
+- Do not repeat any branch-derived word in the subject unless omitting it would make the subject misleading or ambiguous.
+- Before returning the subject, compare it with the exclusion list and rewrite it if a branch-derived word can be replaced by a more concrete behavior from the diff.
 - Prefer the concrete behavioral change over branch wording. For example, on `user/feat/skills`, use `avoid duplicate commit subject wording`, not `feat(skills): update skills pr summary`.
 
 ## Validation Notes

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -10,22 +10,25 @@ description: Commits the current change, force-pushes the branch, and opens a dr
 1. Use `$pr-summary` first to draft a lowercase commit message and Markdown PR summary from the current working tree.
 2. Keep the commit message plain text and lowercase.
 3. Pass only the unprefixed subject as `msg`; `make review` adds the branch-derived `type(scope):` prefix.
-4. Avoid repeating branch-derived type, scope, or name words in `msg` unless they are essential to the meaning.
-5. Keep the summary in the `$pr-summary` format, including honest testing details.
-6. When attribution is appropriate or requested, append this footer to the summary instead of a `Co-authored-by:` trailer:
+4. Treat the current branch as routing metadata, not `msg` source material.
+5. Build a short exclusion list from every meaningful branch-path segment, including type, scope/name segments, and the hyphen- or slash-separated words inside those segments.
+6. Do not repeat any branch-derived word in `msg` unless omitting it would make the subject misleading or ambiguous.
+7. Before running `make review`, compare `msg` with the exclusion list and rewrite it if a branch-derived word can be replaced by a more concrete behavior from the diff.
+8. Keep the summary in the `$pr-summary` format, including honest testing details.
+9. When attribution is appropriate or requested, append this footer to the summary instead of a `Co-authored-by:` trailer:
 
 ```text
 AI-assisted-by: [Codex](https://openai.com/codex/)
 ```
 
-7. Run the review target with the drafted values:
+10. Run the review target with the drafted values:
 
 ```bash
 make msg="unprefixed subject" desc="summary" review
 ```
 
-8. Pass `desc` as the multiline Markdown summary from `$pr-summary`; do not flatten the summary into a single line.
-9. Report the commit message, whether the review target succeeded, and any command failure that needs user action.
+11. Pass `desc` as the multiline Markdown summary from `$pr-summary`; do not flatten the summary into a single line.
+12. Report the commit message, whether the review target succeeded, and any command failure that needs user action.
 
 ## Notes
 


### PR DESCRIPTION
## What

- Added a force target that amends the last commit and force-pushes the current branch.
- Tightened the PR message guidance so generated subjects are drafted from the diff, not the current branch name.
- Added an explicit branch-word exclusion check before returning or using the review message.

## Why

This keeps automatically generated commit subjects from duplicating words that the shared git workflow already adds through the branch-derived prefix.

## Testing

Not run (documentation and Makefile wiring only).

AI-assisted-by: [Codex](https://openai.com/codex/)
