### PR TITLE
feat(go): show test names in specs output

### DIFF
--- a/build/make/client.mak
+++ b/build/make/client.mak
@@ -109,7 +109,7 @@ benchmarks: build
 
 # Run Go tests with gotestsum (race + coverage) and write reports under test/reports/.
 specs:
-	@gotestsum --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
+	@gotestsum --format testname --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
 
 # Open pprof for a captured profile under test/reports/ (set cmd/id/kind).
 pprof:

--- a/build/make/go.mak
+++ b/build/make/go.mak
@@ -71,7 +71,7 @@ format:
 
 # Run tests with gotestsum (race + coverage) and write reports under test/reports/.
 specs:
-	@gotestsum --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
+	@gotestsum --format testname --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
 
 # Run benchmarks for package=$(package) and write $(BENCHMARK_PROFILE).
 # Set benchtime=<duration-or-count> to pass -benchtime to go test.

--- a/build/make/grpc.mak
+++ b/build/make/grpc.mak
@@ -133,7 +133,7 @@ benchmarks: build
 
 # Run Go tests with gotestsum (race + coverage) and write reports under test/reports/.
 specs:
-	@gotestsum --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
+	@gotestsum --format testname --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
 
 # Open pprof for a captured profile under test/reports/ (set id/kind).
 pprof:

--- a/build/make/http.mak
+++ b/build/make/http.mak
@@ -109,7 +109,7 @@ benchmarks: build
 
 # Run Go tests with gotestsum (race + coverage) and write reports under test/reports/.
 specs:
-	@gotestsum --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
+	@gotestsum --format testname --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
 
 # Open pprof for a captured profile under test/reports/ (set id/kind).
 pprof:


### PR DESCRIPTION
## What

- Add `--format testname` to gotestsum in the shared specs targets for `go.mak`, `client.mak`, `http.mak`, and `grpc.mak`.

## Why

- Make specs output show individual test names while preserving the existing JUnit, race, vendor, and coverage behavior.

## Testing

- `rg -n "gotestsum" build/make` - passed
- `gmake -n -f build/make/go.mak specs` - passed
- `gmake -n -f build/make/client.mak specs` - passed
- `gmake -n -f build/make/http.mak specs` - passed
- `gmake -n -f build/make/grpc.mak specs` - passed
- `git diff --check` - passed
- `gmake lint` - failed locally because Bundler 4.0.10 from `Gemfile.lock` is not installed
- `make lint` - failed locally because BSD Make cannot parse this repo's GNU Make syntax in `build/make/git.mak`

AI-assisted-by: [Codex](https://openai.com/codex/)
