### PR TITLE
feat(skills): centralize test design guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ skill instead of one broad default:
 - `change-safety`: compatibility, documented interfaces, migrations, generated
   files, and security-sensitive edits.
 - `change-validation`: test, lint, CI, security, benchmark, and validation selection.
+- `testing-standards`: language-agnostic test design, coverage, fixtures,
+  determinism, and test-layer guidance.
 - `code-review`: review findings, risk assessment, and missing coverage.
 - `security-audit`: security reviews, vulnerability checks, unsafe shell/filesystem/network/auth inspection, and Go/Ruby/shell audit guidance.
 - `issues`: find confirmed issues into `ISSUES.md`, then implement agreed fixes issue by issue.
@@ -60,6 +62,8 @@ Common composition:
   review scope while keeping the review findings format.
 - `security-audit` pairs with `change-safety` for code changes and
   `change-validation` for scanner, lint, or CI command selection.
+- `testing-standards` pairs with language standards for test idioms and
+  `change-validation` for command selection.
 
 ## Quick commands (this repo)
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -15,6 +15,9 @@ checks, and findings.
   `security-audit` for security-sensitive scope.
 - `security-audit` pairs with `change-safety` for code changes and
   `change-validation` for scanner, lint, or CI command selection.
+- `testing-standards` covers language-agnostic test design and coverage
+  decisions; pair it with language standards for idioms and
+  `change-validation` for command selection.
 - `makefile-includes` should follow `project-workflow` when the command surface
   or downstream `./bin` wiring is not yet known.
 - Language standards pair with `change-validation` for check selection and
@@ -28,30 +31,15 @@ and use the caller's output format.
 
 ## Testing Principle
 
-Before adding tests, inspect the repository's existing test suites, fixtures,
-helpers, entrypoints, and CI targets, then follow that standard. Prefer tests
-and validation through the existing public or documented entry points for the
-project type: libraries often use unit/integration tests, while services in
-this ecosystem often use Cucumber features. Use internal seams only when the
-repo already tests that way, the behavior cannot be exercised credibly through
-the established surface, or the change has no stable public surface.
-
-- Do not introduce a new test framework, fixture layout, or test layer unless
-  the task explicitly changes testing infrastructure.
-- Choose the narrowest established test layer that credibly covers the changed
-  behavior; use broader suites for shared infrastructure or release-sensitive
-  changes.
-- Assert changed behavior and contracts, not incidental implementation details.
-- Keep tests deterministic: avoid uncontrolled network, wall-clock time, random
-  data, ordering assumptions, real home directories, and shared mutable state.
-- Cover relevant failure paths, especially invalid input, missing files/tools,
-  non-zero commands, path errors, permissions, and argument pass-through.
-- Do not add behavioral tests for docs-only or formatting-only changes; run the
-  relevant lint, docs, or formatting validation when available.
-- For shared `./bin` scripts and make fragments, validate from the consuming
-  repository root when behavior depends on downstream `$(PWD)/bin/...` wiring.
-- Report validation gaps honestly, including lint-only coverage, missing tools,
-  skipped checks, and wrappers that no-op.
+Use `testing-standards` when adding, reviewing, refactoring, or planning tests.
+In brief: inspect the repository's existing tests, fixtures, helpers,
+entrypoints, CI targets, and dominant test harness before adding new structure.
+Prefer the narrowest established test layer that credibly covers changed
+behavior through a public or documented surface; private-surface tests need
+explicit human approval. Preserve meaningful coverage where practical, check
+whether new or risky behavior needs better coverage, and explain unavoidable
+gaps. Keep tests readable, edge-aware, deterministic, and descriptive when they
+fail.
 
 ## Network And Remote Commands
 

--- a/skills/change-validation/SKILL.md
+++ b/skills/change-validation/SKILL.md
@@ -13,7 +13,8 @@ description: Chooses and reports credible validation commands for tests, linting
 4. Ask for user permission before running validation commands that require SSH credentials, GitHub auth, registry auth, cloning, pushing, publishing, opening PRs, or updating remote state.
 5. Run the narrowest check that credibly exercises the changed behavior, then expand only when risk justifies it.
 6. Notice wrappers that no-op because optional tools are missing, and do not report them as full validation.
