### PR TITLE
feat(skills): route documentation gaps through dedicated workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ skill instead of one broad default:
 - `security-audit`: security reviews, vulnerability checks, unsafe shell/filesystem/network/auth inspection, and Go/Ruby/shell audit guidance.
 - `code-issues`: find confirmed code issues into `ISSUES.md`, then implement agreed fixes one code issue at a time.
 - `test-gaps`: find confirmed missing or weak tests into `ISSUES.md`, then implement agreed test fixes gap by gap.
+- `docs-gaps`: find confirmed missing, stale, or misleading docs/comments into `ISSUES.md`, then implement agreed docs fixes gap by gap.
 - `review-pr`: create a commit, force-push, and open a draft PR with a generated summary.
 - `shell-standards`: Bash scripting, ShellCheck, text processing, directory
   scope, and function documentation conventions.
@@ -60,6 +61,10 @@ Common composition:
 - `test-gaps` orchestrates a two-phase test-gap workflow: aggregate confirmed
   `project-workflow` context and missing or weak test coverage into
   `ISSUES.md`, then implement agreed test fixes gap by gap.
+- `docs-gaps` orchestrates a two-phase documentation-gap workflow: aggregate
+  confirmed `project-workflow` context and missing, stale, or misleading
+  README, docs, examples, comments, and docstrings into `ISSUES.md`, then
+  implement agreed documentation fixes gap by gap.
 - `code-review` conditionally consults `security-audit` for security-sensitive
   review scope while keeping the review findings format.
 - `security-audit` pairs with `change-safety` for code changes and

--- a/skills/README.md
+++ b/skills/README.md
@@ -15,6 +15,10 @@ checks, and findings.
 - `test-gaps` orchestrates a two-phase test-gap workflow: first aggregate
   `project-workflow` context and confirmed missing or weak test coverage into
   `ISSUES.md`, then implement agreed test fixes one gap at a time.
+- `docs-gaps` orchestrates a two-phase documentation-gap workflow: first
+  aggregate `project-workflow` context and confirmed README, docs, examples,
+  comments, and docstring gaps into `ISSUES.md`, then implement agreed
+  documentation fixes one gap at a time.
 - `code-review` performs the review pass and conditionally consults
   `security-audit` for security-sensitive scope.
 - `security-audit` pairs with `change-safety` for code changes and

--- a/skills/code-issues/SKILL.md
+++ b/skills/code-issues/SKILL.md
@@ -33,12 +33,13 @@ Do not combine the two modes in one pass.
 15. Deduplicate overlapping findings and resolve conflicting agent conclusions by re-checking the code directly.
 16. Confirm each candidate finding against the code before recording it. Findings must be concrete bugs, security issues, compatibility breaks, or violated public contracts with user-visible impact.
 17. Do not record standalone missing, weak, flaky, misleading, or wrong-layer tests as code issues unless they are tied to a confirmed bug, security issue, compatibility break, or violated public contract. Use `$test-gaps` for standalone missing or weak test coverage passes.
-18. Do not report optional regression tests, unused convenience aliases, API symmetry, or documentation polish as findings by themselves. List them only as testing gaps or optional follow-up notes when relevant.
-19. If no confirmed code issues are found, report that no code issues were found and do not create `ISSUES.md`.
-20. If confirmed code issues are found, write all findings to the scoped `ISSUES.md` before making any fixes.
-21. Assign every finding a unique ID for the session in the form `ISSUE-<number>`.
-22. Present the scoped `ISSUES.md` and a proposed fix plan to the user.
-23. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
+18. Do not record standalone missing, weak, stale, misleading, or wrong-location documentation, README, example, comment, or docstring gaps as code issues unless they reveal a confirmed bug, security issue, compatibility break, or violated public contract. Use `$docs-gaps` for standalone documentation review passes.
+19. Do not report optional regression tests, unused convenience aliases, API symmetry, or documentation polish as findings by themselves. List them only as testing gaps, docs gaps, or optional follow-up notes when relevant.
+20. If no confirmed code issues are found, report that no code issues were found and do not create `ISSUES.md`.
+21. If confirmed code issues are found, write all findings to the scoped `ISSUES.md` before making any fixes.
+22. Assign every finding a unique ID for the session in the form `ISSUE-<number>`.
+23. Present the scoped `ISSUES.md` and a proposed fix plan to the user.
+24. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
 
 ## `ISSUES.md` Format
 
