### PR TITLE
feat(skills): tighten review signal quality

### DIFF
--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: Reviews changed code for bugs, regressions, risky assumptions, missing tests, compatibility breaks, and missing documentation. Use when the user asks for a general code review, diff review, PR check, or pre-merge issue pass; delegate explicit security scope to security-audit.
+description: Reviews changed code for bugs, regressions, risky assumptions, missing tests, compatibility breaks, missing documentation, and language-specific maintainability or idiom risks. Use when the user asks for a general code review, diff review, PR check, or pre-merge issue pass; delegate explicit security scope to security-audit.
 ---
 
 # Code Review
@@ -10,12 +10,16 @@ description: Reviews changed code for bugs, regressions, risky assumptions, miss
 1. Identify the changed files or requested review scope.
 2. Read `references/findings-format.md` before producing review output.
 3. Inspect behavior, tests, compatibility, security, docs, and maintenance risk before style preferences.
-4. Use `$testing-standards` when judging whether tests are missing, weak, overfit to internals, or at the wrong layer.
-5. If the review scope includes security-sensitive code, configuration, dependencies, shell execution, filesystem writes/deletes, network/auth/TLS behavior, secrets/env handling, Docker helpers, or CI/security tooling, consult `$security-audit` and the smallest matching security reference; keep this skill's findings format.
-6. Verify claims against concrete file and line references whenever possible.
-7. When code review is the final response, use the exact structure in `references/findings-format.md`; do not add, remove, rename, or reorder sections.
-8. When another skill embeds this review, preserve findings, open questions, testing gaps, and summary facts in the caller's output format.
+4. First identify high-risk review leads, especially deletions, cross-boundary drift, silent behavior changes, changed contracts, unhandled sibling cases, and error-path changes. Then verify concrete findings instead of reviewing every line uniformly.
+5. Prefer precision over recall. Do not report plausible concerns unless they survive attempts to disprove them and are grounded in changed code, concrete evidence, and credible user, compatibility, security, maintenance, or test risk.
+6. Pair with relevant language standards (`$go-standards`, `$ruby-standards`, `$shell-standards`) when reviewing language-specific code, APIs, docs, tests, or tooling behavior. Treat idiomatic style concerns as findings only when they create concrete readability, maintenance, correctness, compatibility, or public API risk.
+7. Use `$testing-standards` when judging whether tests are missing, weak, overfit to internals, or at the wrong layer.
+8. If the review scope includes security-sensitive code, configuration, dependencies, shell execution, filesystem writes/deletes, network/auth/TLS behavior, secrets/env handling, Docker helpers, or CI/security tooling, consult `$security-audit` and the smallest matching security reference; keep this skill's findings format.
+9. Verify claims against concrete file and line references whenever possible.
+10. When code review is the final response, use the exact structure in `references/findings-format.md`; do not add, remove, rename, or reorder sections.
+11. When another skill embeds this review, preserve findings, open questions, testing gaps, and summary facts in the caller's output format.
 
 ## References
 
 - Read `references/findings-format.md` for review priorities, output format, and what to say when no issues are found.
+- Use relevant language standards for idiomatic code, API, docs, test, and tooling conventions.

--- a/skills/code-review/agents/openai.yaml
+++ b/skills/code-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Code Review"
   short_description: "Review diffs for bugs and regressions"
-  default_prompt: "Use $code-review for a general bug, regression, and missing-coverage review."
+  default_prompt: "Use $code-review for a general bug, regression, missing-coverage, documentation, and language-idiom risk review."

--- a/skills/code-review/references/findings-format.md
+++ b/skills/code-review/references/findings-format.md
@@ -9,6 +9,7 @@ Use this reference when the user asks for a review.
 - Focus on user-visible impact and maintenance risk before style nits.
 - Prefer concrete findings over broad summaries.
 - Ground each finding in the inspected code and describe the consequence, not just the preference.
+- Avoid broad "consider checking" comments. Each finding needs a concrete changed location, behavior at risk, evidence, and a clear place to start fixing.
 
 ## Severity
 


### PR DESCRIPTION
## What

- Add high-risk lead scouting guidance to code-review for deletions, cross-boundary drift, silent behavior changes, changed contracts, sibling cases, and error paths.
- Add precision-over-recall guidance so plausible concerns must survive verification before becoming findings.
- Route language-specific idiom review through the relevant standards skills and update the code-review prompt metadata.
- Tighten the findings format to avoid broad consider-checking comments without concrete action points.

## Why

- Code review findings should stay specific, evidence-backed, and worth author attention.
- Language-specific idioms belong in standards skills, while code-review should decide when those concerns rise to concrete review risk.

## Testing

- `make dep` - passed
- `make clean-dep` - passed
- `make scripts-lint` - passed
- `make docker-lint` - passed
- `make lint` - passed
- `make sec-lint` - passed
- `ruby -e "require %q[yaml]; YAML.load_file(%q[skills/code-review/agents/openai.yaml]); puts %q[yaml ok]"` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