-7. When reporting standalone validation, use the exact structure in `references/check-selection.md`; when another skill embeds validation, preserve the command, result, coverage, and gap details.
+7. Use `$testing-standards` when the task needs decisions about what tests to add or whether coverage is credible; keep this skill focused on selecting and reporting commands.
+8. When reporting standalone validation, use the exact structure in `references/check-selection.md`; when another skill embeds validation, preserve the command, result, coverage, and gap details.
 
 ## References
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -10,10 +10,11 @@ description: Reviews changed code for bugs, regressions, risky assumptions, miss
 1. Identify the changed files or requested review scope.
 2. Read `references/findings-format.md` before producing review output.
 3. Inspect behavior, tests, compatibility, security, docs, and maintenance risk before style preferences.
-4. If the review scope includes security-sensitive code, configuration, dependencies, shell execution, filesystem writes/deletes, network/auth/TLS behavior, secrets/env handling, Docker helpers, or CI/security tooling, consult `$security-audit` and the smallest matching security reference; keep this skill's findings format.
-5. Verify claims against concrete file and line references whenever possible.
-6. When code review is the final response, use the exact structure in `references/findings-format.md`; do not add, remove, rename, or reorder sections.
-7. When another skill embeds this review, preserve findings, open questions, testing gaps, and summary facts in the caller's output format.
+4. Use `$testing-standards` when judging whether tests are missing, weak, overfit to internals, or at the wrong layer.
+5. If the review scope includes security-sensitive code, configuration, dependencies, shell execution, filesystem writes/deletes, network/auth/TLS behavior, secrets/env handling, Docker helpers, or CI/security tooling, consult `$security-audit` and the smallest matching security reference; keep this skill's findings format.
+6. Verify claims against concrete file and line references whenever possible.
+7. When code review is the final response, use the exact structure in `references/findings-format.md`; do not add, remove, rename, or reorder sections.
+8. When another skill embeds this review, preserve findings, open questions, testing gaps, and summary facts in the caller's output format.
 
 ## References
 

--- a/skills/go-standards/SKILL.md
+++ b/skills/go-standards/SKILL.md
@@ -11,7 +11,8 @@ description: Applies this repository ecosystem's Go coding, documentation, impor
 2. Read `references/conventions.md` before editing exported APIs, documentation, imports, naming, method layout, or tests.
 3. Preserve the repository's existing Go package shape and public API style.
 4. Add or update Go tests when behavior changes and the repository supports tests.
-5. Pair this skill with `change-validation` when selecting Go test, lint, coverage, or benchmark commands.
+5. Pair this skill with `$testing-standards` when designing, reviewing, or refactoring Go test coverage.
+6. Pair this skill with `change-validation` when selecting Go test, lint, coverage, or benchmark commands.
 
 ## References
 

--- a/skills/go-standards/references/conventions.md
+++ b/skills/go-standards/references/conventions.md
@@ -17,16 +17,10 @@ Use this reference when working in Go repositories.
 
 ## Testing
 
-- Before adding new test structure, look for existing tests in the package or adjacent packages and reuse their helpers, fixtures, table shapes, assertions, and naming patterns when they fit.
-- When new coverage is needed, base it on the testing style already present in the repository rather than introducing a new pattern.
+- Follow `$testing-standards` for cross-language test design, coverage, fixtures, determinism, and test-layer decisions.
 - Infer the project type from existing tests and CI: Go libraries commonly use unit and integration tests, while services in this ecosystem may rely on Cucumber feature flows around the service.
-- Prefer testing through the repository's established public or documented Go APIs, commands, or service entrypoints so coverage reflects real consumer behavior.
-- Do not introduce a new Go test framework, fixture layout, or test layer unless the task explicitly changes testing infrastructure.
-- Keep tests deterministic and cover relevant failure paths for changed behavior.
 - In this repository ecosystem, prefer `github.com/stretchr/testify/require` when adding assertion-based tests unless the package already uses a different local pattern.
 - Prefer external test packages named `<package>_test` when the behavior can be exercised through the public interface.
-- Use internal package tests only when the repository already tests that way, the behavior cannot be exercised credibly through the established public surface, or the change has no stable public surface.
-- When internal tests are necessary, keep them focused and still run public-path validation when practical.
 - Keep test cases and test functions first in the file. Place fakes, stubs, spies, mock implementations, and helper types after the tests at the bottom of the file.
 
 ## Method Layout

--- a/skills/issues/SKILL.md
+++ b/skills/issues/SKILL.md
@@ -26,7 +26,7 @@ Do not combine the two modes in one pass.
 10. Launch at least one sub-agent covering the requested root package/folder. Split agent assignments across:
    - files directly under the requested root package/folder.
    - each first-level subpackage/subfolder under the requested root.
-11. Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough and accurate `$code-review` and `$security-audit` for its assigned scope.
+11. Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough and accurate `$code-review` and `$security-audit` for its assigned scope, using `$testing-standards` for concrete missing-coverage or weak-test analysis.
 12. Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
 13. Wait for all agents to finish before aggregating results.
 14. Deduplicate overlapping findings and resolve conflicting agent conclusions by re-checking the code directly.
