### PR TITLE
feat(skills): add measurement guardrails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
       - run: make scripts-lint
       - run: make docker-lint
       - run: make lint
+      - run: make skills-lint
       - run: make sec-lint
     resource_class: arm.large
   sync:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,10 +73,12 @@ From this repository root:
 - Script / Dockerfile linting:
   - `make scripts-lint` (runs `shellcheck` over various scripts)
   - `make docker-lint` (runs `hadolint` on `build/docker/go/Dockerfile`)
+- Skill linting:
+  - `make skills-lint` (checks skill metadata, references, and eval cases)
 - Security scanning:
   - `make sec-lint` (runs Trivy over the repository)
 
-CI runs (CircleCI): `make dep`, `make clean-dep`, `make scripts-lint`, `make docker-lint`, `make lint`, `make sec-lint` (see `.circleci/config.yml`).
+CI runs (CircleCI): `make dep`, `make clean-dep`, `make scripts-lint`, `make docker-lint`, `make lint`, `make skills-lint`, `make sec-lint` (see `.circleci/config.yml`).
 
 ## Tooling dependencies (observed)
 
@@ -188,6 +190,7 @@ Only rely on a command if you can find it being invoked in the relevant `.mak`/s
   - `make scripts-lint`
   - `make docker-lint`
   - `make lint`
+  - `make skills-lint`
   - `make sec-lint`
 
 ## When changing this repo
@@ -196,6 +199,7 @@ Only rely on a command if you can find it being invoked in the relevant `.mak`/s
 - After edits, re-run at least:
   - `make dep`
   - `make lint`
+  - `make skills-lint`
   - `make sec-lint`
   - `make scripts-lint` (if `shellcheck` is available)
   - `make docker-lint` (if `hadolint` is available)

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ scripts-lint:
 docker-lint:
 	@hadolint build/docker/go/Dockerfile
 
+# Lint skill metadata, references, and eval cases.
+skills-lint:
+	@skills/check
+
 # Scan for security issues.
 sec-lint:
 	@build/sec/trivy-repo

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repo contains:
 
 - reusable `build/make/*.mak` fragments (Go/Ruby/proto helpers)
 - small Bash/Ruby scripts under `build/` and `quality/`
+- shared agent skills, eval cases, and skill metadata checks under `skills/`
 - a Dockerfile template for building Go services (`build/docker/go/Dockerfile`)
 
 ## Rationale
@@ -24,6 +25,7 @@ After repeating the same build/lint/test/CI glue across projects, it’s useful 
 | `build/docker/` | Docker helpers and `build/docker/go/Dockerfile`.                                   |
 | `build/sec/`    | Security scanning helpers (Trivy).                                                 |
 | `quality/`      | Quality/test helpers (Go coverage processing, cucumber wrappers).                  |
+| `skills/`       | Shared agent skills, eval cases, references, and metadata checks.                  |
 
 ## Using this repo (recommended: Git submodule)
 
@@ -139,6 +141,7 @@ make clean-dep
 make scripts-lint
 make docker-lint
 make lint
