### PR TITLE
docs(readme): clarify helper documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This gives you targets like:
 - `make lint` / `make fix-lint` / `make format`
 - `make specs` (gotestsum + race + coverage written under `test/reports/`)
 - `make coverage` (HTML + func coverage from `test/reports/final.cov`)
-- `make sec` (govulncheck)
+- `make sec` (govulncheck + Trivy repo scan)
 
 ### Git workflow helpers
 

--- a/build/docker/build
+++ b/build/docker/build
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2155
+# Build a local test Docker image for a service and platform.
 
 set -eo pipefail
 

--- a/build/docker/env
+++ b/build/docker/env
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2086
+# Ensure the sibling docker environment exists, then run a deps command there.
 
 set -eo pipefail
 

--- a/build/docker/manifest
+++ b/build/docker/manifest
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2155
+# Create and push versioned and latest multi-architecture Docker manifests.
 
 set -eo pipefail
 

--- a/build/docker/push
+++ b/build/docker/push
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2155
+# Build and push a versioned Docker image for a service and platform.
 
 set -eo pipefail
 

--- a/build/go/clean
+++ b/build/go/clean
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2155
+# Refresh Go dependencies and caches when go.sum differs from master.
 
 set -eo pipefail
 

--- a/build/go/lint
+++ b/build/go/lint
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Run golangci-lint only when it is installed in PATH.
 
 set -eo pipefail
 

--- a/build/sec/trivy-image
+++ b/build/sec/trivy-image
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Scan a built test Docker image for critical vulnerabilities with Trivy.
 
 set -eo pipefail
 

--- a/build/sec/trivy-repo
+++ b/build/sec/trivy-repo
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Scan the current repository for critical vulnerabilities with Trivy.
 
 set -eo pipefail
 

--- a/quality/go/covfilter
+++ b/quality/go/covfilter
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Filter the main Go coverage profile into the final report profile.
 
 set -eo pipefail
 

--- a/quality/ruby/benchmark
+++ b/quality/ruby/benchmark
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2086
+# Run benchmark-tagged Cucumber scenarios with coverage reporting enabled.
 
 set -eo pipefail
 

--- a/quality/ruby/feature
+++ b/quality/ruby/feature
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Run non-benchmark Cucumber features with coverage reporting enabled.
 
 set -eo pipefail
 


### PR DESCRIPTION
## What

- Update the README Go project example to show that `make sec` runs both govulncheck and Trivy repo scanning.
- Add purpose comments to standalone build shell helpers.
- Add purpose comments to standalone quality shell helpers.

## Why

- The README should accurately describe the shared Go security target.
- Shared executable helpers should carry concise purpose comments so maintainers and downstream users do not have to infer intent from implementation details.

## Testing

- `make dep` - passed
- `make clean-dep` - passed
- `make scripts-lint` - passed
- `make docker-lint` - passed
- `make lint` - passed
- `make sec-lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