@@ -95,5 +96,6 @@ Keep optional follow-up notes separate from findings:
 - Use `$security-audit` for security-sensitive review scope.
 - Use `$testing-standards` when deciding or reviewing regression coverage.
 - Use `$test-gaps` instead when the user asks for a standalone missing or weak test coverage pass.
+- Use `$docs-gaps` instead when the user asks for a standalone missing, stale, misleading, or weak documentation, README, example, comment, or docstring pass.
 - Use `$project-workflow` for repository command discovery, CI expectations, and `./bin` wiring before review planning or validation.
 - Use `$change-validation` when selecting validation commands for implemented fixes.

--- a/skills/docs-gaps/SKILL.md
+++ b/skills/docs-gaps/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: docs-gaps
+description: Finds concrete missing, weak, stale, or misleading documentation in a package or folder, including README files, user-facing docs, examples, and code comments/docstrings required by relevant language standards, records confirmed gaps in that scope's ISSUES.md, and later proposes and implements explicitly agreed documentation fixes gap by gap. Use when the user asks to find $docs-gaps in a package or folder, find docs gaps in a package or folder, implement $docs-gaps in a package or folder, or implement docs gaps in a package or folder.
+---
+
+# Docs Gaps
+
+Use this skill in two distinct modes:
+
+- **Find mode**: `Find $docs-gaps in <package/folder>` or `Find docs gaps in <package/folder>`.
+- **Implement mode**: `Implement $docs-gaps in <package/folder>` or `Implement docs gaps in <package/folder>`.
+
+Do not combine the two modes in one pass.
+
+## Find Mode
+
+1. Identify the requested package or folder scope. If no scope is provided, stop and ask for the package or folder.
+2. Use `ISSUES.md` in the requested package or folder as the review ledger, for example `<package/folder>/ISSUES.md`.
+3. If `ISSUES.md` already exists in the requested package or folder, stop. Tell the user the existing scoped ledger must be resolved first, or the human must delete that scoped `ISSUES.md` before a new find pass there.
+4. Use `$project-workflow` to discover repository entrypoints, CI expectations, documented commands, public APIs, examples, and `./bin` wiring before planning documentation review agents or validation.
+5. Treat `Find $docs-gaps in <package/folder>` or `Find docs gaps in <package/folder>` as the user's explicit request to delegate documentation review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
+6. Use sub-agents for Find mode whenever the active runtime provides them and the runtime permits delegation for the request. Do not treat sub-agents as optional based on scope size, and do not perform the docs-gap review locally first.
+7. Do not claim that extra delegation wording is needed before launching review agents. The Find mode invocation is the explicit delegation request.
+8. If the runtime still requires an approval step before launching sub-agents, ask once with the concrete read-only agent plan. If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
+9. Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, or other non-read-only validation. Without that permission, agents should inspect code and docs only and suggest validation.
+10. Exclude generated files and folders, vendored dependencies, caches, build output, generated API docs, and generated lockfile churn unless the requested scope is explicitly about them.
+11. Launch at least one sub-agent covering the requested root package/folder. Split agent assignments across:
+   - documentation files directly under the requested root package/folder.
+   - source files directly under the requested root package/folder whose comments or docstrings are in scope.
+   - each first-level subpackage/subfolder under the requested root.
+12. Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough documentation review for its assigned scope, pairing with relevant language standards (`$go-standards`, `$ruby-standards`, `$shell-standards`) before recording language-specific comment, docstring, or API documentation findings and `$change-validation` for likely validation commands.
+13. Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
+14. Wait for all agents to finish before aggregating results.
+15. Deduplicate overlapping findings and resolve conflicting agent conclusions by re-checking the code and docs directly.
+16. Confirm each candidate gap against the code, current docs, examples, and documented interfaces before recording it. Gaps must be concrete missing, weak, stale, misleading, or wrong-location documentation with credible risk to users, operators, maintainers, public APIs, documented command behavior, onboarding, setup, or contribution workflows.
+17. Do not record confirmed production bugs, security issues, compatibility breaks, or violated public contracts as docs gaps. If broken behavior is discovered during review, report it as out of scope for the docs-gap ledger and recommend `$code-issues`; use this skill when unclear, missing, stale, or misleading documentation is the finding.
+18. Do not record standalone missing, weak, flaky, misleading, or wrong-layer tests as docs gaps. Recommend `$test-gaps` when the unprotected behavior is the finding.
+19. Do not report arbitrary wording preferences, style nits, exhaustive private implementation comments, or optional documentation polish as findings by themselves. List them only as optional follow-up notes when relevant.
+20. If no confirmed docs gaps are found, report that no docs gaps were found and do not create `ISSUES.md`.
+21. If confirmed docs gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
+22. Assign every finding a unique ID for the session in the form `DOC-<number>`.
+23. Present the scoped `ISSUES.md` and a proposed documentation-fix plan to the user.
+24. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
+
+## Documentation Review Standards
+
+Use these standards to decide whether a documentation concern is concrete enough to record:
+
+- **README and project docs**: README files should quickly explain what the project does, why it is useful, how users get started, where to get help, and who maintains or contributes to it. Prefer root, `.github/`, or `docs/` README placement when GitHub rendering matters. Keep startup docs concise, current, structured with headings, and linked to deeper docs instead of burying long manuals in the README.
+- **Examples and commands**: Installation, setup, usage, Make targets, CLI examples, environment variables, and API examples should be copy-paste-ready when practical and aligned with real entrypoints.
+- **Code comments**: Comments should explain non-obvious intent, tradeoffs, invariants, unidiomatic choices, bug-workaround context, copied-code sources, and helpful external references. Do not demand comments that merely restate obvious code. If a clear comment cannot be written because the code itself is confused, recommend `$code-issues`.
+- **Language-specific docs**: Use the relevant standards skill for code comments, docstrings, public API docs, and language-specific examples before recording findings. Keep GoDoc details in `$go-standards`, RDoc details in `$ruby-standards`, and shell script/function comment rules in `$shell-standards`.
+
+## `ISSUES.md` Format
+
+Use this structure:
+
+```markdown
+# Issues
+
+## DOC-1: Short concrete title
+
+- Type: Docs Gap
+- Severity: Critical|High|Medium|Low
+- Scope: path/to/file-or-folder
+- Impact: Risk created by the missing, weak, stale, misleading, or wrong-location documentation.
+- Evidence: Concrete file and line references, command/API behavior, existing docs, examples, or comment/docstring gap.
+- Proposed fix: Brief documentation direction using the established documentation location and style.
+- Validation: Suggested checks for the documentation change.
+```
+
+Keep optional follow-up notes separate from findings:
+
+```markdown
+## Optional Docs Follow-Ups
+
+- Optional or non-blocking note.
+```
+
+## Implement Mode
+
+1. Identify the requested package or folder scope. If no scope is provided, stop and ask for the package or folder.
+2. Read `ISSUES.md` in the requested package or folder first and treat it as the working docs-gap ledger.
+   If scoped `ISSUES.md` does not exist, stop and ask whether to run Find mode first for that scope.
+3. Use `$project-workflow` before proposing or running validation so repository entrypoints, CI expectations, documented commands, public APIs, examples, and `./bin` wiring are current.
+4. Work through findings sequentially by ID unless the human explicitly names a different finding.
+5. For each finding, first present:
+   - the issue ID and current evidence.
+   - the proposed documentation solution.
+   - documentation-location, public-contract, example accuracy, compatibility, or maintenance tradeoffs.
+   - the intended validation.
+6. Stop after proposing the solution. Do not edit files, update `ISSUES.md`, or start validation until the human explicitly agrees to that finding's solution.
+7. Ask questions when behavior, audience, documentation location, public-contract wording, examples, validation, or user intent is ambiguous. Treat silence or a broad "implement docs gaps" request as permission to start the proposal workflow, not as permission to edit.
+8. Once the solution for the current finding is agreed, implement only that finding with the smallest clear documentation change.
+9. Use relevant language standards for code comments and API docs. Use `$change-safety` when documentation changes public API, command, migration, or compatibility expectations.
+10. Validate the documentation change using checks appropriate to the changed files, such as markdown linting if present, generated documentation checks if present, relevant language linting, examples, or documented command smoke checks.
+11. Report the result for that finding and ask the human to verify and explicitly say `DOC-<number> is done`.
+12. Do not move to the next finding until the human says `DOC-<number> is done`.
+13. After the human confirms a finding is done, remove that finding from scoped `ISSUES.md`. If a finding is deemed invalid or not actually a docs gap, remove it only after explaining why and getting human agreement.
+14. Then propose the solution for the next remaining finding and repeat the same agreement gate.
+15. Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
+16. Summarize what changed, which docs gaps were resolved or dismissed, and which validation steps were run or still need to be carried out by the human.
+
+## References
+
+- Use `$project-workflow` for repository command discovery, documented entrypoints, CI expectations, examples, and `./bin` wiring before review planning or validation.
+- Use relevant language standards for code comments, public API docs, and examples.
+- Use `$change-safety` when documentation affects public contracts, compatibility, migrations, security expectations, or documented operational behavior.
+- Use `$change-validation` when selecting validation commands for implemented documentation fixes.
+- Use `$code-issues` when the confirmed problem is broken behavior, a security issue, a compatibility break, or a violated public contract.
+- Use `$test-gaps` when the confirmed problem is missing or weak test coverage rather than documentation.

