### PR TITLE
feat(skills): honor repository command surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,14 +51,15 @@ display name, short description, or default prompt became stale.
 
 Common composition:
 
-- `review-pr` orchestrates PR preparation with `change-validation`, relevant
-  language standards, `code-review`, summary drafting, and the review target.
+- `review-pr` orchestrates PR preparation with `project-workflow`,
+  `change-validation`, relevant language standards, `code-review`, summary
+  drafting, and the review target.
 - `code-issues` orchestrates a two-phase code-issue workflow: aggregate confirmed
-  `code-review` and `security-audit` findings into `ISSUES.md`, then implement
-  agreed fixes one code issue at a time.
+  `project-workflow`, `code-review`, and `security-audit` findings into
+  `ISSUES.md`, then implement agreed fixes one code issue at a time.
 - `test-gaps` orchestrates a two-phase test-gap workflow: aggregate confirmed
-  missing or weak test coverage into `ISSUES.md`, then implement agreed test
-  fixes gap by gap.
+  `project-workflow` context and missing or weak test coverage into
+  `ISSUES.md`, then implement agreed test fixes gap by gap.
 - `code-review` conditionally consults `security-audit` for security-sensitive
   review scope while keeping the review findings format.
 - `security-audit` pairs with `change-safety` for code changes and
@@ -67,6 +68,8 @@ Common composition:
   `change-validation` for command selection.
 - `project-workflow` covers command discovery, CI expectations, downstream
   `./bin` wiring, and shared Makefile fragment behavior.
+- `change-validation` should use `project-workflow` context before selecting
+  validation commands for orchestrated workflows.
 
 ## Quick commands (this repo)
 
@@ -88,6 +91,31 @@ From this repository root:
   - `make sec-lint` (runs Trivy over the repository)
 
 CI runs (CircleCI): `make dep`, `make clean-dep`, `make scripts-lint`, `make docker-lint`, `make lint`, `make sec-lint` (see `.circleci/config.yml`).
+
+## Command execution policy
+
+- Treat this repository's Makefile, reusable make fragments, and CI
+  configuration as the source of truth for setup, lint, test, security,
+  benchmark, and review commands.
+- Prefer `make` targets and documented repository entry points over direct tool
+  invocations, even when a direct command appears equivalent.
+- Run commands from the repository root unless the Makefile, script, or task
+  explicitly requires another working directory.
+- Use the user's configured shell environment for command execution. If a
+  command fails because a tool is missing, an old version is found, or `PATH`
+  differs from the user's normal terminal, treat that as an environment
+  mismatch or validation gap, not as evidence that the repository command is
+  wrong.
+- Do not replace a Makefile target with guessed direct commands just because the
+  agent environment cannot find the same tools as the user's shell.
+- When diagnosing command-environment mismatches, check the command surface
+  first, then inspect `command -v <tool>`, `<tool> --version`, `SHELL`, and
+  `PATH` as diagnostics only.
+- In this repository and downstream repos that vendor it as `./bin`, `make`
+  targets are the preferred validation interface. If `make` reports an
+  unexpected tool or version problem in the agent environment but works in the
+  user's shell, report the mismatch and keep the Makefile target as the intended
+  command.
 
 ## Tooling dependencies (observed)
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -6,14 +6,15 @@ checks, and findings.
 
 ## Common Composition
 
-- `review-pr` orchestrates PR preparation with `change-validation`, relevant
-  language standards, `code-review`, summary drafting, and the review target.
+- `review-pr` orchestrates PR preparation with `project-workflow`,
+  `change-validation`, relevant language standards, `code-review`, summary
+  drafting, and the review target.
 - `code-issues` orchestrates a two-phase code-issue workflow: first aggregate confirmed
-  `code-review` and `security-audit` findings into `ISSUES.md`, then implement
-  agreed fixes one code issue at a time.
+  `project-workflow`, `code-review`, and `security-audit` findings into
+  `ISSUES.md`, then implement agreed fixes one code issue at a time.
 - `test-gaps` orchestrates a two-phase test-gap workflow: first aggregate
