### PR TITLE
feat(skills): add security audit workflow and harden docker image arguments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ skill instead of one broad default:
   files, and security-sensitive edits.
 - `change-validation`: test, lint, CI, security, benchmark, and validation selection.
 - `code-review`: review findings, risk assessment, and missing coverage.
+- `security-audit`: security reviews, vulnerability checks, unsafe shell/filesystem/network/auth inspection, and Go/Ruby/shell audit guidance.
 - `pr-summary`: commit messages, PR descriptions, and shareable change summaries.
 - `review-pr`: create a commit, force-push, and open a draft PR using `pr-summary`.
 - `makefile-includes`: reusable `build/make/*.mak` behavior and downstream path

--- a/build/docker/build
+++ b/build/docker/build
@@ -1,11 +1,26 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2086,SC2155
+# shellcheck disable=SC2155
 
 set -eo pipefail
 
 readonly name="$1"
 readonly platform="$2"
 readonly dir="$(dirname "$(readlink -f "$0")")"
+readonly dockerfile="$dir/go/Dockerfile"
+readonly image="alexfalkowski/$name:test.$platform"
+
+# Print an error and stop the script.
+die() {
+  printf 'error: %s\n' "$1" >&2
+  exit 1
+}
+
+# Validate Docker image reference components before invoking Docker.
+validate() {
+  [[ "$name" =~ ^[a-z0-9]+([._-][a-z0-9]+)*$ ]] || die "invalid image name: $name"
+  [[ "$platform" =~ ^(amd64|arm64)$ ]] || die "invalid platform: $platform"
+}
 
 # Build docker.
-docker build --build-arg name=$name --build-arg version="latest" -t alexfalkowski/$name:test.$platform -f $dir/go/Dockerfile .
+validate
+docker build --build-arg "name=$name" --build-arg version="latest" -t "$image" -f "$dockerfile" .

--- a/build/docker/manifest
+++ b/build/docker/manifest
@@ -1,17 +1,34 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2086,SC2155
+# shellcheck disable=SC2155
 
 set -eo pipefail
 
 readonly version_file="${APP_VERSION_FILE:-/tmp/workspace/release-version.txt}"
 
+# Print an error and stop the script.
+die() {
+  printf 'error: %s\n' "$1" >&2
+  exit 1
+}
+
+# Validate Docker image reference components before invoking Docker.
+validate() {
+  [[ "$name" =~ ^[a-z0-9]+([._-][a-z0-9]+)*$ ]] || die "invalid image name: $name"
+  [[ "$latest_tag" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]] || die "invalid image tag: $latest_tag"
+}
+
 if [[ -f "$version_file" ]]; then
   readonly name="$1"
   readonly latest_tag="$(cat "$version_file")"
+  readonly image="alexfalkowski/$name:$latest_tag"
+  readonly amd64_image="alexfalkowski/$name:$latest_tag.amd64"
+  readonly arm64_image="alexfalkowski/$name:$latest_tag.arm64"
+  readonly latest_image="alexfalkowski/$name"
 
-  docker manifest create alexfalkowski/$name:$latest_tag --amend alexfalkowski/$name:$latest_tag.amd64 --amend alexfalkowski/$name:$latest_tag.arm64
-  docker manifest push alexfalkowski/$name:$latest_tag
+  validate
+  docker manifest create "$image" --amend "$amd64_image" --amend "$arm64_image"
+  docker manifest push "$image"
 
-  docker manifest create alexfalkowski/$name --amend alexfalkowski/$name:$latest_tag.amd64 --amend alexfalkowski/$name:$latest_tag.arm64
-  docker manifest push alexfalkowski/$name
+  docker manifest create "$latest_image" --amend "$amd64_image" --amend "$arm64_image"
+  docker manifest push "$latest_image"
 fi

--- a/build/docker/push
+++ b/build/docker/push
@@ -1,16 +1,32 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2086,SC2155
+# shellcheck disable=SC2155
 
 set -eo pipefail
 
 readonly version_file="${APP_VERSION_FILE:-/tmp/workspace/release-version.txt}"
