### PR TITLE
feat(skills): tighten deterministic output guidance

### DIFF
--- a/skills/change-validation/SKILL.md
+++ b/skills/change-validation/SKILL.md
@@ -11,7 +11,7 @@ description: Chooses and reports credible validation commands for tests, linting
 2. Read `references/check-selection.md` when choosing between targeted tests, lint commands, make targets, CI mirrors, benchmarks, or security checks.
 3. Run the narrowest check that credibly exercises the changed behavior, then expand only when risk justifies it.
 4. Notice wrappers that no-op because optional tools are missing, and do not report them as full validation.
-5. Report validation using the exact structure in `references/check-selection.md`; do not add, remove, rename, or reorder sections.
+5. When reporting standalone validation, use the exact structure in `references/check-selection.md`; when another skill embeds validation, preserve the command, result, coverage, and gap details.
 
 ## References
 

--- a/skills/change-validation/references/check-selection.md
+++ b/skills/change-validation/references/check-selection.md
@@ -21,7 +21,7 @@ Use this reference when choosing which checks to run.
 
 ## Output Format
 
-Use exactly this Markdown structure and do not add, remove, rename, or reorder sections:
+For standalone validation reports, use exactly this Markdown structure and do not add, remove, rename, or reorder sections:
 
 ```markdown
 ## Validation
@@ -41,6 +41,7 @@ Use exactly this Markdown structure and do not add, remove, rename, or reorder s
 - If no commands ran, write one `Validation` entry with `command: none` and `result: not run`.
 - In `coverage`, state what the command actually validated or why it did not validate anything.
 - If there are no validation gaps, write exactly `- None.`
+- When embedding validation in another skill's output format, preserve command, result, coverage, and gap details without adding standalone sections.
 
 ## Helpful Heuristics
 

--- a/skills/code-review/references/findings-format.md
+++ b/skills/code-review/references/findings-format.md
@@ -47,4 +47,3 @@ Brief one- or two-sentence summary.
 
 - In `Findings`, write exactly `- None.`
 - Use `Testing Gaps` to mention residual risk, blind spots, or testing gaps if they remain.
-- If there are no testing gaps, write exactly `- None.`

--- a/skills/go-standards/references/conventions.md
+++ b/skills/go-standards/references/conventions.md
@@ -35,10 +35,6 @@ Use this reference when working in Go repositories.
 ## Imports And Naming
 
 - Do not alias a Go import unless there is a real collision or required disambiguation.
-- If a project package has the same name as a Go standard-library package, prefer the project package as the natural import in local code.
-- Keep the project package unaliased when possible so the code reads in the repository's domain language.
-- Alias only the standard-library import instead of forcing an awkward alias onto the project package.
-- If the collision is at identifier level rather than import level, alias or rename only the referenced stdlib type, function, or variable needed to keep the code correct and readable.
+- If a project package has the same name as a standard-library package, keep the project package unaliased and alias only the standard-library import.
+- If the collision is at identifier level rather than import level, alias or rename only the referenced standard-library type, function, or variable.
 - Keep aliases short, obvious, and specific to the standard-library package they disambiguate.
-- If there is no collision, import the package without an alias.
-- When there is a collision, alias only what is needed on the stdlib side so the project's own package remains the default name in local code and the import block stays minimal.

--- a/skills/pr-summary/references/format.md
+++ b/skills/pr-summary/references/format.md
@@ -35,10 +35,7 @@ commit message subject
 - Keep the commit message as plain text only.
 - Keep the commit message entirely lowercase.
 - Do not add markdown, labels, bullets, quotes, or surrounding commentary to the commit message.
-- Write the PR summary in Markdown.
-- Use Markdown headings for the PR summary sections: `## What`, `## Why`, and `## Testing`.
-- Do not use bold text as section labels, such as `**What**`.
-- Do not add extra sections or alternate titles.
+- Do not add extra PR summary sections or alternate titles.
 - When another skill requires a footer, append it after `## Testing`; footers are allowed and are not sections.
 - If a PR summary section has no entries, write exactly `- None.`
 - Keep the testing section honest about what ran, what passed, and what did not run.
@@ -47,12 +44,9 @@ commit message subject
 
 - Check whether the local commit workflow adds a conventional-commit prefix from the current branch.
 - In repositories using this shared `bin` workflow, `build/make/git.mak` derives `type(scope):` from branches shaped like `user/type/scope` and prepends it in `make commit`, `make review`, and related targets.
