### PR TITLE
feat(skills): clarify review workflow guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,19 @@ skill instead of one broad default:
 
 Treat this `AGENTS.md` as the repo-specific companion to those skills.
 
+When changing a skill's trigger, scope, workflow, or user-facing behavior,
+check the matching `skills/<name>/agents/openai.yaml` and update it if the
+display name, short description, or default prompt became stale.
+
+Common composition:
+
+- `review-pr` orchestrates PR preparation with `change-validation`, relevant
+  language standards, `code-review`, and `pr-summary`.
+- `code-review` conditionally consults `security-audit` for security-sensitive
+  review scope while keeping the review findings format.
+- `security-audit` pairs with `change-safety` for code changes and
+  `change-validation` for scanner, lint, or CI command selection.
+
 ## Quick commands (this repo)
 
 From this repository root:
@@ -47,14 +60,16 @@ From this repository root:
 - Script / Dockerfile linting:
   - `make scripts-lint` (runs `shellcheck` over various scripts)
   - `make docker-lint` (runs `hadolint` on `build/docker/go/Dockerfile`)
+- Security scanning:
+  - `make sec-lint` (runs Trivy over the repository)
 
-CI runs (CircleCI): `make dep`, `make clean-dep`, `make scripts-lint`, `make docker-lint`, `make lint` (see `.circleci/config.yml`).
+CI runs (CircleCI): `make dep`, `make clean-dep`, `make scripts-lint`, `make docker-lint`, `make lint`, `make sec-lint` (see `.circleci/config.yml`).
 
 ## Tooling dependencies (observed)
 
 Ruby tooling (declared in `Gemfile`):
 
-- Ruby (Rubocop targets Ruby **4.0**, see `.rubocop.yml`)
+- Ruby
 - Bundler (`bundler` gem)
 - RuboCop (`rubocop` gem)
 
@@ -121,7 +136,7 @@ Only rely on a command if you can find it being invoked in the relevant `.mak`/s
 
 ### RuboCop
 
-- `.rubocop.yml` sets `TargetRubyVersion: 4.0`.
+- `.rubocop.yml` defines the Ruby parser/target settings.
 - Excludes `vendor/**/*` and also `bin/**/*` (important in downstream repos that vendor this as `./bin`).
 
 ## Gotchas
@@ -148,9 +163,8 @@ Only rely on a command if you can find it being invoked in the relevant `.mak`/s
   - This is deliberate to reduce local branch-name collisions.
   - Do not flag it as a bug unless the task is specifically about changing branch naming semantics.
 
-- **Ruby/tooling version skew is intentional here**.
-  - `.circleci/config.yml` uses `alexfalkowski/ruby:2.7` for this repo's CI job, while `.rubocop.yml` targets Ruby 4.0.
-  - Treat that mismatch as deliberate unless the task is specifically about modernizing CI or Ruby tooling.
+- **Ruby/tooling version skew may be intentional here**.
+  - Treat differences between the CI image, local Ruby configuration, and RuboCop target settings as deliberate unless the task is specifically about modernizing CI or Ruby tooling.
 
 ## CI signals
 
@@ -161,6 +175,7 @@ Only rely on a command if you can find it being invoked in the relevant `.mak`/s
   - `make scripts-lint`
   - `make docker-lint`
   - `make lint`
+  - `make sec-lint`
 
 ## When changing this repo
 
@@ -168,5 +183,6 @@ Only rely on a command if you can find it being invoked in the relevant `.mak`/s
 - After edits, re-run at least:
   - `make dep`
   - `make lint`