--- a/skills/docs-gaps/agents/openai.yaml
+++ b/skills/docs-gaps/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Docs Gaps"
+  short_description: "Find scoped documentation gaps"
+  default_prompt: "Use $docs-gaps to find scoped missing, weak, stale, or misleading docs and comments, store confirmed gaps in that scope's ISSUES.md, or propose and implement agreed documentation fixes one gap at a time."

--- a/skills/go-standards/references/conventions.md
+++ b/skills/go-standards/references/conventions.md
@@ -9,11 +9,14 @@ Use this reference when working in Go repositories.
 
 ## Documentation
 
-- User-facing or documented Go APIs need clear, accurate, and detailed GoDoc for packages, exported types, functions, methods, and other supported entrypoints.
+- User-facing or documented Go APIs need clear, accurate, and detailed GoDoc for packages, exported types, functions, methods, constants, variables, and other supported entrypoints.
+- Go doc comments should directly precede the declaration they document with no intervening blank line.
+- Go doc comments for exported identifiers should start with the documented identifier where appropriate so generated documentation and summaries read clearly.
 - Keep package-level GoDoc in `doc.go` files.
 - Do not leave package documentation comments on unrelated source files such as `main.go`, `client.go`, or `types.go`.
 - Keep examples aligned with the real public interface and expected calling style when the repository's documentation style supports them.
 - When package documentation needs to change, update `doc.go` rather than scattering package comments across implementation files.
