### PR TITLE
feat(sec): skip ruby lsp cache in trivy

### DIFF
--- a/build/sec/trivy-repo
+++ b/build/sec/trivy-repo
@@ -3,4 +3,4 @@
 set -eo pipefail
 
 # Scan using trivy.
-trivy repo --skip-dirs bin --skip-dirs vendor --skip-dirs test/vendor --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --exit-code 1 --severity CRITICAL ./
+trivy repo --skip-dirs .ruby-lsp --skip-dirs bin --skip-dirs vendor --skip-dirs test/vendor --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --exit-code 1 --severity CRITICAL ./


### PR DESCRIPTION
## What

- Skip `.ruby-lsp` when running Trivy repo scans.

## Why

- Prevent ignored Ruby LSP workspace cache files from failing `sec-lint` while preserving the tracked dependency scan.

## Testing

- `make scripts-lint`
- `make sec-lint`