+  - `make sec-lint`
   - `make scripts-lint` (if `shellcheck` is available)
   - `make docker-lint` (if `hadolint` is available)

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,83 @@
+# Skills
+
+Use the smallest skill that matches the task. Compose skills by letting the
+outer workflow own the final response format and embedded skills provide facts,
+checks, and findings.
+
+## Common Composition
+
+- `review-pr` orchestrates PR preparation with `change-validation`, relevant
+  language standards, `code-review`, and `pr-summary`.
+- `code-review` performs the review pass and conditionally consults
+  `security-audit` for security-sensitive scope.
+- `security-audit` pairs with `change-safety` for code changes and
+  `change-validation` for scanner, lint, or CI command selection.
+- `makefile-includes` should follow `project-workflow` when the command surface
+  or downstream `./bin` wiring is not yet known.
+- Language standards pair with `change-validation` for check selection and
+  `change-safety` when public APIs, commands, or documented behavior change.
+
+## Format Rule
+
+When a skill is used as the final answer, use that skill's required output
+format. When a skill is embedded by another skill, preserve its concrete facts
+and use the caller's output format.
+
+## Testing Principle
+
+Before adding tests, inspect the repository's existing test suites, fixtures,
+helpers, entrypoints, and CI targets, then follow that standard. Prefer tests
+and validation through the existing public or documented entry points for the
+project type: libraries often use unit/integration tests, while services in
+this ecosystem often use Cucumber features. Use internal seams only when the
+repo already tests that way, the behavior cannot be exercised credibly through
+the established surface, or the change has no stable public surface.
+
+- Do not introduce a new test framework, fixture layout, or test layer unless
+  the task explicitly changes testing infrastructure.
+- Choose the narrowest established test layer that credibly covers the changed
+  behavior; use broader suites for shared infrastructure or release-sensitive
+  changes.
+- Assert changed behavior and contracts, not incidental implementation details.
+- Keep tests deterministic: avoid uncontrolled network, wall-clock time, random
+  data, ordering assumptions, real home directories, and shared mutable state.
+- Cover relevant failure paths, especially invalid input, missing files/tools,
+  non-zero commands, path errors, permissions, and argument pass-through.
+- Do not add behavioral tests for docs-only or formatting-only changes; run the
+  relevant lint, docs, or formatting validation when available.
+- For shared `./bin` scripts and make fragments, validate from the consuming
+  repository root when behavior depends on downstream `$(PWD)/bin/...` wiring.
+- Report validation gaps honestly, including lint-only coverage, missing tools,
+  skipped checks, and wrappers that no-op.
+
+## Network And Remote Commands
+
+- Networked commands are acceptable when needed for setup, validation,
+  dependency resolution, scanning, or workflow execution.
+- Before running commands that require SSH credentials, GitHub auth, registry
+  auth, cloning, fetching large dependencies, pushing, publishing, opening PRs,
+  or updating remote state, make the network/auth requirement explicit and get
+  user permission.
+- Treat remote-write commands such as push, publish, release, Docker manifest
+  push, Buf push, and PR update/open flows as permission-gated even when a local
+  Make target wraps them.
+- If a needed command fails because network or credentials are unavailable,
+  report it as an environment or validation gap rather than a code failure.
+
+## Documentation And Examples
+
+- When a public command, API, Make target, environment variable, file format,
+  output shape, or operator-facing behavior changes, update the repository's
+  existing docs and examples in the same change.
+- Prefer updating existing README snippets, inline docs, examples, feature
+  files, or operator docs over creating new documentation locations.
+- If docs or examples are not updated for a user-facing change, state why they
+  are not needed.
+
+## Skill Metadata
+
+- When a skill's trigger, scope, workflow, or user-facing behavior changes,
+  check the matching `agents/openai.yaml` and update its display name, short
+  description, or default prompt if they became stale.
+- Keep `agents/openai.yaml` concise; it should describe when to use the skill,
+  not repeat the full `SKILL.md` workflow.

--- a/skills/change-safety/SKILL.md
+++ b/skills/change-safety/SKILL.md
@@ -10,8 +10,10 @@ description: Protects documented interfaces, compatibility, security, generated 
 1. Identify whether the requested change touches a user-facing or documented interface.
 2. Read `references/safety-checks.md` before editing compatibility-sensitive, security-sensitive, generated, vendored, or documented behavior.
 3. Preserve existing behavior unless the user explicitly requests a breaking change or the fix requires one.
-4. Update documentation in the repository's existing style when behavior, usage, or migration expectations change.
-5. Report safety-relevant notes using the exact structure in `references/safety-checks.md`; do not add, remove, rename, or reorder sections.
+4. Update documentation and examples in the repository's existing style when behavior, usage, or migration expectations change; if no docs update is needed for a user-facing change, state why.
+5. For security-specific risk analysis, pair with `$security-audit` instead of expanding this skill into a full audit.
+6. When safety notes are the final response, use the exact structure in `references/safety-checks.md`; do not add, remove, rename, or reorder sections.
+7. When another skill embeds safety notes, preserve compatibility, migration, security, and generated/external-file facts in the caller's output format.
 
 ## References
 

--- a/skills/change-safety/references/safety-checks.md
+++ b/skills/change-safety/references/safety-checks.md
@@ -10,7 +10,7 @@ Use this reference when deciding how to handle compatibility, documentation, sec
 
 ## Output Format
 