+
+# Print an error and stop the script.
+die() {
+  printf 'error: %s\n' "$1" >&2
+  exit 1
+}
+
+# Validate Docker image reference components before invoking Docker.
+validate() {
+  [[ "$name" =~ ^[a-z0-9]+([._-][a-z0-9]+)*$ ]] || die "invalid image name: $name"
+  [[ "$platform" =~ ^(amd64|arm64)$ ]] || die "invalid platform: $platform"
+  [[ "$latest_tag" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]] || die "invalid image tag: $latest_tag"
+}
 
 if [[ -f "$version_file" ]]; then
   readonly name="$1"
   readonly platform="$2"
   readonly latest_tag="$(cat "$version_file")"
   readonly dir="$(dirname "$(readlink -f "$0")")"
+  readonly dockerfile="$dir/go/Dockerfile"
+  readonly image="alexfalkowski/$name:$latest_tag.$platform"
 
   # Build and push docker.
-  docker build --build-arg name=$name --build-arg version=$latest_tag -t alexfalkowski/$name:$latest_tag.$platform -f $dir/go/Dockerfile --push .
+  validate
+  docker build --build-arg "name=$name" --build-arg "version=$latest_tag" -t "$image" -f "$dockerfile" --push .
 fi

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: security-audit
+description: Reviews code, scripts, Makefile glue, Docker helpers, dependencies, and configuration for security risks. Use when the user asks for a security audit, security review, vulnerability check, secret check, unsafe shell/filesystem/network/auth review, or language-specific security inspection for Go, Ruby, or shell code.
+---
+
+# Security Audit
+
+## Steps
+
+1. Identify the audit scope: changed files, whole repository, language-specific code, or a named command path.
+2. Read the smallest matching reference before auditing:
+   - `references/go.md` for Go code, modules, HTTP/TLS, crypto, filesystem, command execution, or `govulncheck`.
+   - `references/ruby.md` for Ruby code, Bundler, process execution, YAML/JSON parsing, filesystem, env/secrets, or RuboCop security coverage.
+   - `references/shell.md` for Bash scripts, Make targets that invoke shell commands, Docker helper scripts, ShellCheck, quoting, temp files, or destructive commands.
+   - `references/shared.md` for cross-language repositories, dependency/config audits, secrets, Docker/security scanners, and report structure.
+3. Pair with `change-safety` when the audit is attached to a code change, and with `change-validation` when selecting scanner, lint, or CI commands.
+4. Inspect concrete data/control flow before reporting a risk. Prefer file and line references over general advice.
+5. Report exploitable findings first. Use the exact structure in `references/shared.md`; do not add, remove, rename, or reorder sections.
+
+## References
+
+- Read `references/shared.md` for common audit workflow, validation choices, severity guidance, and output expectations.
+- Read language references only when the scoped files or user request calls for them.

--- a/skills/security-audit/agents/openai.yaml
+++ b/skills/security-audit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Security Audit"
+  short_description: "Audit code and scripts for security risk"
+  default_prompt: "Use $security-audit to review this change for security risks."

--- a/skills/security-audit/references/go.md
+++ b/skills/security-audit/references/go.md
@@ -1,0 +1,28 @@
+# Go Security Audit
+
+Use this reference for Go code, tests, module metadata, or Go-related Make targets.
+
+## Inspect
+
+- `os/exec`: avoid shell interpretation; validate command names and args; set working directory and environment deliberately.
+- Filesystem paths: clean and constrain user-provided paths; avoid path traversal, unsafe symlink following, broad `os.RemoveAll`, and weak file modes.
+- HTTP clients/servers: timeouts, request body limits, TLS verification, redirect behavior, header trust, CORS, proxy behavior, and log exposure.
+- Crypto and randomness: use `crypto/rand`; avoid custom crypto, weak hashes for security decisions, hardcoded keys, and nonce reuse.
+- Serialization: treat YAML/JSON/protobuf input as untrusted; enforce limits for large payloads and recursive structures.
+- Database/query code: use parameterized queries; avoid string-built SQL or unsafe query fragments.
+- Concurrency around security state: avoid races in caches, token stores, and auth decisions.
+- Errors/logs: do not leak secrets, tokens, credentials, private keys, or sensitive request bodies.
+
+## Validation
+
+- Prefer repo-defined Go targets first.
+- If `build/make/go.mak` is included, use `make sec` for `govulncheck` plus Trivy.
+- Use `govulncheck -show verbose -test ./...` when a narrower direct vulnerability check is appropriate.
+- Use Go tests for behavioral security fixes, especially path constraints, input validation, auth decisions, and error handling.
+- If `golangci-lint` is wrapped by `build/go/lint`, remember it may no-op when `golangci-lint` is missing.
+
+## Findings
+
+- Prioritize exploitable data flow from untrusted input to dangerous sinks.
+- For dependency findings, include the vulnerable module, vulnerable path when available, and upgrade/remediation path.
+- For API changes, pair with `go-standards`, `change-safety`, and `change-validation`.

