### PR TITLE
feat(skills): document go test and method layout rules

### DIFF
--- a/skills/go-standards/SKILL.md
+++ b/skills/go-standards/SKILL.md
@@ -8,11 +8,11 @@ description: Applies this repository ecosystem's Go coding, documentation, impor
 ## Steps
 
 1. Confirm the task is in a Go repository or touches Go code, Go tests, Go documentation, or Go package APIs.
-2. Read `references/conventions.md` before editing exported APIs, documentation, imports, naming, or tests.
+2. Read `references/conventions.md` before editing exported APIs, documentation, imports, naming, method layout, or tests.
 3. Preserve the repository's existing Go package shape and public API style.
 4. Add or update Go tests when behavior changes and the repository supports tests.
 5. Pair this skill with `change-validation` when selecting Go test, lint, coverage, or benchmark commands.
 
 ## References
 
-- Read `references/conventions.md` for Go API, GoDoc, testing, import, and naming conventions.
+- Read `references/conventions.md` for Go API, GoDoc, testing, method layout, import, and naming conventions.

--- a/skills/go-standards/references/conventions.md
+++ b/skills/go-standards/references/conventions.md
@@ -17,8 +17,15 @@ Use this reference when working in Go repositories.
 
 ## Testing
 
+- Before adding new test structure, look for existing tests in the package or adjacent packages and reuse their helpers, fixtures, table shapes, assertions, and naming patterns when they fit.
+- When new coverage is needed, base it on the testing style already present in the repository rather than introducing a new pattern.
 - Write Go tests using `github.com/stretchr/testify/require`.
 - Keep Go tests in external test packages named `<package>_test` so they exercise the public interface rather than package internals.
+- Keep test cases and test functions first in the file. Place fakes, stubs, spies, mock implementations, and helper types after the tests at the bottom of the file.
+
+## Method Layout
+
+- For types with both exported and unexported methods, keep exported methods near the top of the type's method group and unexported methods below them.
 
 ## Imports And Naming
 


### PR DESCRIPTION
## What

- Updated the Go standards skill to call out method layout guidance.
- Added Go testing conventions for reusing existing test patterns and placing fakes, stubs, and helper implementations after tests.

## Why

- Keeps future Go changes aligned with repository-local testing style and file organization expectations.

## Testing

- `make lint`