-  confirmed missing or weak test coverage into `ISSUES.md`, then implement
-  agreed test fixes one gap at a time.
+  `project-workflow` context and confirmed missing or weak test coverage into
+  `ISSUES.md`, then implement agreed test fixes one gap at a time.
 - `code-review` performs the review pass and conditionally consults
   `security-audit` for security-sensitive scope.
 - `security-audit` pairs with `change-safety` for code changes and
@@ -23,6 +24,8 @@ checks, and findings.
   `change-validation` for command selection.
 - `project-workflow` covers command discovery, CI expectations, downstream
   `./bin` wiring, and shared Makefile fragment behavior.
+- `change-validation` should use `project-workflow` context before selecting
+  validation commands for orchestrated workflows.
 - Language standards pair with `change-validation` for check selection and
   `change-safety` when public APIs, commands, or documented behavior change.
 

--- a/skills/change-validation/references/check-selection.md
+++ b/skills/change-validation/references/check-selection.md
@@ -13,7 +13,18 @@ Use this reference when choosing which checks to run.
 - Ask for permission before running checks that require SSH credentials, GitHub auth, registry auth, cloning, pushing, publishing, opening PRs, or updating remote state.
 - Expand from targeted checks to broader checks only when the task or risk justifies it.
 - Never imply a check ran if the wrapper no-op'd because a dependency was missing.
-- Report network or credential failures as environment or validation gaps rather than code failures.
+- Report network, credential, shell environment, `PATH`, or tool-version failures as environment or validation gaps rather than code failures.
+- Keep the repository-defined command as the intended validation command when the agent environment differs from the user's normal shell.
+
+## Command Execution Environment
+
+- Treat the repository Makefile and CI configuration as the source of truth for setup, lint, test, security, benchmark, and review commands.
+- Prefer `make` targets and documented repository entry points over direct tool invocations, even when a direct command appears equivalent.
+- Run commands from the repository root unless the Makefile, script, or task explicitly requires another working directory.
+- Use the user's configured shell environment for command execution. If a command fails because a tool is missing, an old version is found, or `PATH` differs from the user's normal terminal, treat that as an environment mismatch or validation gap, not as evidence that the repository command is wrong.
+- Do not replace a Makefile target with guessed direct commands just because the agent environment cannot find the same tools as the user's shell.
+- When diagnosing command-environment mismatches, check the command surface first, then inspect `command -v <tool>`, `<tool> --version`, `SHELL`, and `PATH` as diagnostics only.
+- In this shared `bin` repo and downstream repos that vendor it as `./bin`, `make` targets are the preferred validation interface. If `make` reports an unexpected tool or version problem in the agent environment but works in the user's shell, report the mismatch and keep the Makefile target as the intended command.
 
 ## Typical Validation Order
 

--- a/skills/code-issues/SKILL.md
+++ b/skills/code-issues/SKILL.md
@@ -17,27 +17,28 @@ Do not combine the two modes in one pass.
 1. Identify the requested package or folder scope. If no scope is provided, stop and ask for the package or folder.
 2. Use `ISSUES.md` in the requested package or folder as the review ledger, for example `<package/folder>/ISSUES.md`.
 3. If `ISSUES.md` already exists in the requested package or folder, stop. Tell the user the existing scoped ledger must be resolved first, or the human must delete that scoped `ISSUES.md` before a new find pass there.