--- a/skills/security-audit/references/ruby.md
+++ b/skills/security-audit/references/ruby.md
@@ -1,0 +1,27 @@
+# Ruby Security Audit
+
+Use this reference for Ruby scripts, libraries, tests, Bundler metadata, or Ruby Make targets.
+
+## Inspect
+
+- Shell execution: avoid interpolated strings in `system`, backticks, `%x`, `Open3`, and process helpers; pass argv arrays where possible.
+- Filesystem paths: constrain user-provided paths; avoid traversal, unsafe symlink handling, broad deletes, and insecure file permissions.
+- YAML and serialization: avoid unsafe deserialization of untrusted data; prefer safe loaders and explicit classes when loading YAML.
+- Environment and secrets: avoid logging env secrets, tokens, credentials, private keys, and realistic sample credentials.
+- Network calls: verify TLS, set timeouts, avoid SSRF-prone fetches, and constrain redirects/proxies when input controls URLs.
+- Regular expressions: check user-controlled patterns or catastrophic backtracking in request/CLI paths.
+- Metaprogramming: scrutinize `eval`, `instance_eval`, `class_eval`, dynamic constants, and monkey patches.
+
+## Validation
+
+- Prefer repo-defined Ruby targets first.
+- In this repository, `make lint` runs RuboCop and `make sec-lint` runs Trivy repo scanning.
+- If `build/make/ruby.mak` is included downstream, use `make sec` for Trivy repository scanning.
+- If Bundler audit tooling is present in a consuming repo, use the repo's configured entry point rather than inventing one.
+- Report when security coverage is limited to static linting or dependency scanning and no behavior tests exercise the risky path.
+
+## Findings
+
+- Show the exact data path from untrusted input to the Ruby sink.
+- Include a safe replacement pattern, such as argv-array process execution, safe YAML loading, constrained path joins, or redacted logging.
+- Pair with `ruby-standards`, `change-safety`, and `change-validation` for code changes.

