### PR TITLE
feat(go): remove stale coverage merge inputs

### DIFF
--- a/quality/go/covmerge
+++ b/quality/go/covmerge
@@ -4,9 +4,10 @@
 require 'fileutils'
 
 file = '.gocov'
-exclude = File.exist?(file) ? File.read(file).strip : 'test|.pb|main.go'
+exclude = File.exist?(file) ? File.read(file).strip : 'test|\.pb|main\.go'
 path = 'test/reports/filter'
 
+FileUtils.rm_rf path
 FileUtils.mkdir_p path
 
 Dir['test/reports/*.cov'].each do |f|


### PR DESCRIPTION
## What

- Clear `test/reports/filter` before writing filtered coverage files.
- Escape the default `.pb` and `main.go` exclusion patterns so dots are treated literally.

## Why

- Prevent stale filtered coverage files from previous runs from being merged into `final.cov`.
- Keep default generated-file filtering aligned with the documented literal patterns.

## Testing

- `ruby -c quality/go/covmerge`
- `make lint`
- Temporary `gocovmerge` fixture covering stale filter cleanup and literal default exclusions