-Use exactly this Markdown structure and do not add, remove, rename, or reorder sections:
+When safety notes are the final response, use exactly this Markdown structure and do not add, remove, rename, or reorder sections:
 
 ```markdown
 ## Compatibility
@@ -35,6 +35,7 @@ Use exactly this Markdown structure and do not add, remove, rename, or reorder s
 - Use `Migration` for required consumer action, deprecation, or replacement guidance.
 - Use `Security` for security-sensitive tradeoffs, unsafe defaults, secrets, shell execution, filesystem writes, auth, or untrusted input.
 - Use `Generated Or External Files` for generated files, vendored files, lockfiles, or dependency constraints.
+- When another skill embeds safety notes, keep the same compatibility, migration, security, and generated/external-file facts but use the caller's required output sections.
 
 ## Migration And Deprecation
 
@@ -61,4 +62,5 @@ Use exactly this Markdown structure and do not add, remove, rename, or reorder s
 - Prefer updating existing documentation files over creating new ones unless the repository clearly expects a new document.
 - Place examples where the repository already expects them, such as inline docs, example tests, or README snippets.
 - If user-facing behavior changes, update README snippets, examples, changelog entries, or operator docs when the repository uses them.
+- If docs or examples are not updated for a user-facing change, state why they are not needed.
 - Keep documentation aligned with the shipped behavior, not the intended behavior.

--- a/skills/change-validation/SKILL.md
+++ b/skills/change-validation/SKILL.md
@@ -9,9 +9,11 @@ description: Chooses and reports credible validation commands for tests, linting
 
 1. Discover the repository's validation entrypoints before running checks.
 2. Read `references/check-selection.md` when choosing between targeted tests, lint commands, make targets, CI mirrors, benchmarks, or security checks.
-3. Run the narrowest check that credibly exercises the changed behavior, then expand only when risk justifies it.
-4. Notice wrappers that no-op because optional tools are missing, and do not report them as full validation.
-5. When reporting standalone validation, use the exact structure in `references/check-selection.md`; when another skill embeds validation, preserve the command, result, coverage, and gap details.
+3. Run the repository's setup or dependency target first when validation depends on installed dependencies or generated/vendor state.
+4. Ask for user permission before running validation commands that require SSH credentials, GitHub auth, registry auth, cloning, pushing, publishing, opening PRs, or updating remote state.
+5. Run the narrowest check that credibly exercises the changed behavior, then expand only when risk justifies it.
+6. Notice wrappers that no-op because optional tools are missing, and do not report them as full validation.
+7. When reporting standalone validation, use the exact structure in `references/check-selection.md`; when another skill embeds validation, preserve the command, result, coverage, and gap details.
 
 ## References
 

--- a/skills/change-validation/references/check-selection.md
+++ b/skills/change-validation/references/check-selection.md
@@ -9,15 +9,19 @@ Use this reference when choosing which checks to run.
 - Prefer repository-defined commands because they encode project conventions.
 - Use direct commands when they are clearly narrower or better aligned with the task than a broader repo wrapper.
 - Use CI configuration as a strong signal for which checks matter most.
+- Run the repository's setup target, such as `make dep`, when checks depend on installed dependencies, generated files, or vendored state.
+- Ask for permission before running checks that require SSH credentials, GitHub auth, registry auth, cloning, pushing, publishing, opening PRs, or updating remote state.
 - Expand from targeted checks to broader checks only when the task or risk justifies it.
 - Never imply a check ran if the wrapper no-op'd because a dependency was missing.
+- Report network or credential failures as environment or validation gaps rather than code failures.
 
 ## Typical Validation Order
 
-1. Run the most targeted lint or test command that exercises the changed behavior.
-2. Run the nearest repository entry point, often a `make` target, when that is the project's standard workflow.
-3. Run any additional repo-defined checks that are clearly relevant to the risk of the change.
-4. Run broader lint or test suites only when the change touches shared infrastructure, multiple packages, or release-sensitive behavior.
+1. Run setup or dependency installation when the required tools or generated/vendor state may be missing.
+2. Run the most targeted lint or test command that exercises the changed behavior.
+3. Run the nearest repository entry point, often a `make` target, when that is the project's standard workflow.
+4. Run any additional repo-defined checks that are clearly relevant to the risk of the change.
+5. Run broader lint or test suites only when the change touches shared infrastructure, multiple packages, or release-sensitive behavior.
 
 ## Output Format
 
@@ -53,7 +57,9 @@ For standalone validation reports, use exactly this Markdown structure and do no
 - If the repository exposes named test entry points, use the one that matches the affected behavior instead of inventing a different test vocabulary.
 - If the repository exposes benchmark or coverage targets that are relevant to the change, prefer those entry points over ad hoc commands.
 - If a repo exposes `dep`, `lint`, `specs`, `features`, `benchmarks`, `coverage`, or `sec`, prefer those names over ad hoc tool invocations.
-- For this shared `bin` repo itself, CI currently treats `make scripts-lint`, `make docker-lint`, `make lint`, and `make sec-lint` as the authoritative checks.
+- For this shared `bin` repo itself, CI currently runs `make dep`, `make clean-dep`, `make scripts-lint`, `make docker-lint`, `make lint`, and `make sec-lint`.
+- Dependency setup, scanners, Docker commands, Buf commands, and Go module commands may require network access; identify that before relying on them.
+- Push, publish, release, Docker manifest push, Buf push, and PR open/update flows require explicit user permission.
 
 ## `./bin`-Specific Caution
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -10,8 +10,10 @@ description: Reviews code changes for bugs, regressions, risky assumptions, miss
 1. Identify the changed files or requested review scope.
 2. Read `references/findings-format.md` before producing review output.
 3. Inspect behavior, tests, compatibility, security, docs, and maintenance risk before style preferences.
-4. Verify claims against concrete file and line references whenever possible.
-5. Use the exact structure in `references/findings-format.md`; do not add, remove, rename, or reorder sections.
+4. If the review scope includes security-sensitive code, configuration, dependencies, shell execution, filesystem writes/deletes, network/auth/TLS behavior, secrets/env handling, Docker helpers, or CI/security tooling, consult `$security-audit` and the smallest matching security reference; keep this skill's findings format.
+5. Verify claims against concrete file and line references whenever possible.
+6. When code review is the final response, use the exact structure in `references/findings-format.md`; do not add, remove, rename, or reorder sections.
+7. When another skill embeds this review, preserve findings, open questions, testing gaps, and summary facts in the caller's output format.
 
 ## References
 

--- a/skills/code-review/references/findings-format.md
+++ b/skills/code-review/references/findings-format.md
@@ -10,9 +10,18 @@ Use this reference when the user asks for a review.
 - Prefer concrete findings over broad summaries.
 - Ground each finding in the inspected code and describe the consequence, not just the preference.
 
+## Severity
+
+- `critical`: Near-certain production breakage, data loss or corruption, remote code execution, credential exposure, auth bypass, or a change that makes the project unusable for its primary path.
+- `high`: Likely user-visible regression, compatibility break, security issue, CI or release blocker, or broken primary workflow with a clear trigger.
+- `medium`: Real bug, missing validation, edge-case regression, or maintainability risk that can affect users but is scoped, recoverable, or not on the primary path.
+- `low`: Minor correctness issue, hardening gap, confusing behavior, missing docs or tests for a low-risk path, or maintainability concern with limited impact.
+- Do not inflate severity for style preferences, speculative risks, or missing tests without a concrete failure mode.
+- If severity depends on assumptions about downstream use, state the triggering scenario in `Impact` or `Evidence`.
+
 ## Output Format
 
-- Use exactly this Markdown structure and do not add, remove, rename, or reorder sections:
+- When code review is the final response, use exactly this Markdown structure and do not add, remove, rename, or reorder sections:
 
 ```markdown
 ## Findings