+- Preserve `Deprecated:` paragraphs in doc comments when documenting compatibility guidance for identifiers that remain available but should not be used.
 
 ## Testing
 

--- a/skills/ruby-standards/references/conventions.md
+++ b/skills/ruby-standards/references/conventions.md
@@ -11,6 +11,8 @@ Use this reference when working in Ruby repositories.
 ## Documentation
 
 - User-facing or documented Ruby APIs need clear, accurate, and detailed RDoc for modules, classes, methods, and other supported entrypoints.
+- Class and module RDoc should explain the purpose of the API and common uses.
+- Method RDoc should cover the synopsis, important examples, arguments when needed, corner cases, exceptions, and related methods when useful.
 - When a user-facing or documented API is non-trivial, include examples if the repository's documentation style supports them.
 - Keep examples aligned with the real public interface and expected calling style.
 

--- a/skills/test-gaps/SKILL.md
+++ b/skills/test-gaps/SKILL.md
@@ -33,12 +33,13 @@ Do not combine the two modes in one pass.
 15. Deduplicate overlapping findings and resolve conflicting agent conclusions by re-checking the code and tests directly.
 16. Confirm each candidate gap against the code and existing tests before recording it. Gaps must be concrete missing, weak, misleading, flaky, or wrong-layer coverage with credible risk to changed behavior, public contracts, compatibility, release-sensitive workflows, or documented command/API behavior.
 17. Do not record confirmed production bugs, security issues, compatibility breaks, or violated public contracts as test gaps. If such broken behavior is discovered during review, report it as out of scope for the test-gap ledger and recommend `$code-issues`; use this skill when the unprotected or poorly protected behavior is the finding.
