### PR TITLE
feat(skills): standardize agent output and style references

### DIFF
--- a/skills/change-safety/SKILL.md
+++ b/skills/change-safety/SKILL.md
@@ -11,7 +11,7 @@ description: Protects documented interfaces, compatibility, security, generated 
 2. Read `references/safety-checks.md` before editing compatibility-sensitive, security-sensitive, generated, vendored, or documented behavior.
 3. Preserve existing behavior unless the user explicitly requests a breaking change or the fix requires one.
 4. Update documentation in the repository's existing style when behavior, usage, or migration expectations change.
-5. Report any intentional breakage, migration requirement, security tradeoff, or generated-file constraint in the final response.
+5. Report safety-relevant notes using the exact structure in `references/safety-checks.md`; do not add, remove, rename, or reorder sections.
 
 ## References
 

--- a/skills/change-safety/references/safety-checks.md
+++ b/skills/change-safety/references/safety-checks.md
@@ -8,6 +8,34 @@ Use this reference when deciding how to handle compatibility, documentation, sec
 - Preserve existing behavior for downstream consumers when feasible.
 - If a breaking change is necessary, call it out explicitly and document the migration impact.
 
+## Output Format
+
+Use exactly this Markdown structure and do not add, remove, rename, or reorder sections:
+
+```markdown
+## Compatibility
+
+- None.
+
+## Migration
+
+- None.
+
+## Security
+
+- None.
+
+## Generated Or External Files
+
+- None.
+```
+
+- If there are no entries for a section, write exactly `- None.`
+- Use `Compatibility` for intentional breakage or preserved documented interfaces.
+- Use `Migration` for required consumer action, deprecation, or replacement guidance.
+- Use `Security` for security-sensitive tradeoffs, unsafe defaults, secrets, shell execution, filesystem writes, auth, or untrusted input.
+- Use `Generated Or External Files` for generated files, vendored files, lockfiles, or dependency constraints.
+
 ## Migration And Deprecation
 
 - If a change needs consumer action, document the migration path as part of the work.

--- a/skills/change-validation/SKILL.md
+++ b/skills/change-validation/SKILL.md
@@ -11,7 +11,7 @@ description: Chooses and reports credible validation commands for tests, linting
 2. Read `references/check-selection.md` when choosing between targeted tests, lint commands, make targets, CI mirrors, benchmarks, or security checks.
 3. Run the narrowest check that credibly exercises the changed behavior, then expand only when risk justifies it.
 4. Notice wrappers that no-op because optional tools are missing, and do not report them as full validation.
-5. In the final response, list what ran, what passed or failed, and what could not be validated.
+5. Report validation using the exact structure in `references/check-selection.md`; do not add, remove, rename, or reorder sections.
 
 ## References
 

--- a/skills/change-validation/references/check-selection.md
+++ b/skills/change-validation/references/check-selection.md
@@ -19,6 +19,29 @@ Use this reference when choosing which checks to run.
 3. Run any additional repo-defined checks that are clearly relevant to the risk of the change.
 4. Run broader lint or test suites only when the change touches shared infrastructure, multiple packages, or release-sensitive behavior.
 
+## Output Format
+
+Use exactly this Markdown structure and do not add, remove, rename, or reorder sections:
+
+```markdown
+## Validation
+
+- command: `make lint`
+  result: passed
+  coverage: Ruby linting for changed files.
+
+## Gaps
+
+- None.
+```
+
+- Use only these results: `passed`, `failed`, `not run`, `no-op`.
+- Use `no-op` when a wrapper ran but skipped meaningful validation because an optional tool was missing.
+- Use `not run` when a relevant command was intentionally skipped or could not be run.
+- If no commands ran, write one `Validation` entry with `command: none` and `result: not run`.
+- In `coverage`, state what the command actually validated or why it did not validate anything.
+- If there are no validation gaps, write exactly `- None.`
+
 ## Helpful Heuristics
 
 - For shell scripts, Dockerfiles, and Makefile glue, prefer the repo's lint targets when available.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -11,7 +11,7 @@ description: Reviews code changes for bugs, regressions, risky assumptions, miss
 2. Read `references/findings-format.md` before producing review output.
 3. Inspect behavior, tests, compatibility, security, docs, and maintenance risk before style preferences.
 4. Verify claims against concrete file and line references whenever possible.
-5. Present findings first, ordered by severity. Keep summaries secondary and brief.
+5. Use the exact structure in `references/findings-format.md`; do not add, remove, rename, or reorder sections.
 
 ## References
 

--- a/skills/code-review/references/findings-format.md
+++ b/skills/code-review/references/findings-format.md
@@ -12,14 +12,39 @@ Use this reference when the user asks for a review.
 
 ## Output Format
 
