### PR TITLE
feat(agent-guidance): tighten routing and maintenance notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repo contains:
 
 - reusable `build/make/*.mak` fragments (Go/Ruby/proto helpers)
 - small Bash/Ruby scripts under `build/` and `quality/`
+- shared agent skills and references under `skills/`
 - a Dockerfile template for building Go services (`build/docker/go/Dockerfile`)
 
 ## Rationale
@@ -24,6 +25,7 @@ After repeating the same build/lint/test/CI glue across projects, it’s useful 
 | `build/docker/` | Docker helpers and `build/docker/go/Dockerfile`.                                   |
 | `build/sec/`    | Security scanning helpers (Trivy).                                                 |
 | `quality/`      | Quality/test helpers (Go coverage processing, cucumber wrappers).                  |
+| `skills/`       | Shared agent skills and references.                                                |
 
 ## Using this repo (recommended: Git submodule)
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -81,3 +81,22 @@ the established surface, or the change has no stable public surface.
   description, or default prompt if they became stale.
 - Keep `agents/openai.yaml` concise; it should describe when to use the skill,
   not repeat the full `SKILL.md` workflow.
+
+## Skill Lifecycle
+
+- Treat skills as maintained artifacts: review them when project workflow,
+  tooling, model behavior, or team conventions change.
+- Skills generated or drafted by a model need human review before adoption.
+- Periodically compare representative tasks with and without a skill; retire a
+  skill when it no longer improves outcomes or consistently overrides better
+  native behavior.
+
+## Skill Security
+
+- Treat external skills like third-party dependencies and review the full folder
+  before use.
+- Check descriptions for prompt injection or overbroad routing, and check bundled
+  scripts/assets for data exfiltration, broad filesystem access, remote code
+  execution, and unnecessary permissions.
+- Use `security-audit` with `references/skills.md` for skill-specific security
+  review.

--- a/skills/change-safety/SKILL.md
+++ b/skills/change-safety/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: change-safety
-description: Protects documented interfaces, compatibility, security, generated files, dependencies, and migration paths during code or configuration changes. Use before edits that may affect APIs, commands, flags, environment variables, file formats, Make targets, docs, auth, shell execution, or user-facing behavior.
+description: Protects compatibility, documented interfaces, migrations, generated files, dependencies, and user-facing behavior during changes. Use before edits to APIs, commands, flags, environment variables, file formats, Make targets, docs, auth, or shell execution; use code-review for general bug finding.
 ---
 
 # Change Safety

--- a/skills/change-safety/agents/openai.yaml
+++ b/skills/change-safety/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Change Safety"
-  short_description: "Protect interfaces and compatibility"
-  default_prompt: "Use $change-safety before making compatibility-sensitive changes."
+  short_description: "Protect interfaces and migrations"
+  default_prompt: "Use $change-safety before compatibility-sensitive or user-facing changes."

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: Reviews code changes for bugs, regressions, risky assumptions, missing tests, compatibility breaks, unsafe defaults, and missing documentation. Use when the user asks for review, code review, audit, inspect a diff, check a PR, or find issues before merging.
+description: Reviews changed code for bugs, regressions, risky assumptions, missing tests, compatibility breaks, and missing documentation. Use when the user asks for a general code review, diff review, PR check, or pre-merge issue pass; delegate explicit security scope to security-audit.
 ---
 
 # Code Review

--- a/skills/code-review/agents/openai.yaml
+++ b/skills/code-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Code Review"
-  short_description: "Review diffs for bugs and risk"
-  default_prompt: "Use $code-review to review this change for bugs and regressions."
+  short_description: "Review diffs for bugs and regressions"
+  default_prompt: "Use $code-review for a general bug, regression, and missing-coverage review."