+make skills-lint
 make sec-lint
 ```
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -81,3 +81,36 @@ the established surface, or the change has no stable public surface.
   description, or default prompt if they became stale.
 - Keep `agents/openai.yaml` concise; it should describe when to use the skill,
   not repeat the full `SKILL.md` workflow.
+
+## Skill Eval Definitions
+
+- Add or update `skills/evals/cases.yaml` when changing routing descriptions,
+  workflow scope, composition rules, or user-facing behavior.
+- CI validates eval case shape with `make skills-lint`; it does not execute
+  prompts or prove Codex selected the expected skills.
+- Prefer cases from real tasks, PRs, incidents, review corrections, and repeated
+  agent failures over synthetic examples.
+- Track expected skills, forbidden adjacent skills, concrete success criteria,
+  and validation-honesty expectations.
+- Use eval failures to tighten descriptions first, then split, merge, update, or
+  retire skills when routing or outcomes remain poor.
+
+## Skill Lifecycle
+
+- Treat skills as maintained artifacts: review them when project workflow,
+  tooling, model behavior, or team conventions change.
+- Skills generated or drafted by a model need human review before adoption.
+- Periodically compare representative tasks with and without a skill; retire a
+  skill when it no longer improves outcomes or consistently overrides better
+  native behavior.
+- Run `make skills-lint` after skill metadata, reference, or eval changes.
+
+## Skill Security
+
+- Treat external skills like third-party dependencies and review the full folder
+  before use.
+- Check descriptions for prompt injection or overbroad routing, and check bundled
+  scripts/assets for data exfiltration, broad filesystem access, remote code
+  execution, and unnecessary permissions.
+- Use `security-audit` with `references/skills.md` for skill-specific security
+  review.

--- a/skills/change-safety/SKILL.md
+++ b/skills/change-safety/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: change-safety
-description: Protects documented interfaces, compatibility, security, generated files, dependencies, and migration paths during code or configuration changes. Use before edits that may affect APIs, commands, flags, environment variables, file formats, Make targets, docs, auth, shell execution, or user-facing behavior.
+description: Protects compatibility, documented interfaces, migrations, generated files, dependencies, and user-facing behavior during changes. Use before edits to APIs, commands, flags, environment variables, file formats, Make targets, docs, auth, or shell execution; use code-review for general bug finding.
 ---
 
 # Change Safety

--- a/skills/change-safety/agents/openai.yaml
+++ b/skills/change-safety/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Change Safety"
-  short_description: "Protect interfaces and compatibility"
-  default_prompt: "Use $change-safety before making compatibility-sensitive changes."
+  short_description: "Protect interfaces and migrations"
+  default_prompt: "Use $change-safety before compatibility-sensitive or user-facing changes."

--- a/skills/change-validation/references/check-selection.md
+++ b/skills/change-validation/references/check-selection.md
@@ -57,7 +57,7 @@ For standalone validation reports, use exactly this Markdown structure and do no
 - If the repository exposes named test entry points, use the one that matches the affected behavior instead of inventing a different test vocabulary.
 - If the repository exposes benchmark or coverage targets that are relevant to the change, prefer those entry points over ad hoc commands.
 - If a repo exposes `dep`, `lint`, `specs`, `features`, `benchmarks`, `coverage`, or `sec`, prefer those names over ad hoc tool invocations.
-- For this shared `bin` repo itself, CI currently runs `make dep`, `make clean-dep`, `make scripts-lint`, `make docker-lint`, `make lint`, and `make sec-lint`.
+- For this shared `bin` repo itself, CI currently runs `make dep`, `make clean-dep`, `make scripts-lint`, `make docker-lint`, `make lint`, `make skills-lint`, and `make sec-lint`.
 - Dependency setup, scanners, Docker commands, Buf commands, and Go module commands may require network access; identify that before relying on them.
 - Push, publish, release, Docker manifest push, Buf push, and PR open/update flows require explicit user permission.
 

--- a/skills/check
+++ b/skills/check
@@ -1,0 +1,158 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'yaml'
+
+# Keep this checker dependency-light because it runs as a repository lint check.
+SKILLS_DIR = Pathname.new(__dir__).expand_path
+MAX_DESCRIPTION_WORDS = 45
+REQUIRED_AGENT_FIELDS = %w[display_name short_description default_prompt].freeze
+
+def load_yaml(path, errors)
+  YAML.safe_load(path.read, permitted_classes: [], aliases: false)
+rescue Psych::SyntaxError => e
+  errors << "#{path}: invalid YAML: #{e.message}"
+  nil
+end
+
+def frontmatter(path, errors)
+  content = path.read
+  match = content.match(/\A---\n(?<yaml>.*?)\n---\n/m)
+
+  unless match
+    errors << "#{path}: missing YAML frontmatter"
+    return [{}, content]
+  end
+
+  [YAML.safe_load(match[:yaml], permitted_classes: [], aliases: false) || {}, content]
+rescue Psych::SyntaxError => e
+  errors << "#{path}: invalid YAML frontmatter: #{e.message}"
+  [{}, content]
+end
+
+def validate_skill(skill_dir, skill_names, errors)
+  skill_path = skill_dir.join('SKILL.md')
+  metadata, content = frontmatter(skill_path, errors)
+  name = metadata['name']
+
+  validate_skill_name(skill_path, skill_dir, name, errors)
+  validate_description(skill_path, metadata['description'].to_s, errors)
+  validate_agent_metadata(skill_dir, errors)
+  validate_references(skill_dir, content, errors)
+  skill_names << name if name
+end
+
+def validate_skill_name(skill_path, skill_dir, name, errors)
+  return if name == skill_dir.basename.to_s
+
+  errors << "#{skill_path}: name must match directory #{skill_dir.basename}"
+end
+
+def validate_description(skill_path, description, errors)
+  errors << "#{skill_path}: missing description" if description.empty?
+
+  word_count = description.split.size
+  return unless word_count > MAX_DESCRIPTION_WORDS
+
+  errors << "#{skill_path}: description has #{word_count} words; keep it at or below #{MAX_DESCRIPTION_WORDS}"
+end
+
+def validate_agent_metadata(skill_dir, errors)
+  path = skill_dir.join('agents/openai.yaml')
+
+  unless path.file?
+    errors << "#{skill_dir}: missing agents/openai.yaml"
+    return
+  end
+
+  metadata = load_yaml(path, errors) || {}
+  interface = metadata['interface'] || {}
+  missing = REQUIRED_AGENT_FIELDS.select { |field| interface[field].to_s == '' }
+
+  return if missing.empty?
+
+  errors << "#{path}: missing interface fields: #{missing.join(', ')}"
+end
+
+def validate_references(skill_dir, content, errors)
+  # References are intentionally limited to direct links from SKILL.md.
+  references = content.scan(%r{`(references/[^`]+)`}).flatten
+  references += content.scan(%r{\]\((references/[^)]+)\)}).flatten
+
+  references.uniq.each do |reference|
+    path = skill_dir.join(reference)
+    errors << "#{skill_dir.join('SKILL.md')}: missing #{reference}" unless path.file?
+  end
+end
+
+def validate_evals(skill_names, errors)
+  # CI validates eval definitions; Codex routing still needs a manual or external run.
+  path = SKILLS_DIR.join('evals/cases.yaml')
+
+  unless path.file?
+    errors << "#{path}: missing skill eval cases"
+    return
+  end
+
+  cases = load_yaml(path, errors)
+  return validate_eval_case_list(path, cases, errors) unless cases.is_a?(Array) && !cases.empty?
+
+  cases.each_with_index do |test_case, index|
+    validate_eval_case(path, index, test_case, skill_names, errors)
+  end
+end
+
+def validate_eval_case_list(path, cases, errors)
+  errors << "#{path}: expected a non-empty list of eval cases" unless cases.is_a?(Array) && !cases.empty?
+end
+
+def validate_eval_case(path, index, test_case, skill_names, errors)
+  prefix = "#{path}: case #{index + 1}"
+  unless test_case.is_a?(Hash)
+    errors << "#{prefix}: expected a mapping"
+    return
+  end
+
+  validate_eval_required_fields(prefix, test_case, errors)
+  validate_eval_skills(prefix, test_case, skill_names, errors)
+  validate_eval_criteria(prefix, test_case, errors)
+end
+
+def validate_eval_required_fields(prefix, test_case, errors)
+  %w[id prompt expected_skills success_criteria].each do |field|
+    errors << "#{prefix}: missing #{field}" if test_case[field].nil? || test_case[field] == ''
+  end
+end
+
+def validate_eval_skills(prefix, test_case, skill_names, errors)
+  expected = Array(test_case['expected_skills'])
+  forbidden = Array(test_case['forbidden_skills'])
+  unknown = (expected + forbidden).uniq - skill_names
+
+  errors << "#{prefix}: unknown skills: #{unknown.join(', ')}" unless unknown.empty?
+end
+
+def validate_eval_criteria(prefix, test_case, errors)
+  criteria = test_case['success_criteria']
+  return if criteria.is_a?(Array) && criteria.any?
+
+  errors << "#{prefix}: success_criteria must be a non-empty list"
+end
+
+errors = []
+skill_names = []
+
+SKILLS_DIR.children
+          .select { |path| path.directory? && path.join('SKILL.md').file? }
+          .sort
+          .each { |skill_dir| validate_skill(skill_dir, skill_names, errors) }
+
+validate_evals(skill_names, errors)
+
+if errors.empty?
+  puts 'skills metadata OK'
+  exit 0
+end
+
+warn errors.join("\n")
+exit 1

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: Reviews code changes for bugs, regressions, risky assumptions, missing tests, compatibility breaks, unsafe defaults, and missing documentation. Use when the user asks for review, code review, audit, inspect a diff, check a PR, or find issues before merging.
+description: Reviews changed code for bugs, regressions, risky assumptions, missing tests, compatibility breaks, and missing documentation. Use when the user asks for a general code review, diff review, PR check, or pre-merge issue pass; delegate explicit security scope to security-audit.
 ---
 
 # Code Review