--- a/skills/security-audit/references/shared.md
+++ b/skills/security-audit/references/shared.md
@@ -1,0 +1,94 @@
+# Shared Security Audit
+
+Use this reference for any security audit, then load language-specific references only as needed.
+
+## Scope
+
+- Determine whether the user wants a diff audit, full repository audit, dependency scan, or one command/script path.
+- Identify trust boundaries: CLI args, env vars, config files, network input, filesystem paths, generated files, dependency metadata, and CI secrets.
+- For shared `./bin` tooling, consider both this repository root and downstream usage where helpers are invoked through `$(PWD)/bin/...`.
+
+## Common Risks
+
+- Secrets or realistic credentials committed in code, tests, docs, configs, fixtures, or generated files.
+- Untrusted input reaching shell execution, filesystem writes/deletes, archive extraction, templates, SQL/queries, YAML deserialization, HTTP requests, or logs.
+- Unsafe defaults: disabled TLS verification, broad filesystem permissions, world-writable files, unauthenticated endpoints, permissive CORS, weak crypto, or silent fallback to insecure behavior.
+- Dependency or container vulnerabilities not covered by the repository's validation commands.
+- CI or Make targets that expose secrets, run remote code, or differ materially from local validation.
+
+## Validation
+
+- Prefer repository-defined targets before ad hoc scanners.
+- In this repository, relevant checks include:
+  - `make sec-lint` for Trivy repository scanning.
+  - `make scripts-lint` for ShellCheck coverage of shared scripts.
+  - `make docker-lint` for Hadolint coverage of the Go Dockerfile.
+  - `make lint` for RuboCop coverage of Ruby code.
+- In downstream Go repositories that include `build/make/go.mak`, `make sec` runs `govulncheck` and Trivy repo scanning.
+- In downstream Ruby repositories that include `build/make/ruby.mak`, `make sec` runs Trivy repo scanning.
+- Report wrappers as partial or no-op when tools such as `trivy`, `govulncheck`, `shellcheck`, `hadolint`, or `golangci-lint` are missing.
+
+## Freshness
+
+- Treat this reference as stable audit heuristics, not an exhaustive current vulnerability database.
+- Prefer repository-defined commands, local configuration, lockfiles, and scanner output over this reference when they differ.
+- For dependency vulnerabilities, scanner behavior, language or tool security guidance, and newly disclosed issues, verify against current tool output or official documentation.
+- Do not cite CVEs, current scanner capabilities, or current best-practice claims from memory.
+- Keep updates focused on durable risk classes, dangerous sinks, and repository entry points instead of volatile vulnerability lists.
+
+## Verification Sources
+
+- Use current verification sources when a finding depends on vulnerability status, affected versions, scanner behavior, exploit activity, or official hardening guidance.
+- Ruby language and standard library advisories: `https://www.ruby-lang.org/en/security/`.
+- Ruby gems: RubySec and Bundler Audit, especially `https://rubysec.com/` and the local `Gemfile.lock` when present.
+- RubyGems supply-chain guidance: `https://guides.rubygems.org/security/`.
+- Go modules, standard library, and toolchain advisories: `https://pkg.go.dev/vuln/`, `https://go.dev/doc/security/vuln/database`, and `govulncheck` output.
+- Cross-ecosystem open-source dependencies: OSV.dev data/API at `https://osv.dev/`, especially for ecosystems such as Go, RubyGems, Debian, Alpine, Ubuntu, npm, PyPI, and Maven.
+- Docker images and container vulnerability status: Docker Scout and its advisory-source documentation under `https://docs.docker.com/scout/`.
+- Dockerfile and container hardening: Docker security, build secrets, Dockerfile reference, and build best-practices documentation under `https://docs.docker.com/security/`, `https://docs.docker.com/build/`, and `https://docs.docker.com/reference/dockerfile/`.
+- Bash itself: GNU Bash project pages, GNU Bash bug/mailing-list channels, NVD/CVE records, and the relevant operating-system distribution security tracker. Bash does not have a single canonical vulnerability database equivalent to Ruby's security page or the Go vulnerability database.
+- Shell script findings: ShellCheck output and rule documentation, especially `https://www.shellcheck.net/wiki/`, plus local code-flow evidence.
+- Exploit prioritization: CISA Known Exploited Vulnerabilities catalog at `https://www.cisa.gov/known-exploited-vulnerabilities-catalog`.
+- If sources disagree, prefer vendor or ecosystem advisories for affected versions and remediation, scanner output for what the local project currently exposes, and CISA KEV for known exploitation status.
+
+## Severity
+
+- High: likely secret exposure, auth bypass, command injection, arbitrary file write/delete, path traversal to sensitive files, remote code execution, or exploitable critical dependency issue.
+- Medium: constrained injection, sensitive information disclosure, unsafe TLS/auth defaults, dangerous local-only behavior likely to be copied into production, or scanner coverage gaps on security-sensitive changes.
+- Low: hardening issue, defense-in-depth improvement, unclear validation gap, or risky pattern without a demonstrated exploit path.
+
+## Reporting
+
+- Use exactly this Markdown structure and do not add, remove, rename, or reorder sections:
+
+```markdown
+## Findings
+
+- severity: High
+  file: `path/to/file:42`
+  risk: Untrusted input reaches shell execution.
+  trigger: User-controlled CLI arguments are interpolated into a shell command.
+  impact: An attacker can execute arbitrary commands.
+  remediation: Pass arguments as argv entries without shell interpretation.
+
+## Validation
+
+- command: `make sec-lint`
+  result: passed
+  coverage: Trivy repository scan for critical vulnerabilities.
+
+## Gaps
+
+- None.
+```
+
+- Use only these severity values for findings: `High`, `Medium`, `Low`. Use `None` only for the required no-findings entry.
+- Use only these validation results: `passed`, `failed`, `not run`, `no-op`.
+- Use `file: n/a` only for repository-wide dependency, configuration, or validation findings that do not have a precise source line.
+- If there are no findings, write exactly one finding entry with `severity: None`, `file: n/a`, `risk: No findings.`, `trigger: n/a`, `impact: n/a`, and `remediation: n/a`.
+- If no validation ran, write one `Validation` entry with `command: none`, `result: not run`, and a concise coverage explanation.
+- If there are no gaps, write exactly `- None.`
+- Findings must be ordered by severity, with exploitable risks before hardening items.
+- Each finding should state: risk, trigger condition, impact, and remediation.
+- Do not report generic checklist items as findings unless they apply to the audited code.
+- If no findings are found, say that clearly and list meaningful gaps, such as scanners not installed or dynamic behavior not exercised.

