### PR TITLE
feat(skills): clarify assertion failure guidance

### DIFF
--- a/skills/testing-standards/SKILL.md
+++ b/skills/testing-standards/SKILL.md
@@ -27,6 +27,7 @@ description: Applies language-agnostic test design, coverage, fixtures, determin
 - Keep tests deterministic: avoid uncontrolled network, wall-clock time, random data, ordering assumptions, real home directories, and shared mutable state.
 - Structure tests so the setup, action, and assertion are easy to follow; use Arrange-Act-Assert or Given-When-Then when the repository does not already have a clearer local pattern.
 - Make failures obvious and descriptive. Avoid bare assertions such as `expected true but got false`; include the case, input, expected behavior, and observed behavior when the assertion framework does not do so clearly.
+- For repeated low-information assertions, do not rely only on generic framework output such as `Should be false`, `expected true but got false`, or `expected 2, got 1`. Add a short assertion message or use named subtests so the failure identifies the specific scenario. This applies especially to repeated boolean and numeric assertions.
 - Keep tests readable. Add small helpers, fixtures, builders, or assertions when they make behavior easier to read, but avoid abstractions that hide the scenario being tested.
 - Use broader suites for shared infrastructure, compatibility-sensitive behavior, release-sensitive behavior, or changes that cross package, command, or service boundaries.
 - Do not add behavioral tests for docs-only or formatting-only changes; run relevant lint, docs, or formatting validation when available.


### PR DESCRIPTION
## What

- Clarify that repeated low-information assertions should use assertion messages or named subtests so failures identify the specific scenario.

## Why

- Make the testing guidance more actionable for repeated boolean and numeric assertions where default framework output can be too vague.

## Testing

- `make lint` - passed
- `make sec-lint` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