-4. Treat `Find $code-issues in <package/folder>` or `Find code issues in <package/folder>` as the user's explicit request to delegate review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
-5. Use sub-agents for Find mode whenever the active runtime provides them and the runtime permits delegation for the request. Do not treat sub-agents as optional based on scope size, and do not perform the find review locally first.
-6. Do not claim that extra delegation wording is needed before launching review agents. The Find mode invocation is the explicit delegation request.
-7. If the runtime still requires an approval step before launching sub-agents, ask once with the concrete read-only agent plan. If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
-8. Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, or other non-read-only validation. Without that permission, agents should inspect code only and suggest validation.
-9. Exclude generated files and folders, vendored dependencies, caches, build output, and generated lockfile churn unless the requested scope is explicitly about them.
-10. Launch at least one sub-agent covering the requested root package/folder. Split agent assignments across:
+4. Use `$project-workflow` to discover repository entrypoints, CI expectations, and `./bin` wiring before planning review agents or validation.
+5. Treat `Find $code-issues in <package/folder>` or `Find code issues in <package/folder>` as the user's explicit request to delegate review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
+6. Use sub-agents for Find mode whenever the active runtime provides them and the runtime permits delegation for the request. Do not treat sub-agents as optional based on scope size, and do not perform the find review locally first.
+7. Do not claim that extra delegation wording is needed before launching review agents. The Find mode invocation is the explicit delegation request.
+8. If the runtime still requires an approval step before launching sub-agents, ask once with the concrete read-only agent plan. If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
+9. Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, or other non-read-only validation. Without that permission, agents should inspect code only and suggest validation.
+10. Exclude generated files and folders, vendored dependencies, caches, build output, and generated lockfile churn unless the requested scope is explicitly about them.
+11. Launch at least one sub-agent covering the requested root package/folder. Split agent assignments across:
    - files directly under the requested root package/folder.
    - each first-level subpackage/subfolder under the requested root.
-11. Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough and accurate `$code-review` and `$security-audit` for its assigned scope, using `$testing-standards` for concrete missing-coverage or weak-test analysis.
-12. Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
-13. Wait for all agents to finish before aggregating results.
-14. Deduplicate overlapping findings and resolve conflicting agent conclusions by re-checking the code directly.
-15. Confirm each candidate finding against the code before recording it. Findings must be concrete bugs, security issues, compatibility breaks, or violated public contracts with user-visible impact.
-16. Do not record standalone missing, weak, flaky, misleading, or wrong-layer tests as code issues unless they are tied to a confirmed bug, security issue, compatibility break, or violated public contract. Use `$test-gaps` for standalone missing or weak test coverage passes.
-17. Do not report optional regression tests, unused convenience aliases, API symmetry, or documentation polish as findings by themselves. List them only as testing gaps or optional follow-up notes when relevant.
-18. If no confirmed code issues are found, report that no code issues were found and do not create `ISSUES.md`.
-19. If confirmed code issues are found, write all findings to the scoped `ISSUES.md` before making any fixes.
-20. Assign every finding a unique ID for the session in the form `ISSUE-<number>`.
-21. Present the scoped `ISSUES.md` and a proposed fix plan to the user.
-22. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
+12. Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough and accurate `$code-review` and `$security-audit` for its assigned scope, using `$testing-standards` for concrete missing-coverage or weak-test analysis and `$change-validation` for likely validation commands.
+13. Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
+14. Wait for all agents to finish before aggregating results.
+15. Deduplicate overlapping findings and resolve conflicting agent conclusions by re-checking the code directly.
+16. Confirm each candidate finding against the code before recording it. Findings must be concrete bugs, security issues, compatibility breaks, or violated public contracts with user-visible impact.
+17. Do not record standalone missing, weak, flaky, misleading, or wrong-layer tests as code issues unless they are tied to a confirmed bug, security issue, compatibility break, or violated public contract. Use `$test-gaps` for standalone missing or weak test coverage passes.
+18. Do not report optional regression tests, unused convenience aliases, API symmetry, or documentation polish as findings by themselves. List them only as testing gaps or optional follow-up notes when relevant.
+19. If no confirmed code issues are found, report that no code issues were found and do not create `ISSUES.md`.
+20. If confirmed code issues are found, write all findings to the scoped `ISSUES.md` before making any fixes.
+21. Assign every finding a unique ID for the session in the form `ISSUE-<number>`.
+22. Present the scoped `ISSUES.md` and a proposed fix plan to the user.
+23. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
 
 ## `ISSUES.md` Format
 
