### PR TITLE
feat(skills): require comments in executable shell scripts

### DIFF
--- a/skills/shell-standards/agents/openai.yaml
+++ b/skills/shell-standards/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Shell Standards"
-  short_description: "Apply Bash and ShellCheck conventions"
+  short_description: "Apply Bash, ShellCheck, and script documentation conventions"
   default_prompt: "Use $shell-standards when changing shell scripts in this repository."

--- a/skills/shell-standards/references/conventions.md
+++ b/skills/shell-standards/references/conventions.md
@@ -6,6 +6,7 @@ Use this reference when working with shell scripts.
 
 - Use Bash for scripts with `#!/usr/bin/env bash`.
 - Catch failures early with `set -eo pipefail`.
+- In standalone executable scripts, include a descriptive and accurate comment near the top that explains the script's purpose.
 - Preserve existing argument handling, command wrappers, and pass-through semantics.
 
 ## External Style References
@@ -37,7 +38,7 @@ Use this reference when working with shell scripts.
 - In included or sourced shell library files, typically files ending in `.sh`, add comments for public functions.
 - In included or sourced shell library files, functions starting with `_` are private and do not require comments.
 - In standalone executable scripts, functions do not need a leading `_` just to avoid public API treatment.
-- In standalone executable scripts, add comments for helper functions only when their purpose, inputs, outputs, or side effects are not obvious from the local code.
+- In standalone executable scripts, add descriptive and accurate comments for helper functions.
 - Keep function names and call patterns aligned with the surrounding script.
 
 ## ShellCheck


### PR DESCRIPTION
## What

- Require standalone executable shell scripts to include a descriptive and accurate purpose comment near the top.
- Require helper functions in standalone executable scripts to have descriptive and accurate comments.
- Update the OpenAI-facing shell-standards metadata to mention script documentation conventions.

## Why

- Make executable script documentation expectations explicit so future changes do not treat comments as optional in standalone scripts.

## Testing

- `ruby -e 'require "yaml"; YAML.load_file("skills/shell-standards/agents/openai.yaml"); puts "yaml ok"'` - passed
- `git diff --check` - passed
- `make lint` - failed: local BSD make cannot parse the GNU make `$(shell ...)` expression in `build/make/git.mak`
- `gmake lint` - failed: Bundler 4.0.10 required by `Gemfile.lock` is not installed locally
