### PR TITLE
feat(skills): avoid dependency-pass-through test gaps

### DIFF
--- a/skills/test-gaps/SKILL.md
+++ b/skills/test-gaps/SKILL.md
@@ -28,18 +28,21 @@ Do not combine the two modes in one pass.
    - files directly under the requested root package/folder.
    - each first-level subpackage/subfolder under the requested root.
 12. Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough and accurate `$testing-standards` review for its assigned scope, pairing with relevant language standards and `$change-validation` for likely validation commands.
-13. Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
+13. Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally. Each finding must name the repository-owned behavior being protected; reject findings that only test dependency semantics, aliases, or pass-through wrappers.
 14. Wait for all agents to finish before aggregating results.
 15. Deduplicate overlapping findings and resolve conflicting agent conclusions by re-checking the code and tests directly.
 16. Confirm each candidate gap against the code and existing tests before recording it. Gaps must be concrete missing, weak, misleading, flaky, or wrong-layer coverage with credible risk to changed behavior, public contracts, compatibility, release-sensitive workflows, or documented command/API behavior.
-17. Do not record confirmed production bugs, security issues, compatibility breaks, or violated public contracts as test gaps. If such broken behavior is discovered during review, report it as out of scope for the test-gap ledger and recommend `$code-issues`; use this skill when the unprotected or poorly protected behavior is the finding.
-18. Do not record standalone missing, weak, stale, misleading, or wrong-location documentation, README, example, comment, or docstring gaps as test gaps. Use `$doc-gaps` when documentation itself is the finding.
-19. Do not report optional nice-to-have tests, private implementation coverage, arbitrary coverage percentage improvements, style preferences, or docs-only validation as findings by themselves. List them only as doc gaps or optional follow-up notes when relevant.
-20. If no confirmed test gaps are found, report that no test gaps were found and do not create `ISSUES.md`.
-21. If confirmed test gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
-22. Assign every finding a unique ID for the session in the form `TEST-<number>`.
-23. Present the scoped `ISSUES.md` and a proposed test-fix plan to the user.
-24. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
+17. Do not record gaps whose only meaningful test would assert pass-through behavior to an upstream library, standard library, or framework. This includes aliases, type aliases, thin wrappers, direct option forwarding, direct global setter/getter calls, and constructors where the repository adds no branching, validation, transformation, error handling, lifecycle behavior, compatibility policy, or composition contract of its own.
+18. Only record a gap around third-party integration when the untested behavior is repository-owned. Examples include local validation/normalization before calling the dependency, local input/output mapping, local error wrapping/classification/recovery, lifecycle ordering or cleanup owned by the repository, documented compatibility behavior promised across dependency versions, or end-to-end behavior through a supported public repo entrypoint where multiple repo-owned pieces are composed.
+19. When a candidate gap touches a wrapper around a dependency, explicitly ask: "Would the proposed test fail because repository code changed, or only because the dependency's behavior/shape changed?" Record it only when repository code owns the failing behavior.
+20. Do not record confirmed production bugs, security issues, compatibility breaks, or violated public contracts as test gaps. If such broken behavior is discovered during review, report it as out of scope for the test-gap ledger and recommend `$code-issues`; use this skill when the unprotected or poorly protected behavior is the finding.
+21. Do not record standalone missing, weak, stale, misleading, or wrong-location documentation, README, example, comment, or docstring gaps as test gaps. Use `$doc-gaps` when documentation itself is the finding.
+22. Do not report optional nice-to-have tests, private implementation coverage, arbitrary coverage percentage improvements, style preferences, or docs-only validation as findings by themselves. List them only as doc gaps or optional follow-up notes when relevant.
+23. If no confirmed test gaps are found, report that no test gaps were found and do not create `ISSUES.md`.
+24. If confirmed test gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
+25. Assign every finding a unique ID for the session in the form `TEST-<number>`.
+26. Present the scoped `ISSUES.md` and a proposed test-fix plan to the user.
+27. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
 
 ## `ISSUES.md` Format
 


### PR DESCRIPTION
## What

- Added test-gap review guardrails that require findings to identify repository-owned behavior.
- Rejected gaps that only assert upstream dependency semantics, aliases, thin wrappers, option forwarding, or direct global setter/getter calls.
- Added a decision question for dependency-wrapper candidates so reviewers distinguish repo-owned behavior from dependency behavior.

## Why

- Recent telemetry test-gap review produced false positives around aliases and OpenTelemetry pass-through wrappers.
- The workflow now directs agents toward tests that protect local validation, mapping, error handling, lifecycle, compatibility, or supported composition behavior.

## Testing

- `git diff --check` - passed
- `make lint` - failed in this shell because BSD make cannot parse GNU make fragments
- `gmake lint` - failed because Bundler 4.0.10 is not installed in this shell