@@ -69,23 +70,24 @@ Keep optional follow-up notes separate from findings:
 1. Identify the requested package or folder scope. If no scope is provided, stop and ask for the package or folder.
 2. Read `ISSUES.md` in the requested package or folder first and treat it as the working review ledger.
    If scoped `ISSUES.md` does not exist, stop and ask whether to run Find mode first for that scope.
-3. Work through code issues sequentially by ID unless the human explicitly names a different issue.
-4. For each issue, first present:
+3. Use `$project-workflow` before proposing or running validation so repository entrypoints, CI expectations, and `./bin` wiring are current.
+4. Work through code issues sequentially by ID unless the human explicitly names a different issue.
+5. For each issue, first present:
    - the issue ID and current evidence.
    - the proposed solution.
    - compatibility or behavior tradeoffs.
    - the intended validation.
-5. Stop after proposing the solution. Do not edit code, update `ISSUES.md`, or start validation until the human explicitly agrees to that issue's solution.
-6. Ask questions when behavior, compatibility, security, validation, or user intent is ambiguous. Treat silence or a broad "implement code issues" request as permission to start the proposal workflow, not as permission to code.
-7. Once the solution for the current issue is agreed, implement only that issue with the smallest safe change.
-8. Use `$testing-standards` when deciding whether to add or update regression tests for the fix.
-9. Validate the fix using checks appropriate to the changed code.
-10. Report the result for that issue and ask the human to verify and explicitly say `ISSUE-<number> is done`.
-11. Do not move to the next issue until the human says `ISSUE-<number> is done`.
-12. After the human confirms an issue is done, remove that issue from scoped `ISSUES.md`. If an issue is deemed invalid or not actually a code issue, remove it only after explaining why and getting human agreement.
-13. Then propose the solution for the next remaining issue and repeat the same agreement gate.
-14. Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
-15. Summarize what changed, which code issues were resolved or dismissed, and which validation steps were run or still need to be carried out by the human.
+6. Stop after proposing the solution. Do not edit code, update `ISSUES.md`, or start validation until the human explicitly agrees to that issue's solution.
+7. Ask questions when behavior, compatibility, security, validation, or user intent is ambiguous. Treat silence or a broad "implement code issues" request as permission to start the proposal workflow, not as permission to code.
+8. Once the solution for the current issue is agreed, implement only that issue with the smallest safe change.
+9. Use `$testing-standards` when deciding whether to add or update regression tests for the fix.
+10. Validate the fix using checks appropriate to the changed code.
+11. Report the result for that issue and ask the human to verify and explicitly say `ISSUE-<number> is done`.
+12. Do not move to the next issue until the human says `ISSUE-<number> is done`.
+13. After the human confirms an issue is done, remove that issue from scoped `ISSUES.md`. If an issue is deemed invalid or not actually a code issue, remove it only after explaining why and getting human agreement.
+14. Then propose the solution for the next remaining issue and repeat the same agreement gate.
+15. Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
+16. Summarize what changed, which code issues were resolved or dismissed, and which validation steps were run or still need to be carried out by the human.
 
 ## References
 
@@ -93,4 +95,5 @@ Keep optional follow-up notes separate from findings:
 - Use `$security-audit` for security-sensitive review scope.
 - Use `$testing-standards` when deciding or reviewing regression coverage.
 - Use `$test-gaps` instead when the user asks for a standalone missing or weak test coverage pass.
+- Use `$project-workflow` for repository command discovery, CI expectations, and `./bin` wiring before review planning or validation.
 - Use `$change-validation` when selecting validation commands for implemented fixes.

--- a/skills/project-workflow/references/bin-submodule.md
+++ b/skills/project-workflow/references/bin-submodule.md
@@ -20,6 +20,15 @@ Use this reference when you need to establish context quickly and discover how a
 - When `help.mak` is included, use `make` or `make help` as the quickest way to discover the command surface.
 - When planning work, note whether the repository exposes setup targets such as `dep` so you can use them later when the task moves from discovery to edits or validation.
 