@@ -42,6 +51,7 @@ Brief one- or two-sentence summary.
 - Keep the summary brief and secondary to the findings.
 - When useful, state the condition or scenario that triggers the problem so the risk is easy to verify.
 - If a section has no entries, write exactly `- None.`
+- When another skill embeds the review, keep the same finding severity, evidence, impact, recommendation, open-question, and testing-gap facts but use the caller's required output sections.
 
 ## If No Findings
 

--- a/skills/go-standards/references/conventions.md
+++ b/skills/go-standards/references/conventions.md
@@ -19,8 +19,14 @@ Use this reference when working in Go repositories.
 
 - Before adding new test structure, look for existing tests in the package or adjacent packages and reuse their helpers, fixtures, table shapes, assertions, and naming patterns when they fit.
 - When new coverage is needed, base it on the testing style already present in the repository rather than introducing a new pattern.
-- Write Go tests using `github.com/stretchr/testify/require`.
-- Keep Go tests in external test packages named `<package>_test` so they exercise the public interface rather than package internals.
+- Infer the project type from existing tests and CI: Go libraries commonly use unit and integration tests, while services in this ecosystem may rely on Cucumber feature flows around the service.
+- Prefer testing through the repository's established public or documented Go APIs, commands, or service entrypoints so coverage reflects real consumer behavior.
+- Do not introduce a new Go test framework, fixture layout, or test layer unless the task explicitly changes testing infrastructure.
+- Keep tests deterministic and cover relevant failure paths for changed behavior.
+- In this repository ecosystem, prefer `github.com/stretchr/testify/require` when adding assertion-based tests unless the package already uses a different local pattern.
+- Prefer external test packages named `<package>_test` when the behavior can be exercised through the public interface.
+- Use internal package tests only when the repository already tests that way, the behavior cannot be exercised credibly through the established public surface, or the change has no stable public surface.
+- When internal tests are necessary, keep them focused and still run public-path validation when practical.
 - Keep test cases and test functions first in the file. Place fakes, stubs, spies, mock implementations, and helper types after the tests at the bottom of the file.
 
 ## Method Layout

