### PR TITLE
feat(skills): avoid duplicate commit subject wording

### DIFF
--- a/skills/pr-summary/references/format.md
+++ b/skills/pr-summary/references/format.md
@@ -46,9 +46,11 @@ commit message subject
 - Check whether the local commit workflow adds a conventional-commit prefix from the current branch.
 - In repositories using this shared `bin` workflow, `build/make/git.mak` derives `type(scope):` from branches shaped like `user/type/scope` and prepends it in `make commit`, `make review`, and related targets.
 - When the workflow prepends a branch-derived prefix, output only the unprefixed subject intended for `msg`; do not include a conventional prefix such as `feat(scope):`.
-- Treat the current branch as routing metadata, not summary source material, and avoid branch-derived words unless omitting them would make the subject misleading.
-- Before returning the subject, compare it with the branch type, scope/name segments, and hyphen- or slash-separated words inside those segments; rewrite it if a branch word can be replaced by a more concrete behavior from the diff.
+- Treat the current branch as routing metadata, not summary source material.
+- Do not repeat the branch-derived conventional-commit type or scope in `msg`; the final commit subject will already include them in `type(scope):`.
+- Before returning the subject, compare it with the branch type, scope/name segments, and hyphen- or slash-separated words inside those segments; rewrite it if a branch word appears in `msg`.
 - Prefer the concrete behavioral change over branch wording. For example, on `user/feat/skills`, use `avoid duplicate commit subject wording`, not `feat(skills): update skills pr summary`.
+- If the scope word is the obvious domain noun, still avoid restating it when a more specific object is available from the diff. For example, on `user/docs/location`, use `clarify metadata diagnostics`, not `clarify location metadata diagnostics`.
 
 ## Validation Notes
 

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -19,7 +19,7 @@ description: Commits the current change, force-pushes the branch, and opens a dr
 10. Resolve any blocking review findings before continuing; if findings remain intentionally unresolved, call them out in the PR summary.
 11. If `$code-review` reports security findings or security validation gaps, resolve them or document them in the PR summary before `make review`.
 12. Use `$pr-summary` to draft a lowercase, unprefixed `msg` and Markdown PR summary from the current working tree.
-13. Follow `$pr-summary` commit-subject rules: `make review` adds the branch-derived `type(scope):` prefix, so treat branch words as routing metadata rather than message source material.
+13. Follow `$pr-summary` commit-subject rules: `make review` adds the branch-derived `type(scope):` prefix, so treat branch words as routing metadata rather than message source material and do not repeat the type or scope in `msg`.
 14. Keep the summary in the `$pr-summary` format, including honest testing details.
 15. When attribution is appropriate or requested, append this footer to the summary instead of a `Co-authored-by:` trailer:
 


### PR DESCRIPTION
## What

- Tightened commit subject guidance so branch-derived conventional commit types and scopes are not repeated in the unprefixed message.
- Mirrored the no-duplicate type or scope reminder in the review PR flow.

## Why

- Prevents generated subjects such as `docs(location): clarify location metadata diagnostics`, where the scope appears both in the prefix and in the message body.

## Testing

- `make lint` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