+## Command Execution Environment
+
+- Treat the repository Makefile and CI configuration as the source of truth for setup, lint, test, security, benchmark, and review commands.
+- Prefer `make` targets and documented repository entry points over direct tool invocations, even when a direct command appears equivalent.
+- Run commands from the repository root unless the Makefile, script, or task explicitly requires another working directory.
+- Use the user's configured shell environment for command execution. If a command fails because a tool is missing, an old version is found, or `PATH` differs from the user's normal terminal, treat that as an environment mismatch or validation gap, not as evidence that the repository command is wrong.
+- Do not replace a Makefile target with guessed direct commands just because the agent environment cannot find the same tools as the user's shell.
+- When diagnosing command-environment mismatches, check the command surface first, then inspect `command -v <tool>`, `<tool> --version`, `SHELL`, and `PATH` as diagnostics only.
+
 ## Output Format
 
 When workflow discovery is the final response, use exactly this Markdown structure and do not add, remove, rename, or reorder sections:
@@ -56,4 +65,5 @@ When workflow discovery is the final response, use exactly this Markdown structu
 - Use `make-fragments.md` to interpret included shared fragments after checking the root `Makefile`; do not let the fragment map replace the repository's actual command surface.
 - Validate path-sensitive behavior from the consuming repository root, not from inside the `bin` submodule.
 - Be careful with targets that resolve helper paths through `$(PWD)/bin/...`; they may work in a downstream repo and fail inside the `bin` repo itself.
+- If a Make target reports an unexpected tool or version problem in the agent environment but works in the user's shell, report the mismatch and keep the Makefile target as the intended command.
 - Be careful with `start` and `stop` helpers because they may depend on a sibling `../docker` checkout or SSH access.

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -10,37 +10,39 @@ description: Reviews, validates, commits, force-pushes, and opens a draft pull r
 1. Inspect the changed paths from the working tree first; if the working tree is clean, inspect the latest commit.
 2. Confirm the user explicitly asked in the current request to commit, push, update, or open a review PR. If not, do not run `make review`, `make push`, or any equivalent push/PR update command.
 3. If new changes would make an existing PR description, review comment, or previously drafted summary obsolete, flag that and ask whether the user wants the PR updated before pushing anything.
-4. Make the remote-write behavior of `make review` explicit before running it: the target commits, force-pushes, and opens a draft PR.
-5. Use `$change-validation` to select and run credible validation for the full change before `make review`; language-specific standards may refine that validation.
-6. If the changed paths include Go code, Go tests, Go modules, Go docs, or Go tooling behavior, also use `$go-standards`.
-7. If the changed paths include Ruby code, Ruby tests/features, Gemfiles, RuboCop config, Ruby docs, or Ruby tooling behavior, also use `$ruby-standards`.
-8. If the changed paths include shell scripts, Bash helpers, ShellCheck config/directives, shell docs, or script behavior, also use `$shell-standards`.
-9. If the changed paths include tests, test helpers, fixtures, or changes that raise test coverage or test-design questions, also use `$testing-standards`.
-10. Use `$code-review` to inspect the current change before drafting PR text.
-11. Resolve any blocking review findings before continuing; if findings remain intentionally unresolved, call them out in the PR summary.
-12. If `$code-review` reports security findings or security validation gaps, resolve them or document them in the PR summary before `make review`.
-13. Read `references/summary-format.md`, then draft a lowercase, unprefixed `msg` and multiline Markdown `desc` from the current working tree.
-14. Follow the commit-subject rules: `make review` adds the branch-derived `type(scope):` prefix, so treat branch words as routing metadata rather than message source material and do not repeat the type or scope in `msg`.
-15. Keep `desc` in the summary format, including honest testing details.
-16. When attribution is appropriate or requested, append this footer to the summary instead of a `Co-authored-by:` trailer:
+4. Use `$project-workflow` before validation or `make review` so repository entrypoints, CI expectations, and `./bin` wiring are discovered first.
+5. Make the remote-write behavior of `make review` explicit before running it: the target commits, force-pushes, and opens a draft PR.
+6. Use `$change-validation` to select and run credible validation for the full change before `make review`; language-specific standards may refine that validation.
+7. If the changed paths include Go code, Go tests, Go modules, Go docs, or Go tooling behavior, also use `$go-standards`.
+8. If the changed paths include Ruby code, Ruby tests/features, Gemfiles, RuboCop config, Ruby docs, or Ruby tooling behavior, also use `$ruby-standards`.
+9. If the changed paths include shell scripts, Bash helpers, ShellCheck config/directives, shell docs, or script behavior, also use `$shell-standards`.
+10. If the changed paths include tests, test helpers, fixtures, or changes that raise test coverage or test-design questions, also use `$testing-standards`.
+11. Use `$code-review` to inspect the current change before drafting PR text.
+12. Resolve any blocking review findings before continuing; if findings remain intentionally unresolved, call them out in the PR summary.
+13. If `$code-review` reports security findings or security validation gaps, resolve them or document them in the PR summary before `make review`.
+14. Read `references/summary-format.md`, then draft a lowercase, unprefixed `msg` and multiline Markdown `desc` from the current working tree.
+15. Follow the commit-subject rules: `make review` adds the branch-derived `type(scope):` prefix, so treat branch words as routing metadata rather than message source material and do not repeat the type or scope in `msg`.
+16. Keep `desc` in the summary format, including honest testing details.
+17. When attribution is appropriate or requested, append this footer to the summary instead of a `Co-authored-by:` trailer:
 
 ```text
 AI-assisted-by: [Codex](https://openai.com/codex/)
 ```
 