--- a/skills/makefile-includes/SKILL.md
+++ b/skills/makefile-includes/SKILL.md
@@ -11,7 +11,8 @@ description: Works with shared bin/build/make/*.mak includes and downstream Make
 2. Read `references/fragment-map.md` after identifying the included fragments.
 3. Treat the root `Makefile` as the interface and shared fragments as implementation context.
 4. Preserve downstream `./bin` path expectations unless the user explicitly asks to change them.
-5. Validate path-sensitive behavior from the consuming repository root when the target depends on `$(PWD)/bin/...`.
+5. Identify Make targets that clone, fetch, push, publish, open PRs, update remote state, or require SSH/GitHub/registry auth before running them.
+6. Validate path-sensitive behavior from the consuming repository root when the target depends on `$(PWD)/bin/...`.
 
 ## References
 

--- a/skills/makefile-includes/references/fragment-map.md
+++ b/skills/makefile-includes/references/fragment-map.md
@@ -20,6 +20,7 @@ Use this reference after you have already identified which shared `bin/build/mak
 - Especially relevant targets: `dep`, `lint`, `format`, `features`, `benchmarks`, `sec`, `start`, `stop`.
 - `features` and `benchmarks` call wrappers under `$(PWD)/bin/quality/ruby/...`, so they should be run from the consuming repo root.
 - `start` and `stop` delegate to `bin/build/docker/env`, which may require access to a sibling `../docker` checkout and SSH-based cloning if that repo is missing.
+- `dep`, `update-dep`, `update-all-dep`, `sec`, `start`, and `stop` may require network access or external credentials depending on the consuming repo.
 
 ### `go.mak`
 
@@ -28,16 +29,36 @@ Use this reference after you have already identified which shared `bin/build/mak
 - `coverage` depends on coverage files under `test/reports/`.
 - `lint` runs field alignment checks and `golangci-lint`; the wrapper may no-op if `golangci-lint` is not installed.
 - `clean` may assume a `master` branch exists when refreshing dependencies.
+- `dep`, `get`, `get-all`, `update-dep`, `update-all-dep`, `sec`, `start`, and `stop` may require network access or external credentials depending on the consuming repo.
+
+### `buf.mak`
+
+- Especially relevant targets: `lint`, `fix-lint`, `format`, `generate`, `breaking`, `push`, `update-all-dep`.
+- `breaking` compares against `https://github.com/alexfalkowski/$(NAME).git#branch=master`, so branch and remote assumptions matter.
+- `generate` and `push` depend on the consuming repository's Buf configuration.
+- `push` updates remote state and requires explicit user permission.
+
+### `http.mak`, `grpc.mak`, and `client.mak`
+
+- These are project-template fragments that combine Go, Ruby test harness, Docker, security, coverage, and helper targets.
+- `grpc.mak` also includes proto lint, format, generate, breaking, and push targets.
+- `features` and `benchmarks` depend on downstream test/build layout and wrappers under `$(PWD)/bin/quality/ruby/...`.
+- `specs`, coverage, and report cleanup assume downstream `test/reports/` paths.
+- Docker and certificate helper targets depend on external CLIs such as Docker, `mkcert`, `dot`, and `air` depending on the target.
+- Docker push, manifest, release, and registry-publishing targets update remote state and require explicit user permission.
 
 ### `git.mak`
 
 - Common helpers cover branch creation, sync, commit/PR flows, destructive cleanup, and submodule commands.
 - Treat these as convenience wrappers, not default actions.
 - Do not use targets that rewrite history, delete branches, discard changes, or push remotely unless the user explicitly asks.
+- `push`, `force`, `draft`, `pr`, `merge`, `review`, and `ready` update remote GitHub state and require explicit current-request permission.
 
 ## Practical Inference Rules
 
 - If the root `Makefile` includes `ruby.mak`, expect Ruby lint and cucumber-style feature flows.
 - If it includes `go.mak`, expect Go lint, test, coverage, and security flows.
+- If it includes `buf.mak`, expect Buf lint, format, generate, push, and breaking-change flows.
+- If it includes `http.mak`, `grpc.mak`, or `client.mak`, expect combined Go/Ruby validation and downstream test harness assumptions.
 - If the repo exposes both `features` and `specs`, choose the target that best matches the area under change.
 - If the repo overrides a target after including a fragment, trust the root `Makefile` behavior over the fragment default.

--- a/skills/pr-summary/SKILL.md
+++ b/skills/pr-summary/SKILL.md
@@ -13,9 +13,11 @@ description: Drafts commit messages and pull request summaries from repository c
 4. Read `references/format.md` before drafting the output.
 5. When the workflow adds a branch-derived prefix, draft `msg` from the diff or latest commit only; do not use branch words as source material.
 6. Keep the commit message plain text and lowercase when the user asks for one.
-7. Include what changed, why it changed, and honest testing details in the PR summary.
-8. Use the exact structure in `references/format.md`; do not add, remove, rename, or reorder sections.
-9. Do not claim unrun checks passed.
+7. Include what changed, why it changed, documentation/example updates or why none were needed, and honest testing details in the PR summary.
+8. Include unresolved review or security findings from caller workflows in `## Why` or `## Testing`; do not add extra sections.
+9. When the summary is the final response, use the exact structure in `references/format.md`; do not add, remove, rename, or reorder sections.
+10. When another skill embeds this summary, provide the subject and Markdown body content in the caller's output format.
+11. Do not claim unrun checks passed.
 
 ## References
 

--- a/skills/pr-summary/references/format.md
+++ b/skills/pr-summary/references/format.md
@@ -39,6 +39,7 @@ commit message subject
 - When another skill requires a footer, append it after `## Testing`; footers are allowed and are not sections.
 - If a PR summary section has no entries, write exactly `- None.`
 - Keep the testing section honest about what ran, what passed, and what did not run.
+- Include unresolved review findings, security findings, or validation gaps from caller workflows under `## Why` or `## Testing`; do not add a separate risk section.
 
 ## Commit Message Subject
 

--- a/skills/project-workflow/SKILL.md
+++ b/skills/project-workflow/SKILL.md
@@ -11,7 +11,9 @@ description: Discovers project-local workflow, command surfaces, Makefile includ
 2. Identify the project's real command surface before choosing tools. Prefer exposed entrypoints over guessed direct invocations.
 3. If the repository uses this shared project as `./bin`, read `references/bin-submodule.md` before reasoning about path-sensitive behavior.
 4. Inspect only the files, scripts, and make fragments relevant to the user's task.
-5. When reporting workflow discovery, use the exact structure in `references/bin-submodule.md`; do not add, remove, rename, or reorder sections.
+5. Identify commands that require network, SSH, GitHub auth, registry auth, cloning, pushing, publishing, opening PRs, or updating remote state before running or recommending them.
+6. When workflow discovery is the final response, use the exact structure in `references/bin-submodule.md`; do not add, remove, rename, or reorder sections.
+7. When another skill embeds this discovery, preserve the discovered commands, CI expectations, bin wiring, and constraints in the caller's output format.
 
 ## References
 

--- a/skills/project-workflow/references/bin-submodule.md
+++ b/skills/project-workflow/references/bin-submodule.md
@@ -15,12 +15,13 @@ Use this reference when you need to establish context quickly and discover how a
 - Prefer repository entry points such as `make` targets over calling tools directly.
 - Use direct tool invocations only when the repository does not provide a stable entry point or when a narrower check is clearly better for the task.
 - Confirm that a target or script is actually wired into the repo before relying on it.
+- Identify whether a command fetches, clones, pushes, publishes, opens PRs, updates remote state, or requires SSH/GitHub/registry credentials before running it.
 - When `help.mak` is included, use `make` or `make help` as the quickest way to discover the command surface.
 - When planning work, note whether the repository exposes setup targets such as `dep` so you can use them later when the task moves from discovery to edits or validation.
 
 ## Output Format
 
-Use exactly this Markdown structure when reporting workflow discovery, and do not add, remove, rename, or reorder sections:
+When workflow discovery is the final response, use exactly this Markdown structure and do not add, remove, rename, or reorder sections:
 
 ```markdown
 ## Command Surface
@@ -44,7 +45,8 @@ Use exactly this Markdown structure when reporting workflow discovery, and do no
 - Use `Command Surface` for local commands, Make targets, scripts, or package-manager entrypoints.
 - Use `CI Expectations` for checks required by CI configuration.
 - Use `Bin Wiring` for included `bin/build/make/*.mak` fragments or `$(PWD)/bin/...` path behavior.
-- Use `Constraints` for missing tools, downstream-only paths, CI-only behavior, SSH/network requirements, or other workflow limits.
+- Use `Constraints` for missing tools, downstream-only paths, CI-only behavior, SSH/network/auth requirements, remote-write targets, or other workflow limits.
+- When another skill embeds workflow discovery, keep the same command, CI, bin-wiring, and constraint facts but use the caller's required output sections.
 
 ## When The Repo Uses `./bin`
 

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -8,29 +8,33 @@ description: Commits the current change, force-pushes the branch, and opens a dr
 ## Steps
 
 1. Inspect the changed paths from the working tree first; if the working tree is clean, inspect the latest commit.
-2. Use `$change-validation` to select and run credible validation for the full change before `make review`; language-specific standards may refine that validation.
-3. If the changed paths include Go code, Go tests, Go modules, Go docs, or Go tooling behavior, also use `$go-standards`.
-4. If the changed paths include Ruby code, Ruby tests/features, Gemfiles, RuboCop config, Ruby docs, or Ruby tooling behavior, also use `$ruby-standards`.
-5. If the changed paths include shell scripts, Bash helpers, ShellCheck config/directives, shell docs, or script behavior, also use `$shell-standards`.
-6. Use `$code-review` to inspect the current change before drafting PR text.
-7. Resolve any blocking review findings before continuing; if findings remain intentionally unresolved, call them out in the PR summary.
-8. Use `$pr-summary` to draft a lowercase, unprefixed `msg` and Markdown PR summary from the current working tree.
-9. Follow `$pr-summary` commit-subject rules: `make review` adds the branch-derived `type(scope):` prefix, so treat branch words as routing metadata rather than message source material.
-10. Keep the summary in the `$pr-summary` format, including honest testing details.
-11. When attribution is appropriate or requested, append this footer to the summary instead of a `Co-authored-by:` trailer:
+2. Confirm the user explicitly asked in the current request to commit, push, update, or open a review PR. If not, do not run `make review`, `make push`, or any equivalent push/PR update command.
+3. If new changes would make an existing PR description, review comment, or previously drafted summary obsolete, flag that and ask whether the user wants the PR updated before pushing anything.
+4. Make the remote-write behavior of `make review` explicit before running it: the target commits, force-pushes, and opens a draft PR.
+5. Use `$change-validation` to select and run credible validation for the full change before `make review`; language-specific standards may refine that validation.
+6. If the changed paths include Go code, Go tests, Go modules, Go docs, or Go tooling behavior, also use `$go-standards`.
+7. If the changed paths include Ruby code, Ruby tests/features, Gemfiles, RuboCop config, Ruby docs, or Ruby tooling behavior, also use `$ruby-standards`.
+8. If the changed paths include shell scripts, Bash helpers, ShellCheck config/directives, shell docs, or script behavior, also use `$shell-standards`.
+9. Use `$code-review` to inspect the current change before drafting PR text.
+10. Resolve any blocking review findings before continuing; if findings remain intentionally unresolved, call them out in the PR summary.
+11. If `$code-review` reports security findings or security validation gaps, resolve them or document them in the PR summary before `make review`.
+12. Use `$pr-summary` to draft a lowercase, unprefixed `msg` and Markdown PR summary from the current working tree.
+13. Follow `$pr-summary` commit-subject rules: `make review` adds the branch-derived `type(scope):` prefix, so treat branch words as routing metadata rather than message source material.
+14. Keep the summary in the `$pr-summary` format, including honest testing details.
+15. When attribution is appropriate or requested, append this footer to the summary instead of a `Co-authored-by:` trailer:
 
 ```text
 AI-assisted-by: [Codex](https://openai.com/codex/)
 ```
 
-12. Run the review target with the drafted values:
+16. Run the review target with the drafted values:
 
 ```bash
 make msg="unprefixed subject" desc="summary" review
 ```
 
-13. Pass `desc` as the multiline Markdown summary from `$pr-summary`; do not flatten the summary into a single line.
-14. Report the result using the exact structure in `Output Format`; do not add, remove, rename, or reorder sections.
+17. Pass `desc` as the multiline Markdown summary from `$pr-summary`; do not flatten the summary into a single line.
+18. Report the result using the exact structure in `Output Format`; do not add, remove, rename, or reorder sections.
 
 ## Output Format
 
@@ -78,5 +82,6 @@ unprefixed subject
 ## Notes
 
 - The `review` target commits, force-pushes the current branch, and opens a draft PR.
+- Future changes do not imply permission to push again. Ask the user before updating an existing PR or replacing an existing PR description/comment.
 - Do not claim a PR exists unless the review target output confirms it.
 - Do not claim unrun checks passed.

--- a/skills/review-pr/agents/openai.yaml
+++ b/skills/review-pr/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Review PR"
-  short_description: "Review, validate, commit, push, and draft a PR"
-  default_prompt: "Use $review-pr to commit this change and open a draft PR for review."
+  short_description: "Prepare an approved review PR flow"
+  default_prompt: "Use $review-pr when I explicitly ask to commit, push, and open or update a review PR."

--- a/skills/ruby-standards/SKILL.md
+++ b/skills/ruby-standards/SKILL.md
@@ -11,7 +11,8 @@ description: Applies this repository ecosystem's Ruby coding, API, documentation
 2. Read `references/conventions.md` before editing documented modules, classes, methods, commands, or task interfaces.
 3. Preserve the repository's existing Ruby style, naming, error handling, and test idioms.
 4. Avoid clever metaprogramming or monkey patches unless the repository already relies on them or the task requires them.
-5. Pair this skill with `change-validation` when selecting Ruby lint, feature, benchmark, or security commands.
+5. Pair this skill with `change-safety` when Ruby changes affect documented commands, public methods, task interfaces, or migration expectations.
+6. Pair this skill with `change-validation` when selecting Ruby lint, feature, benchmark, or security commands.
 
 ## References
 

--- a/skills/ruby-standards/references/conventions.md
+++ b/skills/ruby-standards/references/conventions.md
@@ -14,6 +14,16 @@ Use this reference when working in Ruby repositories.
 - When a user-facing or documented API is non-trivial, include examples if the repository's documentation style supports them.
 - Keep examples aligned with the real public interface and expected calling style.
 
+## Testing
+
+- Reuse the repository's existing test, feature, fixture, helper, assertion, and naming patterns before adding new structure.
+- Infer the project type from existing tests and CI: Ruby libraries commonly use unit and integration tests such as RSpec, while services in this ecosystem commonly use Cucumber feature flows.
+- Prefer testing through the repository's established public or documented Ruby APIs, commands, tasks, or feature flows so coverage reflects real consumer behavior.
+- Do not introduce a new Ruby test framework, fixture layout, or test layer unless the task explicitly changes testing infrastructure.
+- Keep tests deterministic and cover relevant failure paths for changed behavior.
+- Use internal seams only when the repository already tests that way, the behavior cannot be exercised credibly through the established public surface, or the change has no stable public surface.
+- When internal tests are necessary, keep them focused and still run public-path validation when practical.
+
 ## External Style References
 
 - When this repository does not state a more specific convention, use the RuboCop Ruby Style Guide and the Shopify Ruby Style Guide as advisory references.

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -14,8 +14,11 @@ description: Reviews code, scripts, Makefile glue, Docker helpers, dependencies,
    - `references/shell.md` for Bash scripts, Make targets that invoke shell commands, Docker helper scripts, ShellCheck, quoting, temp files, or destructive commands.
    - `references/shared.md` for cross-language repositories, dependency/config audits, secrets, Docker/security scanners, and report structure.
 3. Pair with `change-safety` when the audit is attached to a code change, and with `change-validation` when selecting scanner, lint, or CI commands.
-4. Inspect concrete data/control flow before reporting a risk. Prefer file and line references over general advice.
-5. Report exploitable findings first. Use the exact structure in `references/shared.md`; do not add, remove, rename, or reorder sections.
+4. Ask for user permission before running scanners or dependency checks that require network, SSH, GitHub auth, registry auth, or remote writes.
+5. Inspect concrete data/control flow before reporting a risk. Prefer file and line references over general advice.
+6. Report exploitable findings first.
+7. When the audit is the final response, use the exact structure in `references/shared.md`; do not add, remove, rename, or reorder sections.
+8. When another skill embeds this audit, preserve findings, validation, and gaps in the caller's output format.
 
 ## References
 

--- a/skills/security-audit/references/shared.md
+++ b/skills/security-audit/references/shared.md
@@ -19,6 +19,7 @@ Use this reference for any security audit, then load language-specific reference
 ## Validation
 
 - Prefer repository-defined targets before ad hoc scanners.
+- Ask for permission before running scanners or dependency checks that need network, SSH, GitHub auth, registry auth, or remote writes.
 - In this repository, relevant checks include:
   - `make sec-lint` for Trivy repository scanning.
   - `make scripts-lint` for ShellCheck coverage of shared scripts.
@@ -27,6 +28,7 @@ Use this reference for any security audit, then load language-specific reference
 - In downstream Go repositories that include `build/make/go.mak`, `make sec` runs `govulncheck` and Trivy repo scanning.
 - In downstream Ruby repositories that include `build/make/ruby.mak`, `make sec` runs Trivy repo scanning.
 - Report wrappers as partial or no-op when tools such as `trivy`, `govulncheck`, `shellcheck`, `hadolint`, or `golangci-lint` are missing.
+- Report network or credential failures as validation gaps unless the audited code caused the failure.
 
 ## Freshness
 
@@ -59,7 +61,7 @@ Use this reference for any security audit, then load language-specific reference
 
 ## Reporting
 
-- Use exactly this Markdown structure and do not add, remove, rename, or reorder sections:
+- When security-audit is the final response, use exactly this Markdown structure and do not add, remove, rename, or reorder sections:
 
 ```markdown
 ## Findings
@@ -92,3 +94,4 @@ Use this reference for any security audit, then load language-specific reference
 - Each finding should state: risk, trigger condition, impact, and remediation.
 - Do not report generic checklist items as findings unless they apply to the audited code.
 - If no findings are found, say that clearly and list meaningful gaps, such as scanners not installed or dynamic behavior not exercised.
+- When another skill embeds the audit, keep the same factual content and severity meaning but use the caller's required output sections.

--- a/skills/shell-standards/SKILL.md
+++ b/skills/shell-standards/SKILL.md
@@ -11,7 +11,8 @@ description: Applies this repository ecosystem's Bash scripting, ShellCheck, tex
 2. Read `references/conventions.md` before editing script structure, ShellCheck directives, text processing, directory handling, or functions.
 3. Preserve the repository's existing shell style, argument handling, and command wrappers.
 4. Use Bash for scripts with `#!/usr/bin/env bash` and catch failures early with `set -eo pipefail`.
-5. Pair this skill with `change-validation` when selecting ShellCheck or script lint commands.
+5. Pair this skill with `$security-audit` for `eval`, shell-command construction, broad file deletion/writes, downloads, temp files, env/secrets, or other trust-boundary changes.
+6. Pair this skill with `change-validation` when selecting ShellCheck or script lint commands.
 
 ## References
 

--- a/skills/shell-standards/references/conventions.md
+++ b/skills/shell-standards/references/conventions.md
@@ -23,12 +23,21 @@ Use this reference when working with shell scripts.
 - When a command needs to run from another directory, use a subshell such as `(cd path && command)`.
 - Avoid changing the caller's working directory as a side effect.
 
+## Testing
+
+- Prefer validating shell changes through public or documented commands, scripts, Make targets, and argument flows.
+- Reuse the repository's existing script tests, feature flows, lint targets, and validation entrypoints before adding ad hoc checks.
+- Cover relevant failure paths such as invalid arguments, missing files/tools, non-zero commands, path errors, permissions, and argument pass-through.
+- Keep checks deterministic and avoid relying on the caller's real home directory, global config, network, wall-clock time, or shared mutable state.
+- Use internal helper seams only when the repository already tests that way, the behavior cannot be exercised credibly through the established command path, or the change has no stable public surface.
+- When internal checks are necessary, keep them focused and still run public-path validation when practical.
+
 ## Functions
 
 - In included or sourced shell library files, typically files ending in `.sh`, add comments for public functions.
 - In included or sourced shell library files, functions starting with `_` are private and do not require comments.
 - In standalone executable scripts, functions do not need a leading `_` just to avoid public API treatment.
-- Add comments for non-underscore functions in both standalone executable scripts and included shell library files.
+- In standalone executable scripts, add comments for helper functions only when their purpose, inputs, outputs, or side effects are not obvious from the local code.
 - Keep function names and call patterns aligned with the surrounding script.
 
 ## ShellCheck


### PR DESCRIPTION
## What

- Added shared skill composition, testing, network, documentation, and metadata guidance.
- Updated review, validation, safety, security, Makefile, language-standard, and PR workflows to preserve caller formats, require explicit PR/remote-write permission, and follow existing test standards.
- Updated AGENTS.md to remove volatile Ruby version details and document current skill-maintenance expectations.

## Why

- Keeps agent behavior consistent across nested skills and prevents accidental PR updates, remote writes, stale metadata, or tests/docs that do not match repository conventions.
- Documentation and examples were updated in AGENTS.md and skill references because the changed behavior is agent-facing documentation.

## Testing

- `make dep` - passed
- `make clean-dep` - passed
- `make lint` - passed
- `make scripts-lint` - passed
- `make docker-lint` - passed
- `make sec-lint` - passed
- `git diff --check` - passed