@@ -77,16 +77,18 @@ Keep optional follow-up notes separate from findings:
 5. Stop after proposing the solution. Do not edit code, update `ISSUES.md`, or start validation until the human explicitly agrees to that issue's solution.
 6. Ask questions when behavior, compatibility, security, validation, or user intent is ambiguous. Treat silence or a broad "implement issues" request as permission to start the proposal workflow, not as permission to code.
 7. Once the solution for the current issue is agreed, implement only that issue with the smallest safe change.
-8. Validate the fix using checks appropriate to the changed code.
-9. Report the result for that issue and ask the human to verify and explicitly say `ISSUE-<number> is done`.
-10. Do not move to the next issue until the human says `ISSUE-<number> is done`.
-11. After the human confirms an issue is done, remove that issue from scoped `ISSUES.md`. If an issue is deemed invalid or not actually an issue, remove it only after explaining why and getting human agreement.
-12. Then propose the solution for the next remaining issue and repeat the same agreement gate.
-13. Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
-14. Summarize what changed, which issues were resolved or dismissed, and which validation steps were run or still need to be carried out by the human.
+8. Use `$testing-standards` when deciding whether to add or update regression tests for the fix.
+9. Validate the fix using checks appropriate to the changed code.
+10. Report the result for that issue and ask the human to verify and explicitly say `ISSUE-<number> is done`.
+11. Do not move to the next issue until the human says `ISSUE-<number> is done`.
+12. After the human confirms an issue is done, remove that issue from scoped `ISSUES.md`. If an issue is deemed invalid or not actually an issue, remove it only after explaining why and getting human agreement.
+13. Then propose the solution for the next remaining issue and repeat the same agreement gate.
+14. Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
+15. Summarize what changed, which issues were resolved or dismissed, and which validation steps were run or still need to be carried out by the human.
 
 ## References
 
 - Use `$code-review` for review rigor and finding quality.
 - Use `$security-audit` for security-sensitive review scope.
+- Use `$testing-standards` when deciding or reviewing regression coverage.
 - Use `$change-validation` when selecting validation commands for implemented fixes.

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -15,26 +15,27 @@ description: Reviews, validates, commits, force-pushes, and opens a draft pull r
 6. If the changed paths include Go code, Go tests, Go modules, Go docs, or Go tooling behavior, also use `$go-standards`.
 7. If the changed paths include Ruby code, Ruby tests/features, Gemfiles, RuboCop config, Ruby docs, or Ruby tooling behavior, also use `$ruby-standards`.
 8. If the changed paths include shell scripts, Bash helpers, ShellCheck config/directives, shell docs, or script behavior, also use `$shell-standards`.
-9. Use `$code-review` to inspect the current change before drafting PR text.
-10. Resolve any blocking review findings before continuing; if findings remain intentionally unresolved, call them out in the PR summary.
-11. If `$code-review` reports security findings or security validation gaps, resolve them or document them in the PR summary before `make review`.
-12. Use `$pr-summary` to draft a lowercase, unprefixed `msg` and Markdown PR summary from the current working tree.
-13. Follow `$pr-summary` commit-subject rules: `make review` adds the branch-derived `type(scope):` prefix, so treat branch words as routing metadata rather than message source material and do not repeat the type or scope in `msg`.
-14. Keep the summary in the `$pr-summary` format, including honest testing details.
-15. When attribution is appropriate or requested, append this footer to the summary instead of a `Co-authored-by:` trailer:
+9. If the changed paths include tests, test helpers, fixtures, or changes that raise test coverage or test-design questions, also use `$testing-standards`.
+10. Use `$code-review` to inspect the current change before drafting PR text.
+11. Resolve any blocking review findings before continuing; if findings remain intentionally unresolved, call them out in the PR summary.
+12. If `$code-review` reports security findings or security validation gaps, resolve them or document them in the PR summary before `make review`.
+13. Use `$pr-summary` to draft a lowercase, unprefixed `msg` and Markdown PR summary from the current working tree.
+14. Follow `$pr-summary` commit-subject rules: `make review` adds the branch-derived `type(scope):` prefix, so treat branch words as routing metadata rather than message source material and do not repeat the type or scope in `msg`.
+15. Keep the summary in the `$pr-summary` format, including honest testing details.
+16. When attribution is appropriate or requested, append this footer to the summary instead of a `Co-authored-by:` trailer:
 
 ```text
 AI-assisted-by: [Codex](https://openai.com/codex/)
 ```
 