--- a/skills/code-review/agents/openai.yaml
+++ b/skills/code-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Code Review"
-  short_description: "Review diffs for bugs and risk"
-  default_prompt: "Use $code-review to review this change for bugs and regressions."
+  short_description: "Review diffs for bugs and regressions"
+  default_prompt: "Use $code-review for a general bug, regression, and missing-coverage review."

--- a/skills/evals/README.md
+++ b/skills/evals/README.md
@@ -1,0 +1,31 @@
+# Skill Evals
+
+Skill evals are lightweight cases for recording whether this repository's
+skills activate for the right work and improve the resulting output.
+
+CI only validates the shape of these eval definitions through `make
+skills-lint`. Runtime routing still needs a manual Codex run or an external
+agent harness that can report which skills activated.
+
+## Metrics
+
+- Activation precision: expected skills activate and forbidden skills do not.
+- Activation recall: companion skills needed for the task are not missed.
+- Outcome quality: the response or change satisfies the case's success criteria.
+- Validation honesty: commands, skipped checks, no-op wrappers, and gaps are reported accurately.
+- Lifecycle signal: repeated failures identify skills to update, split, merge, or retire.
+
+## How To Use
+
+1. Run or simulate each prompt in `cases.yaml`.
+2. Record the skills that activated, the output, validation claims, and any missed criteria.
+3. Compare the result against the expected and forbidden skill lists.
+4. For failing cases, update routing descriptions, skill instructions, references, or the case itself if the workflow changed.
+5. Periodically run representative tasks with and without the skill. Retire skills that no longer improve outcomes.
+
+## Adding Cases
+
+- Base cases on real tasks, PRs, incidents, review corrections, or repeated agent failures.
+- Keep each case focused on one workflow or a small intentional composition.
+- Include adjacent skills in `forbidden_skills` when routing confusion is likely.
+- Prefer concrete success criteria over broad quality labels.

