### PR TITLE
feat(skills): treat issue find as delegation request

### DIFF
--- a/skills/issues/SKILL.md
+++ b/skills/issues/SKILL.md
@@ -17,24 +17,26 @@ Do not combine the two modes in one pass.
 1. Identify the requested package or folder scope. If no scope is provided, stop and ask for the package or folder.
 2. Use `ISSUES.md` in the requested package or folder as the review ledger, for example `<package/folder>/ISSUES.md`.
 3. If `ISSUES.md` already exists in the requested package or folder, stop. Tell the user the existing issues in that scope must be resolved first, or the human must delete that scoped `ISSUES.md` before a new find pass there.
-4. Use sub-agents for Find mode whenever the active runtime provides them and the runtime permits delegation for the request. Do not treat sub-agents as optional based on scope size, and do not perform the find review locally first.
-5. If explicit delegation permission is required, ask once with the concrete read-only agent plan. If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
-6. Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, or other non-read-only validation. Without that permission, agents should inspect code only and suggest validation.
-7. Exclude generated files and folders, vendored dependencies, caches, build output, and generated lockfile churn unless the requested scope is explicitly about them.
-8. Launch at least one sub-agent covering the requested root package/folder. Split agent assignments across:
+4. Treat `Find $issues in <package/folder>` or `Find issues in <package/folder>` as the user's explicit request to delegate review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
+5. Use sub-agents for Find mode whenever the active runtime provides them and the runtime permits delegation for the request. Do not treat sub-agents as optional based on scope size, and do not perform the find review locally first.
+6. Do not claim that extra delegation wording is needed before launching review agents. The Find mode invocation is the explicit delegation request.
+7. If the runtime still requires an approval step before launching sub-agents, ask once with the concrete read-only agent plan. If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
+8. Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, or other non-read-only validation. Without that permission, agents should inspect code only and suggest validation.
+9. Exclude generated files and folders, vendored dependencies, caches, build output, and generated lockfile churn unless the requested scope is explicitly about them.
+10. Launch at least one sub-agent covering the requested root package/folder. Split agent assignments across:
    - files directly under the requested root package/folder.
    - each first-level subpackage/subfolder under the requested root.
-9. Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough and accurate `$code-review` and `$security-audit` for its assigned scope.
-10. Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
-11. Wait for all agents to finish before aggregating results.
-12. Deduplicate overlapping findings and resolve conflicting agent conclusions by re-checking the code directly.
-13. Confirm each candidate finding against the code before recording it. Findings must be concrete bugs, security issues, compatibility breaks, or violated public contracts with user-visible impact.
-14. Do not report optional regression tests, unused convenience aliases, API symmetry, or documentation polish as findings by themselves. List them only as testing gaps or optional follow-up notes when relevant.
-15. If no confirmed issues are found, report that no issues were found and do not create `ISSUES.md`.
-16. If confirmed issues are found, write all findings to the scoped `ISSUES.md` before making any fixes.
-17. Assign every finding a unique ID for the session in the form `ISSUE-<number>`.
-18. Present the scoped `ISSUES.md` and a proposed fix plan to the user.
-19. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
+11. Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough and accurate `$code-review` and `$security-audit` for its assigned scope.
+12. Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
+13. Wait for all agents to finish before aggregating results.
+14. Deduplicate overlapping findings and resolve conflicting agent conclusions by re-checking the code directly.
+15. Confirm each candidate finding against the code before recording it. Findings must be concrete bugs, security issues, compatibility breaks, or violated public contracts with user-visible impact.
+16. Do not report optional regression tests, unused convenience aliases, API symmetry, or documentation polish as findings by themselves. List them only as testing gaps or optional follow-up notes when relevant.
+17. If no confirmed issues are found, report that no issues were found and do not create `ISSUES.md`.
+18. If confirmed issues are found, write all findings to the scoped `ISSUES.md` before making any fixes.
+19. Assign every finding a unique ID for the session in the form `ISSUE-<number>`.
+20. Present the scoped `ISSUES.md` and a proposed fix plan to the user.
+21. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
 
 ## `ISSUES.md` Format
 

--- a/skills/issues/agents/openai.yaml
+++ b/skills/issues/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Issues"
-  short_description: "Find scoped issues and implement agreed fixes one at a time"
-  default_prompt: "Use $issues to find concrete issues in a package or folder, storing them in that scope's ISSUES.md, or to propose and implement explicitly agreed fixes from a scoped ISSUES.md one issue at a time."
+  short_description: "Find scoped issues with delegated review and implement fixes"
+  default_prompt: "Use $issues to delegate issue-finding in a package or folder, store confirmed findings in that scope's ISSUES.md, or propose and implement explicitly agreed fixes from a scoped ISSUES.md one issue at a time."


### PR DESCRIPTION
## What

- Treat `Find $issues in <package/folder>` as an explicit request to delegate issue review for that scope.
- Clarify that Find mode should not require separate wording like `use sub-agents` before launching review agents.
- Update the issues skill metadata to describe delegated issue-finding.

## Why

- Prevents the workflow from falling back to local review with a message saying delegation was not explicitly requested.
- Keeps the skill chip and default prompt aligned with the enforced delegated review behavior.

## Testing

- `ruby -e 'require "yaml"; skill=File.read("skills/issues/SKILL.md").split("---",3)[1]; YAML.safe_load(skill); YAML.safe_load(File.read("skills/issues/agents/openai.yaml")); puts "ok"'` - passed
- `git diff --check` - passed
- `rg 'spawn review agents unless|explicitly ask for delegation|Sub-agents are optional|Find \$issues for|Implement \$issues`' skills/issues -n` - passed with no matches
- `gmake lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
