### PR TITLE
feat(go): use testdox formatter for specs

### DIFF
--- a/build/make/client.mak
+++ b/build/make/client.mak
@@ -109,7 +109,7 @@ benchmarks: build
 
 # Run Go tests with gotestsum (race + coverage) and write reports under test/reports/.
 specs:
-	@gotestsum --format testname --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
+	@gotestsum --format testdox --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
 
 # Open pprof for a captured profile under test/reports/ (set cmd/id/kind).
 pprof:

--- a/build/make/go.mak
+++ b/build/make/go.mak
@@ -71,7 +71,7 @@ format:
 
 # Run tests with gotestsum (race + coverage) and write reports under test/reports/.
 specs:
-	@gotestsum --format testname --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
+	@gotestsum --format testdox --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
 
 # Run benchmarks for package=$(package) and write $(BENCHMARK_PROFILE).
 # Set benchtime=<duration-or-count> to pass -benchtime to go test.

--- a/build/make/grpc.mak
+++ b/build/make/grpc.mak
@@ -133,7 +133,7 @@ benchmarks: build
 
 # Run Go tests with gotestsum (race + coverage) and write reports under test/reports/.
 specs:
-	@gotestsum --format testname --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
+	@gotestsum --format testdox --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
 
 # Open pprof for a captured profile under test/reports/ (set id/kind).
 pprof:

--- a/build/make/http.mak
+++ b/build/make/http.mak
@@ -109,7 +109,7 @@ benchmarks: build
 
 # Run Go tests with gotestsum (race + coverage) and write reports under test/reports/.
 specs:
-	@gotestsum --format testname --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
+	@gotestsum --format testdox --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
 
 # Open pprof for a captured profile under test/reports/ (set id/kind).
 pprof:


### PR DESCRIPTION
## What

- Switch gotestsum specs targets from testname output to testdox output in the shared Go, HTTP, client, and gRPC Make fragments.

## Why

- Make test output read as sentence-style test descriptions while preserving the existing race, coverage, JUnit, vendor, and package arguments.

## Testing

- `rg -n "gotestsum --format|--format testname|--format testdox" build/make` - passed
- `make -f build/make/go.mak -n specs` - passed
- `make -f build/make/http.mak -n specs` - passed
- `make -f build/make/client.mak -n specs` - passed
- `make -f build/make/grpc.mak -n specs` - passed
- `env GOCACHE=/private/tmp/go-build-cache gotestsum --format testdox --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=./... -coverprofile=test/reports/profile.cov ./...` - passed