--- a/skills/evals/cases.yaml
+++ b/skills/evals/cases.yaml
@@ -1,0 +1,122 @@
+---
+- id: discover_downstream_bin_workflow
+  prompt: "I am in a consuming repo that includes bin/build/make/go.mak. What commands should I trust before making changes?"
+  expected_skills:
+    - project-workflow
+    - makefile-includes
+  forbidden_skills:
+    - review-pr
+  success_criteria:
+    - identifies project-local entrypoints before direct tool invocations
+    - explains ./bin path semantics from the consuming repository root
+    - flags network or remote-write targets before recommending them
+
+- id: review_shell_security_change
+  prompt: "Review this diff that changes a bash script using user-provided paths and rm."
+  expected_skills:
+    - code-review
+    - security-audit
+    - shell-standards
+  forbidden_skills:
+    - go-standards
+  success_criteria:
+    - reports exploitable shell or filesystem risks before style preferences
+    - cites concrete files and lines when available
+    - reports missing ShellCheck or behavior validation honestly
+
+- id: audit_imported_skill
+  prompt: "Can you security review this new third-party skill before we install it?"
+  expected_skills:
+    - security-audit
+  forbidden_skills:
+    - review-pr
+  success_criteria:
+    - inspects descriptions, scripts, assets, references, and permissions
+    - treats the skill as executable third-party code
+    - reports prompt-injection and data-exfiltration risks when present
+
+- id: change_public_make_target
+  prompt: "Update a shared build/make target that downstream repos include through ./bin."
+  expected_skills:
+    - makefile-includes
+    - change-safety
+    - change-validation
+  forbidden_skills:
+    - pr-summary
+  success_criteria:
+    - preserves downstream ./bin path expectations unless explicitly changed
+    - considers documented target compatibility and migration impact
+    - chooses validation from the repository's exposed Make targets
+
+- id: edit_go_api
+  prompt: "Change an exported Go API in a repo that uses this shared bin tooling."
+  expected_skills:
+    - go-standards
+    - change-safety
+    - change-validation
+  forbidden_skills:
+    - ruby-standards
+  success_criteria:
+    - preserves or documents public API compatibility
+    - follows existing Go documentation and test style
+    - selects Go tests, lint, or coverage through established entrypoints
+
+- id: edit_ruby_helper
+  prompt: "Refactor a Ruby helper script and update its documented command behavior."
+  expected_skills:
+    - ruby-standards
+    - change-safety
+    - change-validation
+  forbidden_skills:
+    - go-standards
+  success_criteria:
+    - follows existing Ruby style without adding a new test framework
+    - updates docs or explains why none are needed
+    - runs or selects the relevant Ruby lint and behavior checks
+
+- id: validate_docs_only_change
+  prompt: "I changed only documentation. What validation should run?"
+  expected_skills:
+    - change-validation
+  forbidden_skills:
+    - security-audit
+  success_criteria:
+    - avoids adding behavior tests for docs-only changes
+    - selects relevant lint or formatting checks when available
+    - reports validation gaps without overstating coverage
+
+- id: draft_pr_summary
+  prompt: "Write a commit message and PR description for the current diff."
+  expected_skills:
+    - pr-summary
+  forbidden_skills:
+    - review-pr
+  success_criteria:
+    - inspects the working tree or latest commit before drafting
+    - includes honest testing details
+    - does not claim unrun checks passed
+
+- id: open_review_pr
+  prompt: "Commit this change, force-push the branch, and open a draft review PR."
+  expected_skills:
+    - review-pr
+    - change-validation
+    - code-review
+    - pr-summary
+  forbidden_skills: []
+  success_criteria:
+    - confirms the current request permits remote writes
+    - validates and reviews before running the review target
+    - reports the PR result using the required output format
+
+- id: skill_routing_update
+  prompt: "Tighten a skill description so it stops firing for adjacent review tasks."
+  expected_skills:
+    - change-safety
+    - change-validation
+  forbidden_skills:
+    - review-pr
+  success_criteria:
+    - updates matching agents/openai.yaml metadata if stale
+    - adds or updates eval cases that cover the routing boundary
+    - validates skill metadata consistency

