### PR TITLE
feat(skills): avoid unrelated submodule exploration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,19 @@ skill instead of one broad default:
 
 Treat this `AGENTS.md` as the repo-specific companion to those skills.
 
+When this repository is read from a downstream repo as `./bin`, treat `bin/`
+as vendored shared tooling:
+
+- Read `bin/AGENTS.md` and the relevant `bin/skills/**` files when shared
+  guidance is needed.
+- Do not search, read, edit, or review other files under `bin/**` unless the
+  task is explicitly about shared `bin` tooling, Makefile includes, skills, or
+  submodule wiring.
+- Prefer searches from the consuming repo that exclude unrelated submodule
+  contents, for example `rg --glob '!bin/**' ...`.
+- If a Make target invokes `$(PWD)/bin/...`, reason about that path from the
+  consuming repository root without exploring unrelated files inside `bin/`.
+
 When changing a skill's trigger, scope, workflow, or user-facing behavior,
 check the matching `skills/<name>/agents/openai.yaml` and update it if the
 display name, short description, or default prompt became stale.


### PR DESCRIPTION
## What

- Added central guidance in `AGENTS.md` for downstream repos that read this repository as `./bin`.
- Clarified that agents may read `bin/AGENTS.md` and relevant `bin/skills/**`, but should avoid unrelated `bin/**` exploration unless the task is about shared tooling or submodule wiring.

## Why

- Existing downstream repos already point to `bin/AGENTS.md`, so this keeps the exclusion behavior centralized without requiring every consuming repo to change its local instructions.

## Testing

- `git diff --check` - passed
- `make lint` - failed before validation because the local BSD make cannot parse the GNU Make functions in `build/make/git.mak`
- `gmake lint` - failed before validation because Bundler 4.0.10 is not installed in this environment

AI-assisted-by: [Codex](https://openai.com/codex/)