-17. Run the review target with the drafted values:
+18. Run the review target with the drafted values:
 
 ```bash
 make msg="unprefixed subject" desc="summary" review
 ```
 
-18. Pass `desc` as the multiline Markdown summary; do not flatten the summary into a single line.
-19. Read `references/output-format.md`, then report the result using that exact structure; do not add, remove, rename, or reorder sections.
+19. Pass `desc` as the multiline Markdown summary; do not flatten the summary into a single line.
+20. Read `references/output-format.md`, then report the result using that exact structure; do not add, remove, rename, or reorder sections.
 
 ## References
 
 - Read `references/summary-format.md` before drafting the `msg` and `desc` values.
 - Read `references/output-format.md` before producing the final review PR report.
+- Use `$project-workflow` for repository command discovery, CI expectations, and `./bin` wiring before validation and `make review`.
 
 ## Notes
 

--- a/skills/test-gaps/SKILL.md
+++ b/skills/test-gaps/SKILL.md
@@ -17,27 +17,28 @@ Do not combine the two modes in one pass.
 1. Identify the requested package or folder scope. If no scope is provided, stop and ask for the package or folder.
 2. Use `ISSUES.md` in the requested package or folder as the review ledger, for example `<package/folder>/ISSUES.md`.
 3. If `ISSUES.md` already exists in the requested package or folder, stop. Tell the user the existing scoped ledger must be resolved first, or the human must delete that scoped `ISSUES.md` before a new find pass there.