-16. Run the review target with the drafted values:
+17. Run the review target with the drafted values:
 
 ```bash
 make msg="unprefixed subject" desc="summary" review
 ```
 
-17. Pass `desc` as the multiline Markdown summary from `$pr-summary`; do not flatten the summary into a single line.
-18. Read `references/output-format.md`, then report the result using that exact structure; do not add, remove, rename, or reorder sections.
+18. Pass `desc` as the multiline Markdown summary from `$pr-summary`; do not flatten the summary into a single line.
+19. Read `references/output-format.md`, then report the result using that exact structure; do not add, remove, rename, or reorder sections.
 
 ## References
 

--- a/skills/ruby-standards/SKILL.md
+++ b/skills/ruby-standards/SKILL.md
@@ -12,7 +12,8 @@ description: Applies this repository ecosystem's Ruby coding, API, documentation
 3. Preserve the repository's existing Ruby style, naming, error handling, and test idioms.
 4. Avoid clever metaprogramming or monkey patches unless the repository already relies on them or the task requires them.
 5. Pair this skill with `change-safety` when Ruby changes affect documented commands, public methods, task interfaces, or migration expectations.
-6. Pair this skill with `change-validation` when selecting Ruby lint, feature, benchmark, or security commands.
+6. Pair this skill with `$testing-standards` when designing, reviewing, or refactoring Ruby test or feature coverage.
+7. Pair this skill with `change-validation` when selecting Ruby lint, feature, benchmark, or security commands.
 
 ## References
 

--- a/skills/ruby-standards/references/conventions.md
+++ b/skills/ruby-standards/references/conventions.md
@@ -16,13 +16,9 @@ Use this reference when working in Ruby repositories.
 
 ## Testing
 
-- Reuse the repository's existing test, feature, fixture, helper, assertion, and naming patterns before adding new structure.
+- Follow `$testing-standards` for cross-language test design, coverage, fixtures, determinism, and test-layer decisions.
 - Infer the project type from existing tests and CI: Ruby libraries commonly use unit and integration tests such as RSpec, while services in this ecosystem commonly use Cucumber feature flows.
-- Prefer testing through the repository's established public or documented Ruby APIs, commands, tasks, or feature flows so coverage reflects real consumer behavior.
-- Do not introduce a new Ruby test framework, fixture layout, or test layer unless the task explicitly changes testing infrastructure.
-- Keep tests deterministic and cover relevant failure paths for changed behavior.
-- Use internal seams only when the repository already tests that way, the behavior cannot be exercised credibly through the established public surface, or the change has no stable public surface.
-- When internal tests are necessary, keep them focused and still run public-path validation when practical.
+- Match the repository's established Ruby test, feature, helper, assertion, and naming idioms.
 
 ## External Style References
 

--- a/skills/shell-standards/SKILL.md
+++ b/skills/shell-standards/SKILL.md
@@ -12,7 +12,8 @@ description: Applies this repository ecosystem's Bash scripting, ShellCheck, tex
 3. Preserve the repository's existing shell style, argument handling, and command wrappers.
 4. Use Bash for scripts with `#!/usr/bin/env bash` and catch failures early with `set -eo pipefail`.
 5. Pair this skill with `$security-audit` for `eval`, shell-command construction, broad file deletion/writes, downloads, temp files, env/secrets, or other trust-boundary changes.
-6. Pair this skill with `change-validation` when selecting ShellCheck or script lint commands.
+6. Pair this skill with `$testing-standards` when designing, reviewing, or refactoring script behavior tests.
+7. Pair this skill with `change-validation` when selecting ShellCheck or script lint commands.
 
 ## References
 

--- a/skills/shell-standards/references/conventions.md
+++ b/skills/shell-standards/references/conventions.md
@@ -26,12 +26,9 @@ Use this reference when working with shell scripts.
 
 ## Testing
 
+- Follow `$testing-standards` for cross-language test design, coverage, fixtures, determinism, and test-layer decisions.
 - Prefer validating shell changes through public or documented commands, scripts, Make targets, and argument flows.
-- Reuse the repository's existing script tests, feature flows, lint targets, and validation entrypoints before adding ad hoc checks.
 - Cover relevant failure paths such as invalid arguments, missing files/tools, non-zero commands, path errors, permissions, and argument pass-through.
-- Keep checks deterministic and avoid relying on the caller's real home directory, global config, network, wall-clock time, or shared mutable state.
-- Use internal helper seams only when the repository already tests that way, the behavior cannot be exercised credibly through the established command path, or the change has no stable public surface.
-- When internal checks are necessary, keep them focused and still run public-path validation when practical.
 
 ## Functions
 

