### PR TITLE
feat(skills): require validation before drafts

### DIFF
--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -7,28 +7,33 @@ description: Commits the current change, force-pushes the branch, and opens a dr
 
 ## Steps
 
-1. Use `$pr-summary` first to draft a lowercase commit message and Markdown PR summary from the current working tree.
-2. Keep the commit message plain text and lowercase.
-3. Pass only the unprefixed subject as `msg`; `make review` adds the branch-derived `type(scope):` prefix.
-4. Treat the current branch as routing metadata, not `msg` source material.
-5. Build a short exclusion list from every meaningful branch-path segment, including type, scope/name segments, and the hyphen- or slash-separated words inside those segments.
-6. Do not repeat any branch-derived word in `msg` unless omitting it would make the subject misleading or ambiguous.
-7. Before running `make review`, compare `msg` with the exclusion list and rewrite it if a branch-derived word can be replaced by a more concrete behavior from the diff.
-8. Keep the summary in the `$pr-summary` format, including honest testing details.
-9. When attribution is appropriate or requested, append this footer to the summary instead of a `Co-authored-by:` trailer:
+1. Inspect the changed paths from the working tree first; if the working tree is clean, inspect the latest commit.
+2. Use `$change-validation` to select and run credible validation before `make review`.
+3. If the changed paths include Go code, Go tests, Go modules, Go docs, or Go tooling behavior, also use `$go-standards`.
+4. If the changed paths include Ruby code, Ruby tests/features, Gemfiles, RuboCop config, Ruby docs, or Ruby tooling behavior, also use `$ruby-standards`.
+5. If the changed paths include shell scripts, Bash helpers, ShellCheck config/directives, shell docs, or script behavior, also use `$shell-standards`.
+6. Use `$pr-summary` to draft a lowercase commit message and Markdown PR summary from the current working tree.
+7. Keep the commit message plain text and lowercase.
+8. Pass only the unprefixed subject as `msg`; `make review` adds the branch-derived `type(scope):` prefix.
+9. Treat the current branch as routing metadata, not `msg` source material.
+10. Build a short exclusion list from every meaningful branch-path segment, including type, scope/name segments, and the hyphen- or slash-separated words inside those segments.
+11. Do not repeat any branch-derived word in `msg` unless omitting it would make the subject misleading or ambiguous.
+12. Before running `make review`, compare `msg` with the exclusion list and rewrite it if a branch-derived word can be replaced by a more concrete behavior from the diff.
+13. Keep the summary in the `$pr-summary` format, including honest testing details.
+14. When attribution is appropriate or requested, append this footer to the summary instead of a `Co-authored-by:` trailer:
 
 ```text
 AI-assisted-by: [Codex](https://openai.com/codex/)
 ```
 
-10. Run the review target with the drafted values:
+15. Run the review target with the drafted values:
 
 ```bash
 make msg="unprefixed subject" desc="summary" review
 ```
 
-11. Pass `desc` as the multiline Markdown summary from `$pr-summary`; do not flatten the summary into a single line.
-12. Report the commit message, whether the review target succeeded, and any command failure that needs user action.
+16. Pass `desc` as the multiline Markdown summary from `$pr-summary`; do not flatten the summary into a single line.
+17. Report the commit message, validation results, whether the review target succeeded, and any command failure that needs user action.
 
 ## Notes
 

--- a/skills/review-pr/agents/openai.yaml
+++ b/skills/review-pr/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Review PR"
-  short_description: "Commit, push, and draft a PR"
+  short_description: "Validate, commit, push, and draft a PR"
   default_prompt: "Use $review-pr to commit this change and open a draft PR for review."


### PR DESCRIPTION
## What

- Updated the review-pr workflow to inspect changed paths, run change-validation before make review, and load Go, Ruby, or shell standards when matching files changed.
- Updated the Review PR UI metadata to mention validation.

## Why

- Keeps the review PR flow from opening drafts before credible checks and language-specific guidance have been considered.

## Testing

- `ruby -e "require 'yaml'; YAML.load_file('skills/review-pr/agents/openai.yaml'); puts 'yaml ok'"`
- `make lint`
- `git diff --check`