--- a/skills/security-audit/references/shell.md
+++ b/skills/security-audit/references/shell.md
@@ -1,0 +1,28 @@
+# Shell Security Audit
+
+Use this reference for Bash scripts, Make recipes that execute shell code, Docker helper scripts, and command wrappers.
+
+## Inspect
+
+- Quoting: quote variable expansions unless intentional word splitting is documented and safe.
+- Shell interpretation: avoid `eval`, `bash -c`, `sh -c`, and interpolated command strings with untrusted input.
+- Argument pass-through: preserve argv boundaries with arrays or `"$@"`; document intentional pass-through and ShellCheck disables.
+- Filesystem operations: constrain delete/write paths; scrutinize `rm -rf`, `mv`, `cp`, globbing, symlink handling, and relative paths.
+- Temp files: use `mktemp`; avoid predictable names and races.
+- Downloads and remote execution: avoid `curl | sh`; verify sources and fail closed.
+- Environment and secrets: avoid printing secrets with `set -x`, logs, or error messages.
+- Error handling: use `set -eo pipefail` where consistent with the repo; handle expected non-zero statuses explicitly.
+
+## Validation
+
+- Prefer repo-defined targets first.
+- In this repository, use `make scripts-lint` for ShellCheck coverage of shared scripts.
+- For Docker-related script changes, consider `make docker-lint` and `make sec-lint` when relevant.
+- ShellCheck is necessary but not sufficient: still inspect trust boundaries, path constraints, and command construction manually.
+- Report `make scripts-lint` as not run or no-op if `shellcheck` is unavailable.
+
+## Findings
+
+- Treat untrusted input reaching shell parsing or broad filesystem mutation as high severity unless strongly constrained.
+- Include a concrete safer rewrite: arrays, `--` separators, anchored working directories, constrained path checks, or explicit allowlists.
+- Pair with `shell-standards`, `change-safety`, and `change-validation` for script changes.

--- a/skills/shell-standards/references/conventions.md
+++ b/skills/shell-standards/references/conventions.md
@@ -25,8 +25,10 @@ Use this reference when working with shell scripts.
 
 ## Functions
 
-- Add comments for public functions.
-- Functions starting with `_` are private and do not require comments.
+- In included or sourced shell library files, typically files ending in `.sh`, add comments for public functions.
+- In included or sourced shell library files, functions starting with `_` are private and do not require comments.
+- In standalone executable scripts, functions do not need a leading `_` just to avoid public API treatment.
+- Add comments for non-underscore functions in both standalone executable scripts and included shell library files.
 - Keep function names and call patterns aligned with the surrounding script.
 
 ## ShellCheck


### PR DESCRIPTION
## What

- Added a security-audit skill with deterministic findings, validation, and gap reporting.
- Added Go, Ruby, shell, shared freshness, and verification-source references for security audits.
- Registered security-audit in AGENTS.md.
- Hardened Docker build, push, and manifest helpers by validating image inputs and quoting Docker CLI arguments.

## Why

- Security audits need stable output, current-source verification guidance, and language-specific checklists.
- Docker helper arguments previously relied on broad ShellCheck disables and unquoted image reference components.

## Testing

- `make scripts-lint` - passed
- `make docker-lint` - passed
- `make lint` - passed
- `make sec-lint` - passed
- `bash -n build/docker/build build/docker/push build/docker/manifest` - passed
- `ruby -e 'require "yaml"; text = File.read("skills/security-audit/SKILL.md"); YAML.safe_load(text.split("---", 3)[1]); YAML.safe_load(File.read("skills/security-audit/agents/openai.yaml")); puts "ok"'` - passed
- Docker helper negative checks for invalid image names and tags - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