--- a/skills/testing-standards/SKILL.md
+++ b/skills/testing-standards/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: testing-standards
+description: Applies language-agnostic test design, coverage, fixtures, determinism, and test-layer conventions. Use when adding, reviewing, refactoring, or planning tests across languages; pair with language standards for language-specific idioms and change-validation for commands.
+---
+
+# Testing Standards
+
+## Steps
+
+1. Confirm the task involves adding tests, changing tests, reviewing test quality, planning coverage, or deciding where behavior should be exercised.
+2. Inspect the repository's existing tests, fixtures, helpers, entrypoints, CI targets, and the language or harness used by most relevant tests before adding new structure.
+3. Check whether the change should preserve, restore, or improve coverage; do not let meaningful behavior lose coverage without calling out the gap.
+4. Choose the narrowest established test layer that credibly covers the changed behavior.
+5. Test through public or documented APIs, commands, tasks, or service entrypoints so coverage reflects real consumer behavior.
+6. Do not add tests against private functions, private methods, or internal-only seams unless the human explicitly asks for that approach; if private-surface testing seems necessary, ask first.
+7. Preserve the repository's existing test framework, fixture layout, helper style, assertion idioms, and naming patterns unless the task explicitly changes testing infrastructure.
+8. Pair with the relevant language standard skill for language-specific idioms, and with `change-validation` for selecting or reporting commands.
+9. If another testing-focused skill applies, use this skill for cross-language test policy and the other skill only for specialized language, framework, or library details; this skill's cross-language rules take precedence unless the human or repository instructions explicitly say otherwise.
+
+## Principles
+
+- Assert changed behavior and contracts, not incidental implementation details.
+- Treat coverage as a useful signal, not a blind target: preserve existing meaningful coverage where practical, improve it when new or risky behavior is under-tested, and explain when coverage cannot reasonably be added.
+- Just because production code is written in one language does not mean new tests should be written in that language; follow the dominant relevant test harness when the repository tests behavior from another language or feature layer.
+- Prefer table-driven tests when covering multiple inputs, branches, edge cases, or examples, unless the repository's local style clearly uses another readable pattern.
+- Cover relevant edge cases and failure paths for changed behavior, especially empty input, boundary values, malformed input, missing files or tools, non-zero commands, path errors, permissions, parsing failures, and argument pass-through.
+- Keep tests deterministic: avoid uncontrolled network, wall-clock time, random data, ordering assumptions, real home directories, and shared mutable state.
+- Structure tests so the setup, action, and assertion are easy to follow; use Arrange-Act-Assert or Given-When-Then when the repository does not already have a clearer local pattern.
+- Make failures obvious and descriptive. Avoid bare assertions such as `expected true but got false`; include the case, input, expected behavior, and observed behavior when the assertion framework does not do so clearly.
+- Keep tests readable. Add small helpers, fixtures, builders, or assertions when they make behavior easier to read, but avoid abstractions that hide the scenario being tested.
+- Use broader suites for shared infrastructure, compatibility-sensitive behavior, release-sensitive behavior, or changes that cross package, command, or service boundaries.
+- Do not add behavioral tests for docs-only or formatting-only changes; run relevant lint, docs, or formatting validation when available.
+- When reviewing tests, check these rules explicitly and flag tests that use private surfaces without approval, follow the wrong harness, miss important edge cases, produce unclear failures, or are hard to read.
+- For shared `./bin` scripts and make fragments, validate from the consuming repository root when behavior depends on downstream `$(PWD)/bin/...` wiring.
+- Report validation gaps honestly, including lint-only coverage, missing tools, skipped checks, environment limits, and wrappers that no-op.

--- a/skills/testing-standards/agents/openai.yaml
+++ b/skills/testing-standards/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Testing Standards"
+  short_description: "Design focused cross-language tests"
+  default_prompt: "Use $testing-standards to design or review focused tests for this change."


### PR DESCRIPTION
## What

- Add `testing-standards` as the shared home for cross-language test design, coverage, fixture, determinism, and test-layer guidance.
- Wire testing guidance into review, issue, validation, PR, and language-standard workflows where it changes behavior.
- Trim duplicated generic testing guidance from Go, Ruby, and shell convention references while keeping language-specific idioms.

## Why

- Keep test authoring and review policy consistent across languages without duplicating the same rules in every language reference.
- Preserve language-specific testing details while making the shared public-interface, edge-case, readability, and descriptive-failure expectations easier to apply.

## Testing

- `make lint` - passed
- `make sec-lint` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