-- Use Markdown headings for review sections, not bolded labels.
-- Present findings first.
+- Use exactly this Markdown structure and do not add, remove, rename, or reorder sections:
+
+```markdown
+## Findings
+
+- [severity] path/to/file:line - Finding title
+  Impact: Describe the concrete bug, regression, or risk.
+  Evidence: Point to the inspected code or behavior.
+  Recommendation: Describe the smallest credible fix.
+
+## Open Questions
+
+- None.
+
+## Testing Gaps
+
+- None.
+
+## Summary
+
+Brief one- or two-sentence summary.
+```
+
+- Use only these severities: `critical`, `high`, `medium`, `low`.
 - Order findings by severity.
 - Include file and line references for each finding when possible.
+- If no line reference is available, use `path/to/file` without a line number and explain the location in `Evidence`.
 - Keep the summary brief and secondary to the findings.
 - When useful, state the condition or scenario that triggers the problem so the risk is easy to verify.
+- If a section has no entries, write exactly `- None.`
 
 ## If No Findings
 
-- Say explicitly that no findings were identified.
-- Still mention residual risk, blind spots, or testing gaps if they remain.
+- In `Findings`, write exactly `- None.`
+- Use `Testing Gaps` to mention residual risk, blind spots, or testing gaps if they remain.
+- If there are no testing gaps, write exactly `- None.`

--- a/skills/go-standards/references/conventions.md
+++ b/skills/go-standards/references/conventions.md
@@ -27,6 +27,11 @@ Use this reference when working in Go repositories.
 
 - For types with both exported and unexported methods, keep exported methods near the top of the type's method group and unexported methods below them.
 
+## External Style References
+
+- When this repository does not state a more specific convention, use Effective Go, the Google Go Style Guide, and the Uber Go Style Guide as advisory references.
+- Repository-local conventions take precedence over external style guides.
+
 ## Imports And Naming
 
 - Do not alias a Go import unless there is a real collision or required disambiguation.

--- a/skills/pr-summary/SKILL.md
+++ b/skills/pr-summary/SKILL.md
@@ -14,7 +14,8 @@ description: Drafts commit messages and pull request summaries from repository c
 5. When the workflow adds a branch-derived prefix, draft `msg` from the diff or latest commit only; do not use branch words as source material.
 6. Keep the commit message plain text and lowercase when the user asks for one.
 7. Include what changed, why it changed, and honest testing details in the PR summary.
-8. Do not claim unrun checks passed.
+8. Use the exact structure in `references/format.md`; do not add, remove, rename, or reorder sections.
+9. Do not claim unrun checks passed.
 
 ## References
 

--- a/skills/pr-summary/references/format.md
+++ b/skills/pr-summary/references/format.md
@@ -12,7 +12,26 @@ Use this reference when the user asks for a PR or wants a shareable change summa
 
 ## Required Format
 
-- Provide the commit message first, on its own line, when the user asks for one.
+- When the user asks for a commit message and PR summary, use exactly this structure and do not add, remove, rename, or reorder sections:
+
+```markdown
+commit message subject
+
+## What
+
+- Describe the concrete change.
+
+## Why
+
+- Describe why the change was made.
+
+## Testing
+
+- `command` - passed
+```
+
+- When the user asks only for a commit message, output only the commit message subject.
+- When the user asks only for a PR summary, output only the `## What`, `## Why`, and `## Testing` sections from the template.
 - Keep the commit message as plain text only.
 - Keep the commit message entirely lowercase.
 - Do not add markdown, labels, bullets, quotes, or surrounding commentary to the commit message.
@@ -20,6 +39,8 @@ Use this reference when the user asks for a PR or wants a shareable change summa
 - Use Markdown headings for the PR summary sections: `## What`, `## Why`, and `## Testing`.
 - Do not use bold text as section labels, such as `**What**`.
 - Do not add extra sections or alternate titles.
+- When another skill requires a footer, append it after `## Testing`; footers are allowed and are not sections.
+- If a PR summary section has no entries, write exactly `- None.`
 - Keep the testing section honest about what ran, what passed, and what did not run.
 
 ## Commit Message Subject

--- a/skills/project-workflow/SKILL.md
+++ b/skills/project-workflow/SKILL.md
@@ -11,7 +11,7 @@ description: Discovers project-local workflow, command surfaces, Makefile includ
 2. Identify the project's real command surface before choosing tools. Prefer exposed entrypoints over guessed direct invocations.
 3. If the repository uses this shared project as `./bin`, read `references/bin-submodule.md` before reasoning about path-sensitive behavior.
 4. Inspect only the files, scripts, and make fragments relevant to the user's task.
-5. Report any workflow constraint that affects the work, such as missing tools, downstream-only paths, or CI-only behavior.
+5. When reporting workflow discovery, use the exact structure in `references/bin-submodule.md`; do not add, remove, rename, or reorder sections.
 
 ## References
 

--- a/skills/project-workflow/references/bin-submodule.md
+++ b/skills/project-workflow/references/bin-submodule.md
@@ -18,6 +18,34 @@ Use this reference when you need to establish context quickly and discover how a
 - When `help.mak` is included, use `make` or `make help` as the quickest way to discover the command surface.
 - When planning work, note whether the repository exposes setup targets such as `dep` so you can use them later when the task moves from discovery to edits or validation.
 