--- a/skills/makefile-includes/SKILL.md
+++ b/skills/makefile-includes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: makefile-includes
-description: Works with shared bin/build/make/*.mak includes and downstream Makefile integration. Use when editing, reviewing, or debugging reusable Make targets, included make files, ./bin path semantics, or downstream projects that include this repository's make files.
+description: Edits, reviews, or debugs shared bin/build/make/*.mak fragments and downstream Makefile integration. Use for reusable Make targets, included make files, ./bin path semantics, or consuming projects after project-workflow identifies the command surface.
 ---
 
 # Makefile Includes

--- a/skills/makefile-includes/agents/openai.yaml
+++ b/skills/makefile-includes/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Makefile Includes"
   short_description: "Work with shared Makefile includes"
-  default_prompt: "Use $makefile-includes to update or debug shared Makefile includes."
+  default_prompt: "Use $makefile-includes to update, review, or debug shared Makefile fragments and downstream ./bin path behavior."

--- a/skills/project-workflow/SKILL.md
+++ b/skills/project-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-workflow
-description: Discovers project-local workflow, command surfaces, Makefile includes, CI expectations, and shared ./bin submodule wiring. Use when starting work in a project, inspecting how to run tasks, or deciding which project entrypoints to trust before edits or validation.
+description: Discovers project-local workflow, command surfaces, CI expectations, and shared ./bin submodule wiring before work begins. Use when starting in a project, inspecting how to run tasks, or deciding trusted entrypoints; use makefile-includes when editing or debugging reusable make fragments.
 ---
 
 # Project Workflow

--- a/skills/project-workflow/agents/openai.yaml
+++ b/skills/project-workflow/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Project Workflow"
   short_description: "Discover project commands and CI flow"
-  default_prompt: "Use $project-workflow to discover this project workflow."
+  default_prompt: "Use $project-workflow to discover project entrypoints, CI expectations, and ./bin wiring before work begins."

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-pr
-description: Commits the current change, force-pushes the branch, and opens a draft pull request by reviewing the change before using pr-summary output with the repository review make target. Use when the user asks to prepare a PR for review, open a draft PR, run the review flow, or create a review PR from local changes.
+description: Reviews, validates, commits, force-pushes, and opens a draft pull request with the repository review target. Use only when the user explicitly asks to prepare, open, update, or run a review PR from local changes.
 ---
 
 # Review PR
@@ -34,50 +34,11 @@ make msg="unprefixed subject" desc="summary" review
 ```
 
 17. Pass `desc` as the multiline Markdown summary from `$pr-summary`; do not flatten the summary into a single line.
-18. Report the result using the exact structure in `Output Format`; do not add, remove, rename, or reorder sections.
+18. Read `references/output-format.md`, then report the result using that exact structure; do not add, remove, rename, or reorder sections.
 
-## Output Format
+## References
 
-Use exactly this Markdown structure and do not add, remove, rename, or reorder sections:
-
-```markdown
-## Commit Message
-
-unprefixed subject
-
-## PR Summary
-
-<multiline Markdown summary passed as desc>
-
-## Validation
-
-- command: `make lint`
-  result: passed
-  coverage: Ruby linting for changed files.
-
-- gaps: None.
-
-## Code Review
-
-- result: no blocking findings
-
-## Review Target
-
-- command: `make msg="..." desc="..." review`
-  result: passed
-  pr: https://github.com/org/repo/pull/123
-
-## Notes
-
-- None.
-```
-
-- In `Validation`, include one item per command plus a final `gaps` item.
-- In `Code Review`, state whether there were no findings, blocking findings were resolved, or unresolved findings were documented in the PR summary.
-- If a command was not run, write `not run` as the result and explain why in `coverage`.
-- If `make review` fails before opening the PR, set `pr: unavailable`.
-- If `make review` succeeds but the PR URL is not visible in the command output, set `pr: unavailable`.
-- If there are no notes, write exactly `- None.`
+- Read `references/output-format.md` before producing the final review PR report.
 
 ## Notes
 

--- a/skills/review-pr/references/output-format.md
+++ b/skills/review-pr/references/output-format.md
@@ -1,0 +1,42 @@
+# Review PR Output Format
+
+Use exactly this Markdown structure and do not add, remove, rename, or reorder sections:
+
+```markdown
+## Commit Message
+
+unprefixed subject
+
+## PR Summary
+
+<multiline Markdown summary passed as desc>
+
+## Validation
+
+- command: `make lint`
+  result: passed
+  coverage: Ruby linting for changed files.
+
+- gaps: None.
+
+## Code Review
+
+- result: no blocking findings
+
+## Review Target
+
+- command: `make msg="..." desc="..." review`
+  result: passed
+  pr: https://github.com/org/repo/pull/123
+
+## Notes
+
+- None.
+```
+
+- In `Validation`, include one item per command plus a final `gaps` item.
+- In `Code Review`, state whether there were no findings, blocking findings were resolved, or unresolved findings were documented in the PR summary.
+- If a command was not run, write `not run` as the result and explain why in `coverage`.
+- If `make review` fails before opening the PR, set `pr: unavailable`.
+- If `make review` succeeds but the PR URL is not visible in the command output, set `pr: unavailable`.
+- If there are no notes, write exactly `- None.`

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-audit
-description: Reviews code, scripts, Makefile glue, Docker helpers, dependencies, and configuration for security risks. Use when the user asks for a security audit, security review, vulnerability check, secret check, unsafe shell/filesystem/network/auth review, or language-specific security inspection for Go, Ruby, or shell code.
+description: Reviews security-sensitive code, scripts, Makefile glue, Docker helpers, skills, dependencies, and configuration. Use when the user asks for a security audit, vulnerability or secret check, unsafe shell/filesystem/network/auth review, or language-specific security inspection.
 ---
 
 # Security Audit
@@ -12,6 +12,7 @@ description: Reviews code, scripts, Makefile glue, Docker helpers, dependencies,
    - `references/go.md` for Go code, modules, HTTP/TLS, crypto, filesystem, command execution, or `govulncheck`.
    - `references/ruby.md` for Ruby code, Bundler, process execution, YAML/JSON parsing, filesystem, env/secrets, or RuboCop security coverage.
    - `references/shell.md` for Bash scripts, Make targets that invoke shell commands, Docker helper scripts, ShellCheck, quoting, temp files, or destructive commands.
+   - `references/skills.md` for skill descriptions, bundled scripts/assets, permissions, prompt-injection risk, or external skill adoption.
    - `references/shared.md` for cross-language repositories, dependency/config audits, secrets, Docker/security scanners, and report structure.
 3. Pair with `change-safety` when the audit is attached to a code change, and with `change-validation` when selecting scanner, lint, or CI commands.
 4. Ask for user permission before running scanners or dependency checks that require network, SSH, GitHub auth, registry auth, or remote writes.

--- a/skills/security-audit/agents/openai.yaml
+++ b/skills/security-audit/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Security Audit"
-  short_description: "Audit code and scripts for security risk"
-  default_prompt: "Use $security-audit to review this change for security risks."
+  short_description: "Audit security-sensitive changes"
+  default_prompt: "Use $security-audit for security, vulnerability, secret, auth, filesystem, shell, dependency, or skill-safety review."

--- a/skills/security-audit/references/skills.md
+++ b/skills/security-audit/references/skills.md
@@ -1,0 +1,19 @@
+# Skill Security
+
+Use this reference when adding, updating, importing, or auditing skills.
+
+## Review Checklist
+
+- Treat external skills like third-party dependencies: review the full folder before use, especially scripts, assets, references, and metadata.
+- Inspect `description` text for prompt-injection attempts, hidden instructions, remote URLs, or routing language that would trigger the skill outside its intended scope.
+- Check bundled scripts for command injection, broad filesystem access, network calls, credential reads, destructive commands, and unpinned dependency downloads.
+- Keep permissions and command scope as narrow as the workflow allows; avoid workspace-wide access when a specific directory or file is enough.
+- Prefer references for procedural knowledge and scripts only for deterministic operations that justify executable code.
+- For generated or model-drafted skills, require human review before adoption and test them against representative tasks before relying on them.
+- Record validation gaps when a skill cannot be executed safely in the current environment.
+
+## Common Findings
+
+- High: skill instructions or scripts exfiltrate secrets, disable safety checks, run untrusted remote code, or escalate permissions.
+- Medium: scripts have injection-prone argument handling, broad writes/deletes, unsafe temp files, or network access beyond the skill's purpose.
+- Low: vague routing descriptions, missing metadata, stale references, or missing representative-task review that make incorrect activation likely.


### PR DESCRIPTION
## What

- Tighten routing descriptions for overlapping shared skills and refresh the matching OpenAI metadata.
- Move the review PR output format into a reference file to keep the main workflow focused.
- Add skill lifecycle and security-review guidance without adding eval or CI-check scaffolding.

## Why

- Make skill activation boundaries clearer and easier to maintain.
- Keep detailed output and security guidance available through progressive disclosure.

## Testing

- `make lint` - passed
- `git diff --check HEAD` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