-4. Treat `Find $test-gaps in <package/folder>` or `Find test gaps in <package/folder>` as the user's explicit request to delegate test-gap review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
-5. Use sub-agents for Find mode whenever the active runtime provides them and the runtime permits delegation for the request. Do not treat sub-agents as optional based on scope size, and do not perform the test-gap review locally first.
-6. Do not claim that extra delegation wording is needed before launching review agents. The Find mode invocation is the explicit delegation request.
-7. If the runtime still requires an approval step before launching sub-agents, ask once with the concrete read-only agent plan. If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
-8. Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, or other non-read-only validation. Without that permission, agents should inspect code and tests only and suggest validation.
-9. Exclude generated files and folders, vendored dependencies, caches, build output, and generated lockfile churn unless the requested scope is explicitly about them.
-10. Launch at least one sub-agent covering the requested root package/folder. Split agent assignments across:
+4. Use `$project-workflow` to discover repository entrypoints, CI expectations, and `./bin` wiring before planning review agents or validation.
+5. Treat `Find $test-gaps in <package/folder>` or `Find test gaps in <package/folder>` as the user's explicit request to delegate test-gap review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
+6. Use sub-agents for Find mode whenever the active runtime provides them and the runtime permits delegation for the request. Do not treat sub-agents as optional based on scope size, and do not perform the test-gap review locally first.
+7. Do not claim that extra delegation wording is needed before launching review agents. The Find mode invocation is the explicit delegation request.
+8. If the runtime still requires an approval step before launching sub-agents, ask once with the concrete read-only agent plan. If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
+9. Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, or other non-read-only validation. Without that permission, agents should inspect code and tests only and suggest validation.
+10. Exclude generated files and folders, vendored dependencies, caches, build output, and generated lockfile churn unless the requested scope is explicitly about them.
+11. Launch at least one sub-agent covering the requested root package/folder. Split agent assignments across:
    - files directly under the requested root package/folder.
    - each first-level subpackage/subfolder under the requested root.
-11. Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough and accurate `$testing-standards` review for its assigned scope, pairing with relevant language standards and `$change-validation` for likely validation commands.
-12. Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
-13. Wait for all agents to finish before aggregating results.
-14. Deduplicate overlapping findings and resolve conflicting agent conclusions by re-checking the code and tests directly.
-15. Confirm each candidate gap against the code and existing tests before recording it. Gaps must be concrete missing, weak, misleading, flaky, or wrong-layer coverage with credible risk to changed behavior, public contracts, compatibility, release-sensitive workflows, or documented command/API behavior.
-16. Do not record confirmed production bugs, security issues, compatibility breaks, or violated public contracts as test gaps. If such broken behavior is discovered during review, report it as out of scope for the test-gap ledger and recommend `$code-issues`; use this skill when the unprotected or poorly protected behavior is the finding.
-17. Do not report optional nice-to-have tests, private implementation coverage, arbitrary coverage percentage improvements, style preferences, or docs-only validation as findings by themselves. List them only as optional follow-up notes when relevant.
-18. If no confirmed test gaps are found, report that no test gaps were found and do not create `ISSUES.md`.
-19. If confirmed test gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
-20. Assign every finding a unique ID for the session in the form `TEST-<number>`.
-21. Present the scoped `ISSUES.md` and a proposed test-fix plan to the user.
-22. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
+12. Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough and accurate `$testing-standards` review for its assigned scope, pairing with relevant language standards and `$change-validation` for likely validation commands.
+13. Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
+14. Wait for all agents to finish before aggregating results.
+15. Deduplicate overlapping findings and resolve conflicting agent conclusions by re-checking the code and tests directly.
+16. Confirm each candidate gap against the code and existing tests before recording it. Gaps must be concrete missing, weak, misleading, flaky, or wrong-layer coverage with credible risk to changed behavior, public contracts, compatibility, release-sensitive workflows, or documented command/API behavior.
+17. Do not record confirmed production bugs, security issues, compatibility breaks, or violated public contracts as test gaps. If such broken behavior is discovered during review, report it as out of scope for the test-gap ledger and recommend `$code-issues`; use this skill when the unprotected or poorly protected behavior is the finding.
+18. Do not report optional nice-to-have tests, private implementation coverage, arbitrary coverage percentage improvements, style preferences, or docs-only validation as findings by themselves. List them only as optional follow-up notes when relevant.
+19. If no confirmed test gaps are found, report that no test gaps were found and do not create `ISSUES.md`.
+20. If confirmed test gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
+21. Assign every finding a unique ID for the session in the form `TEST-<number>`.
+22. Present the scoped `ISSUES.md` and a proposed test-fix plan to the user.
+23. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
 
 ## `ISSUES.md` Format
 