-18. Do not report optional nice-to-have tests, private implementation coverage, arbitrary coverage percentage improvements, style preferences, or docs-only validation as findings by themselves. List them only as optional follow-up notes when relevant.
-19. If no confirmed test gaps are found, report that no test gaps were found and do not create `ISSUES.md`.
-20. If confirmed test gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
-21. Assign every finding a unique ID for the session in the form `TEST-<number>`.
-22. Present the scoped `ISSUES.md` and a proposed test-fix plan to the user.
-23. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
+18. Do not record standalone missing, weak, stale, misleading, or wrong-location documentation, README, example, comment, or docstring gaps as test gaps. Use `$docs-gaps` when documentation itself is the finding.
+19. Do not report optional nice-to-have tests, private implementation coverage, arbitrary coverage percentage improvements, style preferences, or docs-only validation as findings by themselves. List them only as docs gaps or optional follow-up notes when relevant.
+20. If no confirmed test gaps are found, report that no test gaps were found and do not create `ISSUES.md`.
+21. If confirmed test gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
+22. Assign every finding a unique ID for the session in the form `TEST-<number>`.
+23. Present the scoped `ISSUES.md` and a proposed test-fix plan to the user.
+24. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
 
 ## `ISSUES.md` Format
 
@@ -94,5 +95,6 @@ Keep optional follow-up notes separate from findings:
 
 - Use `$testing-standards` for cross-language test quality, coverage, fixtures, determinism, and test-layer decisions.
 - Use relevant language standards for local test idioms.
+- Use `$docs-gaps` instead when the user asks for a standalone missing, stale, misleading, or weak documentation, README, example, comment, or docstring pass.
 - Use `$project-workflow` for repository command discovery, CI expectations, and `./bin` wiring before review planning or validation.
 - Use `$change-validation` when selecting validation commands for implemented test fixes.


### PR DESCRIPTION
## What

- Add a docs-gaps skill for scoped documentation gap finding and one-gap-at-a-time fixes.
- Register docs-gaps in the shared skill lists and route docs-only findings away from code-issues and test-gaps.
- Move language-specific documentation expectations into the Go and Ruby standards references.

## Why

- Documentation gaps need their own ledger workflow instead of being mixed into code or test findings.
- Language-specific docs guidance should stay with the standards skills so it does not drift from their conventions.

## Testing

- `make dep` - passed
- `make clean-dep` - passed
- `make scripts-lint` - passed
- `make docker-lint` - passed
- `make lint` - passed
- `make sec-lint` - passed
- `ruby -e "require 'yaml'; YAML.load_file('skills/docs-gaps/agents/openai.yaml'); puts 'yaml ok'"` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