+## Output Format
+
+Use exactly this Markdown structure when reporting workflow discovery, and do not add, remove, rename, or reorder sections:
+
+```markdown
+## Command Surface
+
+- `make lint` - defined by root `Makefile`.
+
+## CI Expectations
+
+- `make lint` - required by CI.
+
+## Bin Wiring
+
+- Uses `./bin` shared make fragments.
+
+## Constraints
+
+- None.
+```
+
+- If a section has no entries, write exactly `- None.`
+- Use `Command Surface` for local commands, Make targets, scripts, or package-manager entrypoints.
+- Use `CI Expectations` for checks required by CI configuration.
+- Use `Bin Wiring` for included `bin/build/make/*.mak` fragments or `$(PWD)/bin/...` path behavior.
+- Use `Constraints` for missing tools, downstream-only paths, CI-only behavior, SSH/network requirements, or other workflow limits.
+
 ## When The Repo Uses `./bin`
 
 - Treat the consuming repository as the primary execution context.

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -8,7 +8,7 @@ description: Commits the current change, force-pushes the branch, and opens a dr
 ## Steps
 
 1. Inspect the changed paths from the working tree first; if the working tree is clean, inspect the latest commit.
-2. Use `$change-validation` to select and run credible validation before `make review`.
+2. Use `$change-validation` to select and run credible validation for the full change before `make review`; language-specific standards may refine that validation.
 3. If the changed paths include Go code, Go tests, Go modules, Go docs, or Go tooling behavior, also use `$go-standards`.
 4. If the changed paths include Ruby code, Ruby tests/features, Gemfiles, RuboCop config, Ruby docs, or Ruby tooling behavior, also use `$ruby-standards`.
 5. If the changed paths include shell scripts, Bash helpers, ShellCheck config/directives, shell docs, or script behavior, also use `$shell-standards`.
@@ -35,7 +35,46 @@ make msg="unprefixed subject" desc="summary" review
 ```
 
 18. Pass `desc` as the multiline Markdown summary from `$pr-summary`; do not flatten the summary into a single line.
-19. Report the commit message, validation results, code-review result, whether the review target succeeded, and any command failure that needs user action.
+19. Report the result using the exact structure in `Output Format`; do not add, remove, rename, or reorder sections.
+
+## Output Format
+
+Use exactly this Markdown structure and do not add, remove, rename, or reorder sections:
+
+```markdown
+## Commit Message
+
+unprefixed subject
+
+## PR Summary
+
+<multiline Markdown summary passed as desc>
+
+## Validation
+
+- command: `make lint`
+  result: passed
+
+## Code Review
+
+- result: no blocking findings
+
+## Review Target
+
+- command: `make msg="..." desc="..." review`
+  result: passed
+  pr: https://github.com/org/repo/pull/123
+
+## Notes
+
+- None.
+```
+
+- If a command was not run, write `not run` and explain why.
+- If `make review` fails before opening the PR, set `pr: unavailable`.
+- If `make review` succeeds but the PR URL is not visible in the command output, set `pr: unavailable`.
+- If there are no notes, write exactly `- None.`
+- Do not claim a PR exists unless the review target output confirms it.
 
 ## Notes
 

--- a/skills/ruby-standards/references/conventions.md
+++ b/skills/ruby-standards/references/conventions.md
@@ -14,6 +14,11 @@ Use this reference when working in Ruby repositories.
 - When a user-facing or documented API is non-trivial, include examples if the repository's documentation style supports them.
 - Keep examples aligned with the real public interface and expected calling style.
 
+## External Style References
+
+- When this repository does not state a more specific convention, use the RuboCop Ruby Style Guide and the Shopify Ruby Style Guide as advisory references.
+- Repository-local conventions take precedence over external style guides.
+
 ## Conventions
 
 - Keep method signatures, return shapes, exceptions, and side effects aligned with the repository's existing Ruby conventions.

--- a/skills/shell-standards/references/conventions.md
+++ b/skills/shell-standards/references/conventions.md
@@ -8,6 +8,11 @@ Use this reference when working with shell scripts.
 - Catch failures early with `set -eo pipefail`.
 - Preserve existing argument handling, command wrappers, and pass-through semantics.
 
+## External Style References
+
+- When this repository does not state a more specific convention, use the Google Shell Style Guide and Wooledge BashGuide Practices as advisory references.
+- Repository-local conventions take precedence over external style guides.
+
 ## Text Processing
 
 - Prefer `sed` or `awk` for text manipulation when shell tooling is the right fit.


### PR DESCRIPTION
## What

- Added fixed output templates for review, review-pr, PR summary, validation, safety, and workflow discovery reporting.
- Added advisory external style-guide references for Go, Ruby, and shell standards.
- Clarified review-pr validation scope and allowed PR summary footers required by orchestration flows.

## Why

- Make generated skill output more deterministic across repeated use.
- Keep repository-local conventions first while giving language standards clear external fallback references.

## Testing

- `make lint` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