-- When the workflow will prepend that branch-derived prefix, output only the unprefixed subject intended for `msg`.
-- Do not include a conventional prefix such as `feat(scope):` in that subject.
-- Treat the current branch as routing metadata, not summary source material.
-- Build a short exclusion list from every meaningful branch-path segment, including type, scope/name segments, and the hyphen- or slash-separated words inside those segments.
-- Do not repeat any branch-derived word in the subject unless omitting it would make the subject misleading or ambiguous.
-- Before returning the subject, compare it with the exclusion list and rewrite it if a branch-derived word can be replaced by a more concrete behavior from the diff.
+- When the workflow prepends a branch-derived prefix, output only the unprefixed subject intended for `msg`; do not include a conventional prefix such as `feat(scope):`.
+- Treat the current branch as routing metadata, not summary source material, and avoid branch-derived words unless omitting them would make the subject misleading.
+- Before returning the subject, compare it with the branch type, scope/name segments, and hyphen- or slash-separated words inside those segments; rewrite it if a branch word can be replaced by a more concrete behavior from the diff.
 - Prefer the concrete behavioral change over branch wording. For example, on `user/feat/skills`, use `avoid duplicate commit subject wording`, not `feat(skills): update skills pr summary`.
 
 ## Validation Notes

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -14,28 +14,23 @@ description: Commits the current change, force-pushes the branch, and opens a dr
 5. If the changed paths include shell scripts, Bash helpers, ShellCheck config/directives, shell docs, or script behavior, also use `$shell-standards`.
 6. Use `$code-review` to inspect the current change before drafting PR text.
 7. Resolve any blocking review findings before continuing; if findings remain intentionally unresolved, call them out in the PR summary.
-8. Use `$pr-summary` to draft a lowercase commit message and Markdown PR summary from the current working tree.
-9. Keep the commit message plain text and lowercase.
-10. Pass only the unprefixed subject as `msg`; `make review` adds the branch-derived `type(scope):` prefix.
-11. Treat the current branch as routing metadata, not `msg` source material.
-12. Build a short exclusion list from every meaningful branch-path segment, including type, scope/name segments, and the hyphen- or slash-separated words inside those segments.
-13. Do not repeat any branch-derived word in `msg` unless omitting it would make the subject misleading or ambiguous.
-14. Before running `make review`, compare `msg` with the exclusion list and rewrite it if a branch-derived word can be replaced by a more concrete behavior from the diff.
-15. Keep the summary in the `$pr-summary` format, including honest testing details.
-16. When attribution is appropriate or requested, append this footer to the summary instead of a `Co-authored-by:` trailer:
+8. Use `$pr-summary` to draft a lowercase, unprefixed `msg` and Markdown PR summary from the current working tree.
+9. Follow `$pr-summary` commit-subject rules: `make review` adds the branch-derived `type(scope):` prefix, so treat branch words as routing metadata rather than message source material.
+10. Keep the summary in the `$pr-summary` format, including honest testing details.
+11. When attribution is appropriate or requested, append this footer to the summary instead of a `Co-authored-by:` trailer:
 
 ```text
 AI-assisted-by: [Codex](https://openai.com/codex/)
 ```
 
-17. Run the review target with the drafted values:
+12. Run the review target with the drafted values:
 
 ```bash
 make msg="unprefixed subject" desc="summary" review
 ```
 
-18. Pass `desc` as the multiline Markdown summary from `$pr-summary`; do not flatten the summary into a single line.
-19. Report the result using the exact structure in `Output Format`; do not add, remove, rename, or reorder sections.
+13. Pass `desc` as the multiline Markdown summary from `$pr-summary`; do not flatten the summary into a single line.
+14. Report the result using the exact structure in `Output Format`; do not add, remove, rename, or reorder sections.
 
 ## Output Format
 
@@ -54,6 +49,9 @@ unprefixed subject
 
 - command: `make lint`
   result: passed
+  coverage: Ruby linting for changed files.
+
+- gaps: None.
 
 ## Code Review
 
@@ -70,14 +68,15 @@ unprefixed subject
 - None.
 ```
 
-- If a command was not run, write `not run` and explain why.
+- In `Validation`, include one item per command plus a final `gaps` item.
+- In `Code Review`, state whether there were no findings, blocking findings were resolved, or unresolved findings were documented in the PR summary.
+- If a command was not run, write `not run` as the result and explain why in `coverage`.
 - If `make review` fails before opening the PR, set `pr: unavailable`.
 - If `make review` succeeds but the PR URL is not visible in the command output, set `pr: unavailable`.
 - If there are no notes, write exactly `- None.`
-- Do not claim a PR exists unless the review target output confirms it.
 
 ## Notes
 
 - The `review` target commits, force-pushes the current branch, and opens a draft PR.
-- Do not claim the PR exists if `make review` fails before the draft step.
+- Do not claim a PR exists unless the review target output confirms it.
 - Do not claim unrun checks passed.


### PR DESCRIPTION
## What

- Clarified standalone versus embedded validation reporting.
- Compressed repeated review-pr and PR summary wording by delegating commit-subject rules to the summary skill.
- Tightened repeated import-collision and empty-section guidance without changing the intended behavior.

## Why

- Reduce duplicated skill instructions that can drift over time.
- Keep deterministic output requirements clear while avoiding contradictory standalone and embedded report formats.

## Testing

- `make lint` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