@@ -70,26 +71,28 @@ Keep optional follow-up notes separate from findings:
 1. Identify the requested package or folder scope. If no scope is provided, stop and ask for the package or folder.
 2. Read `ISSUES.md` in the requested package or folder first and treat it as the working test-gap ledger.
    If scoped `ISSUES.md` does not exist, stop and ask whether to run Find mode first for that scope.
-3. Work through findings sequentially by ID unless the human explicitly names a different finding.
-4. For each finding, first present:
+3. Use `$project-workflow` before proposing or running validation so repository entrypoints, CI expectations, and `./bin` wiring are current.
+4. Work through findings sequentially by ID unless the human explicitly names a different finding.
+5. For each finding, first present:
    - the issue ID and current evidence.
    - the proposed test solution.
    - test-layer, fixture, determinism, compatibility, or maintenance tradeoffs.
    - the intended validation.
-5. Stop after proposing the solution. Do not edit code, update `ISSUES.md`, or start validation until the human explicitly agrees to that finding's solution.
-6. Ask questions when behavior, compatibility, test layer, fixture strategy, validation, or user intent is ambiguous. Treat silence or a broad "implement test gaps" request as permission to start the proposal workflow, not as permission to code.
-7. Once the solution for the current finding is agreed, implement only that finding with the smallest clear test change.
-8. Use `$testing-standards` for test design and pair with the relevant language standard for local idioms.
-9. Validate the test change using checks appropriate to the changed tests.
-10. Report the result for that finding and ask the human to verify and explicitly say `TEST-<number> is done`.
-11. Do not move to the next finding until the human says `TEST-<number> is done`.
-12. After the human confirms a finding is done, remove that finding from scoped `ISSUES.md`. If a finding is deemed invalid or not actually a test gap, remove it only after explaining why and getting human agreement.
-13. Then propose the solution for the next remaining finding and repeat the same agreement gate.
-14. Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
-15. Summarize what changed, which test gaps were resolved or dismissed, and which validation steps were run or still need to be carried out by the human.
+6. Stop after proposing the solution. Do not edit code, update `ISSUES.md`, or start validation until the human explicitly agrees to that finding's solution.
+7. Ask questions when behavior, compatibility, test layer, fixture strategy, validation, or user intent is ambiguous. Treat silence or a broad "implement test gaps" request as permission to start the proposal workflow, not as permission to code.
+8. Once the solution for the current finding is agreed, implement only that finding with the smallest clear test change.
+9. Use `$testing-standards` for test design and pair with the relevant language standard for local idioms.
+10. Validate the test change using checks appropriate to the changed tests.
+11. Report the result for that finding and ask the human to verify and explicitly say `TEST-<number> is done`.
+12. Do not move to the next finding until the human says `TEST-<number> is done`.
+13. After the human confirms a finding is done, remove that finding from scoped `ISSUES.md`. If a finding is deemed invalid or not actually a test gap, remove it only after explaining why and getting human agreement.
+14. Then propose the solution for the next remaining finding and repeat the same agreement gate.
+15. Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
+16. Summarize what changed, which test gaps were resolved or dismissed, and which validation steps were run or still need to be carried out by the human.
 
 ## References
 
 - Use `$testing-standards` for cross-language test quality, coverage, fixtures, determinism, and test-layer decisions.
 - Use relevant language standards for local test idioms.
+- Use `$project-workflow` for repository command discovery, CI expectations, and `./bin` wiring before review planning or validation.
 - Use `$change-validation` when selecting validation commands for implemented test fixes.


### PR DESCRIPTION
## What

- Added command execution policy requiring agents to treat Makefile and CI entrypoints as source of truth.
- Wired project workflow discovery into PR, code issue, and test gap orchestration before validation.

## Why

- Prevent agents from replacing repository targets with guessed direct commands when their shell or PATH differs.
- Ensure downstream repos that vendor this shared bin guidance preserve user shell and ./bin wiring expectations.

## Testing

- `git diff --check` - passed
- `make dep` - passed
- `make clean-dep` - passed
- `make scripts-lint` - passed
- `make docker-lint` - passed
- `make lint` - passed
- `make sec-lint` - passed
