### PR TITLE
feat(skills): document assertion scan rules

### DIFF
--- a/skills/go-standards/references/conventions.md
+++ b/skills/go-standards/references/conventions.md
@@ -20,6 +20,7 @@ Use this reference when working in Go repositories.
 - Follow `$testing-standards` for cross-language test design, coverage, fixtures, determinism, and test-layer decisions.
 - Infer the project type from existing tests and CI: Go libraries commonly use unit and integration tests, while services in this ecosystem may rely on Cucumber feature flows around the service.
 - In this repository ecosystem, prefer `github.com/stretchr/testify/require` when adding assertion-based tests unless the package already uses a different local pattern.
+- When changing Go tests, scan changed `require.True`, `require.False`, `require.Equal`, `require.EqualValues`, `require.Less`, and `require.LessOrEqual` calls. Repeated or scenario-sensitive boolean and numeric assertions should include a message unless the test or subtest name already makes the behavior obvious.
 - Prefer external test packages named `<package>_test` when the behavior can be exercised through the public interface.
 - Keep test cases and test functions first in the file. Place fakes, stubs, spies, mock implementations, and helper types after the tests at the bottom of the file.
 

--- a/skills/ruby-standards/references/conventions.md
+++ b/skills/ruby-standards/references/conventions.md
@@ -19,6 +19,7 @@ Use this reference when working in Ruby repositories.
 - Follow `$testing-standards` for cross-language test design, coverage, fixtures, determinism, and test-layer decisions.
 - Infer the project type from existing tests and CI: Ruby libraries commonly use unit and integration tests such as RSpec, while services in this ecosystem commonly use Cucumber feature flows.
 - Match the repository's established Ruby test, feature, helper, assertion, and naming idioms.
+- When changing RSpec tests, scan changed boolean and numeric expectations such as `be(true)`, `be(false)`, `eq(...)`, comparison matchers, and count/status expectations. Repeated or scenario-sensitive expectations should have descriptive example names, contexts, or failure messages unless the surrounding example already makes the behavior obvious.
 
 ## External Style References
 

--- a/skills/testing-standards/SKILL.md
+++ b/skills/testing-standards/SKILL.md
@@ -16,6 +16,7 @@ description: Applies language-agnostic test design, coverage, fixtures, determin
 7. Preserve the repository's existing test framework, fixture layout, helper style, assertion idioms, and naming patterns unless the task explicitly changes testing infrastructure.
 8. Pair with the relevant language standard skill for language-specific idioms, and with `change-validation` for selecting or reporting commands.
 9. If another testing-focused skill applies, use this skill for cross-language test policy and the other skill only for specialized language, framework, or library details; this skill's cross-language rules take precedence unless the human or repository instructions explicitly say otherwise.
+10. Before finishing test changes or reviews, scan changed tests for repeated boolean or numeric assertions whose default failure output would not identify the behavior under test; add named subtests or assertion messages where needed.
 
 ## Principles
 


### PR DESCRIPTION
## What

- Add a shared finishing check for repeated boolean and numeric assertions whose default failure output would not identify the behavior under test.
- Add Go/Testify guidance for changed `require.*` assertions that may need messages or named subtests.
- Add Ruby/RSpec guidance for changed boolean, numeric, count, and status expectations that may need clearer examples, contexts, or messages.

## Why

- Make the testing guidance more actionable for low-information assertion failures while preserving local test style and avoiding unnecessary messages when names already explain the scenario.

## Testing

- `make lint` - passed
- `make sec-lint` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