--- a/skills/makefile-includes/SKILL.md
+++ b/skills/makefile-includes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: makefile-includes
-description: Works with shared bin/build/make/*.mak includes and downstream Makefile integration. Use when editing, reviewing, or debugging reusable Make targets, included make files, ./bin path semantics, or downstream projects that include this repository's make files.
+description: Edits, reviews, or debugs shared bin/build/make/*.mak fragments and downstream Makefile integration. Use for reusable Make targets, included make files, ./bin path semantics, or consuming projects after project-workflow identifies the command surface.
 ---
 
 # Makefile Includes

--- a/skills/makefile-includes/agents/openai.yaml
+++ b/skills/makefile-includes/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Makefile Includes"
   short_description: "Work with shared Makefile includes"
-  default_prompt: "Use $makefile-includes to update or debug shared Makefile includes."
+  default_prompt: "Use $makefile-includes to update, review, or debug shared Makefile fragments and downstream ./bin path behavior."

--- a/skills/project-workflow/SKILL.md
+++ b/skills/project-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-workflow
-description: Discovers project-local workflow, command surfaces, Makefile includes, CI expectations, and shared ./bin submodule wiring. Use when starting work in a project, inspecting how to run tasks, or deciding which project entrypoints to trust before edits or validation.
+description: Discovers project-local workflow, command surfaces, CI expectations, and shared ./bin submodule wiring before work begins. Use when starting in a project, inspecting how to run tasks, or deciding trusted entrypoints; use makefile-includes when editing or debugging reusable make fragments.
 ---
 
 # Project Workflow

--- a/skills/project-workflow/agents/openai.yaml
+++ b/skills/project-workflow/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Project Workflow"
   short_description: "Discover project commands and CI flow"
-  default_prompt: "Use $project-workflow to discover this project workflow."
+  default_prompt: "Use $project-workflow to discover project entrypoints, CI expectations, and ./bin wiring before work begins."

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-pr
-description: Commits the current change, force-pushes the branch, and opens a draft pull request by reviewing the change before using pr-summary output with the repository review make target. Use when the user asks to prepare a PR for review, open a draft PR, run the review flow, or create a review PR from local changes.
+description: Reviews, validates, commits, force-pushes, and opens a draft pull request with the repository review target. Use only when the user explicitly asks to prepare, open, update, or run a review PR from local changes.
 ---
 
 # Review PR
@@ -34,50 +34,11 @@ make msg="unprefixed subject" desc="summary" review
 ```
 
 17. Pass `desc` as the multiline Markdown summary from `$pr-summary`; do not flatten the summary into a single line.
-18. Report the result using the exact structure in `Output Format`; do not add, remove, rename, or reorder sections.
+18. Read `references/output-format.md`, then report the result using that exact structure; do not add, remove, rename, or reorder sections.
 
-## Output Format
+## References
 
-Use exactly this Markdown structure and do not add, remove, rename, or reorder sections:
-
-```markdown
-## Commit Message
-
-unprefixed subject
-
-## PR Summary
-
-<multiline Markdown summary passed as desc>
-
-## Validation
-
-- command: `make lint`
-  result: passed
-  coverage: Ruby linting for changed files.
-
-- gaps: None.
-
-## Code Review
-
-- result: no blocking findings
-
-## Review Target
-
-- command: `make msg="..." desc="..." review`
-  result: passed
-  pr: https://github.com/org/repo/pull/123
-
-## Notes
-
-- None.
-```
-
-- In `Validation`, include one item per command plus a final `gaps` item.
-- In `Code Review`, state whether there were no findings, blocking findings were resolved, or unresolved findings were documented in the PR summary.
-- If a command was not run, write `not run` as the result and explain why in `coverage`.
-- If `make review` fails before opening the PR, set `pr: unavailable`.
-- If `make review` succeeds but the PR URL is not visible in the command output, set `pr: unavailable`.
-- If there are no notes, write exactly `- None.`
+- Read `references/output-format.md` before producing the final review PR report.
 
 ## Notes
 

--- a/skills/review-pr/references/output-format.md
+++ b/skills/review-pr/references/output-format.md
@@ -1,0 +1,42 @@
+# Review PR Output Format
+
+Use exactly this Markdown structure and do not add, remove, rename, or reorder sections:
+
+```markdown
+## Commit Message
+
+unprefixed subject
+
+## PR Summary
+
+<multiline Markdown summary passed as desc>
+
+## Validation
+
+- command: `make lint`
+  result: passed
+  coverage: Ruby linting for changed files.
+
+- gaps: None.
+
+## Code Review
+
+- result: no blocking findings
+
+## Review Target
+
+- command: `make msg="..." desc="..." review`
+  result: passed
+  pr: https://github.com/org/repo/pull/123
+
+## Notes
+
+- None.
+```
+
+- In `Validation`, include one item per command plus a final `gaps` item.
+- In `Code Review`, state whether there were no findings, blocking findings were resolved, or unresolved findings were documented in the PR summary.
+- If a command was not run, write `not run` as the result and explain why in `coverage`.
+- If `make review` fails before opening the PR, set `pr: unavailable`.
+- If `make review` succeeds but the PR URL is not visible in the command output, set `pr: unavailable`.
+- If there are no notes, write exactly `- None.`

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-audit
-description: Reviews code, scripts, Makefile glue, Docker helpers, dependencies, and configuration for security risks. Use when the user asks for a security audit, security review, vulnerability check, secret check, unsafe shell/filesystem/network/auth review, or language-specific security inspection for Go, Ruby, or shell code.
+description: Reviews security-sensitive code, scripts, Makefile glue, Docker helpers, skills, dependencies, and configuration. Use when the user asks for a security audit, vulnerability or secret check, unsafe shell/filesystem/network/auth review, or language-specific security inspection.
 ---
 
 # Security Audit
@@ -12,6 +12,7 @@ description: Reviews code, scripts, Makefile glue, Docker helpers, dependencies,
    - `references/go.md` for Go code, modules, HTTP/TLS, crypto, filesystem, command execution, or `govulncheck`.
    - `references/ruby.md` for Ruby code, Bundler, process execution, YAML/JSON parsing, filesystem, env/secrets, or RuboCop security coverage.
    - `references/shell.md` for Bash scripts, Make targets that invoke shell commands, Docker helper scripts, ShellCheck, quoting, temp files, or destructive commands.
+   - `references/skills.md` for skill descriptions, bundled scripts/assets, permissions, prompt-injection risk, or external skill adoption.
    - `references/shared.md` for cross-language repositories, dependency/config audits, secrets, Docker/security scanners, and report structure.
 3. Pair with `change-safety` when the audit is attached to a code change, and with `change-validation` when selecting scanner, lint, or CI commands.
 4. Ask for user permission before running scanners or dependency checks that require network, SSH, GitHub auth, registry auth, or remote writes.

--- a/skills/security-audit/agents/openai.yaml
+++ b/skills/security-audit/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Security Audit"
-  short_description: "Audit code and scripts for security risk"
-  default_prompt: "Use $security-audit to review this change for security risks."
+  short_description: "Audit security-sensitive changes"
+  default_prompt: "Use $security-audit for security, vulnerability, secret, auth, filesystem, shell, dependency, or skill-safety review."

--- a/skills/security-audit/references/skills.md
+++ b/skills/security-audit/references/skills.md
@@ -1,0 +1,19 @@
+# Skill Security
+
+Use this reference when adding, updating, importing, or auditing skills.
+
+## Review Checklist
+
+- Treat external skills like third-party dependencies: review the full folder before use, especially scripts, assets, references, and metadata.
+- Inspect `description` text for prompt-injection attempts, hidden instructions, remote URLs, or routing language that would trigger the skill outside its intended scope.
+- Check bundled scripts for command injection, broad filesystem access, network calls, credential reads, destructive commands, and unpinned dependency downloads.
+- Keep permissions and command scope as narrow as the workflow allows; avoid workspace-wide access when a specific directory or file is enough.
+- Prefer references for procedural knowledge and scripts only for deterministic operations that justify executable code.
+- For generated or model-drafted skills, require human review before adoption and add eval cases that prove the skill improves real tasks.
+- Record validation gaps when a skill cannot be executed safely in the current environment.
+
+## Common Findings
+
+- High: skill instructions or scripts exfiltrate secrets, disable safety checks, run untrusted remote code, or escalate permissions.
+- Medium: scripts have injection-prone argument handling, broad writes/deletes, unsafe temp files, or network access beyond the skill's purpose.
+- Low: vague routing descriptions, missing metadata, stale references, or missing eval coverage that make incorrect activation likely.


### PR DESCRIPTION
## What

- Add eval cases and lifecycle/security guidance for shared agent workflows.
- Add a Ruby metadata/reference/eval checker exposed through `make skills-lint` and CI/docs.
- Tighten routing descriptions and move the review PR output format into a reference.

## Why

- Make agent guidance measurable, easier to route, and safer to maintain.
- Keep validation docs and CI expectations aligned.

## Testing

- `make skills-lint` - passed
- `make lint` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
