### PR TITLE
feat(skills): tighten test-gap review gates

### DIFF
--- a/skills/test-gaps/SKILL.md
+++ b/skills/test-gaps/SKILL.md
@@ -32,17 +32,19 @@ Do not combine the two modes in one pass.
 14. Wait for all agents to finish before aggregating results.
 15. Deduplicate overlapping findings and resolve conflicting agent conclusions by re-checking the code and tests directly.
 16. Confirm each candidate gap against the code and existing tests before recording it. Gaps must be concrete missing, weak, misleading, flaky, or wrong-layer coverage with credible risk to changed behavior, public contracts, compatibility, release-sensitive workflows, or documented command/API behavior.
-17. Do not record gaps whose only meaningful test would assert pass-through behavior to an upstream library, standard library, or framework. This includes aliases, type aliases, thin wrappers, direct option forwarding, direct global setter/getter calls, and constructors where the repository adds no branching, validation, transformation, error handling, lifecycle behavior, compatibility policy, or composition contract of its own.
-18. Only record a gap around third-party integration when the untested behavior is repository-owned. Examples include local validation/normalization before calling the dependency, local input/output mapping, local error wrapping/classification/recovery, lifecycle ordering or cleanup owned by the repository, documented compatibility behavior promised across dependency versions, or end-to-end behavior through a supported public repo entrypoint where multiple repo-owned pieces are composed.
-19. When a candidate gap touches a wrapper around a dependency, explicitly ask: "Would the proposed test fail because repository code changed, or only because the dependency's behavior/shape changed?" Record it only when repository code owns the failing behavior.
-20. Do not record confirmed production bugs, security issues, compatibility breaks, or violated public contracts as test gaps. If such broken behavior is discovered during review, report it as out of scope for the test-gap ledger and recommend `$code-issues`; use this skill when the unprotected or poorly protected behavior is the finding.
-21. Do not record standalone missing, weak, stale, misleading, or wrong-location documentation, README, example, comment, or docstring gaps as test gaps. Use `$doc-gaps` when documentation itself is the finding.
-22. Do not report optional nice-to-have tests, private implementation coverage, arbitrary coverage percentage improvements, style preferences, or docs-only validation as findings by themselves. List them only as doc gaps or optional follow-up notes when relevant.
-23. If no confirmed test gaps are found, report that no test gaps were found and do not create `ISSUES.md`.
-24. If confirmed test gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
-25. Assign every finding a unique ID for the session in the form `TEST-<number>`.
-26. Present the scoped `ISSUES.md` and a proposed test-fix plan to the user.
-27. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
+17. For each candidate, explicitly identify the nearby existing test shape and why extending existing tests, fixtures, tables, helpers, or assertions does not already cover the behavior. Do not record a gap when the proposed fix would duplicate coverage already provided by that local shape.
+18. Do not record gaps whose only meaningful test would assert pass-through behavior to an upstream library, standard library, or framework. This includes aliases, type aliases, thin wrappers, direct option forwarding, direct global setter/getter calls, dependency injection container behavior, validator tag behavior, encoder/parser behavior, and constructors where the repository adds no branching, validation, transformation, error handling, lifecycle behavior, compatibility policy, or composition contract of its own.
+19. Only record a gap around third-party integration when the untested behavior is repository-owned. Examples include local validation/normalization before calling the dependency, local input/output mapping, local error wrapping/classification/recovery, lifecycle ordering or cleanup owned by the repository, documented compatibility behavior promised across dependency versions, or end-to-end behavior through a supported public repo entrypoint where multiple repo-owned pieces are composed.
+20. When a candidate gap touches a wrapper around a dependency, explicitly ask: "Would the proposed test fail because repository code changed, or only because the dependency's behavior/shape changed?" Record it only when repository code owns the failing behavior.
+21. Do not record gaps that require build tags, architecture-specific execution, optional services, integration environments, or other validation modes the repository does not normally run, unless the finding is explicitly that CI or the documented validation path must add that mode.
+22. Do not record confirmed production bugs, security issues, compatibility breaks, or violated public contracts as test gaps. If such broken behavior is discovered during review, report it as out of scope for the test-gap ledger and recommend `$code-issues`; use this skill when the unprotected or poorly protected behavior is the finding.
+23. Do not record standalone missing, weak, stale, misleading, or wrong-location documentation, README, example, comment, or docstring gaps as test gaps. Use `$doc-gaps` when documentation itself is the finding.
+24. Do not report optional nice-to-have tests, private implementation coverage, arbitrary coverage percentage improvements, style preferences, or docs-only validation as findings by themselves. List them only as doc gaps or optional follow-up notes when relevant.
+25. If no confirmed test gaps are found, report that no test gaps were found and do not create `ISSUES.md`.
+26. If confirmed test gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
+27. Assign every finding a unique ID for the session in the form `TEST-<number>`.
+28. Present the scoped `ISSUES.md` and a proposed test-fix plan to the user.
+29. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
 
 ## `ISSUES.md` Format
 
@@ -77,22 +79,24 @@ Keep optional follow-up notes separate from findings:
    If scoped `ISSUES.md` does not exist, stop and ask whether to run Find mode first for that scope.
 3. Use `$project-workflow` before proposing or running validation so repository entrypoints, CI expectations, and `./bin` wiring are current.
 4. Work through findings sequentially by ID unless the human explicitly names a different finding.
-5. For each finding, first present:
+5. Before proposing a fix for each finding, re-check the current code and nearby tests. Treat the ledger as something that can go stale: dismiss or revise findings that are already covered, would duplicate the local test shape, test only underlying libraries/frameworks, or require validation modes the repository does not run.
+6. For each finding, first present:
    - the issue ID and current evidence.
    - the proposed test solution.
+   - why the behavior is repository-owned and not already covered by existing tests.
    - test-layer, fixture, determinism, compatibility, or maintenance tradeoffs.
    - the intended validation.
-6. Stop after proposing the solution. Do not edit code, update `ISSUES.md`, or start validation until the human explicitly agrees to that finding's solution.
-7. Ask questions when behavior, compatibility, test layer, fixture strategy, validation, or user intent is ambiguous. Treat silence or a broad "implement test gaps" request as permission to start the proposal workflow, not as permission to code.
-8. Once the solution for the current finding is agreed, implement only that finding with the smallest clear test change.
-9. Use `$testing-standards` for test design and pair with the relevant language standard for local idioms.
-10. Validate the test change using checks appropriate to the changed tests.
-11. Report the result for that finding and ask the human to verify and explicitly say `TEST-<number> is done`.
-12. Do not move to the next finding until the human says `TEST-<number> is done`.
-13. After the human confirms a finding is done, remove that finding from scoped `ISSUES.md`. If a finding is deemed invalid or not actually a test gap, remove it only after explaining why and getting human agreement.
-14. Then propose the solution for the next remaining finding and repeat the same agreement gate.
-15. Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
-16. Summarize what changed, which test gaps were resolved or dismissed, and which validation steps were run or still need to be carried out by the human.
+7. Stop after proposing the solution. Do not edit code, update `ISSUES.md`, or start validation until the human explicitly agrees to that finding's solution.
+8. Ask questions when behavior, compatibility, test layer, fixture strategy, validation, or user intent is ambiguous. Treat silence or a broad "implement test gaps" request as permission to start the proposal workflow, not as permission to code.
+9. Once the solution for the current finding is agreed, implement only that finding with the smallest clear test change, preferring the existing local test shape over new standalone structure.
+10. Use `$testing-standards` for test design and pair with the relevant language standard for local idioms.
+11. Validate the test change using checks appropriate to the changed tests.
+12. Report the result for that finding and ask the human to verify and explicitly say `TEST-<number> is done`.
+13. Do not move to the next finding until the human says `TEST-<number> is done`.
+14. After the human confirms a finding is done, remove that finding from scoped `ISSUES.md`. If a finding is deemed invalid or not actually a test gap, remove it only after explaining why and getting human agreement.
+15. Then propose the solution for the next remaining finding and repeat the same agreement gate.
+16. Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
+17. Summarize what changed, which test gaps were resolved or dismissed, and which validation steps were run or still need to be carried out by the human.
 
 ## References
 

--- a/skills/testing-standards/SKILL.md
+++ b/skills/testing-standards/SKILL.md
@@ -10,26 +10,32 @@ description: Applies language-agnostic test design, coverage, fixtures, determin
 1. Confirm the task involves adding tests, changing tests, reviewing test quality, planning coverage, or deciding where behavior should be exercised.
 2. Inspect the repository's existing tests, fixtures, helpers, entrypoints, CI targets, and the language or harness used by most relevant tests before adding new structure.
 3. Check whether the change should preserve, restore, or improve coverage; do not let meaningful behavior lose coverage without calling out the gap.
-4. Choose the narrowest established test layer that credibly covers the changed behavior.
-5. Test through public or documented APIs, commands, tasks, or service entrypoints so coverage reflects real consumer behavior.
-6. Do not add tests against private functions, private methods, or internal-only seams unless the human explicitly asks for that approach; if private-surface testing seems necessary, ask first.
-7. Preserve the repository's existing test framework, fixture layout, helper style, assertion idioms, and naming patterns unless the task explicitly changes testing infrastructure.
-8. Pair with the relevant language standard skill for language-specific idioms, and with `change-validation` for selecting or reporting commands.
-9. If another testing-focused skill applies, use this skill for cross-language test policy and the other skill only for specialized language, framework, or library details; this skill's cross-language rules take precedence unless the human or repository instructions explicitly say otherwise.
-10. When tests use mocks, stubs, spies, fakes, or other test doubles, check whether each double protects a true boundary or only mirrors internal implementation; flag interaction-only tests that could pass while real behavior is broken.
-11. Before finishing test changes or reviews, scan changed tests for repeated boolean or numeric assertions whose default failure output would not identify the behavior under test; add named subtests or assertion messages where needed.
+4. Before adding a new standalone test, check whether the behavior is already covered by existing tests and whether the right change is to extend an existing table, fixture, helper, or assertion block.
+5. Choose the narrowest established test layer that credibly covers the changed behavior.
+6. Test through public or documented APIs, commands, tasks, or service entrypoints so coverage reflects real consumer behavior.
+7. Do not add tests against private functions, private methods, or internal-only seams unless the human explicitly asks for that approach; if private-surface testing seems necessary, ask first.
+8. Preserve the repository's existing test framework, fixture layout, helper style, assertion idioms, and naming patterns unless the task explicitly changes testing infrastructure.
+9. Pair with the relevant language standard skill for language-specific idioms, and with `change-validation` for selecting or reporting commands.
+10. If another testing-focused skill applies, use this skill for cross-language test policy and the other skill only for specialized language, framework, or library details; this skill's cross-language rules take precedence unless the human or repository instructions explicitly say otherwise.
+11. When tests use mocks, stubs, spies, fakes, or other test doubles, check whether each double protects a true boundary or only mirrors internal implementation; flag interaction-only tests that could pass while real behavior is broken.
+12. Before finishing test changes or reviews, scan changed tests for repeated boolean or numeric assertions whose default failure output would not identify the behavior under test; add named subtests or assertion messages where needed.
 
 ## Principles
 
 - Assert changed behavior and contracts, not incidental implementation details.
 - Prefer classicist, behavior-oriented tests over mockist, interaction-heavy tests: test observable outcomes through real in-process collaborators where practical, and avoid mocking your own code just to isolate a class, method, function, or file.
 - Treat the unit under test as a behavior at an appropriate boundary, not automatically a single class, method, function, or file.
+- Treat audit findings as candidates, not marching orders. Re-check whether nearby tests already cover the behavior before adding new tests.
+- Do not add tests whose main assertion is that an underlying library or framework works correctly, including dependency injection containers, validators, encoders, parsers, serializers, client libraries, or standard-library behavior. Test repository-owned validation, mapping, error handling, lifecycle, compatibility promises, or consumer-visible composition instead.
+- Prefer extending the local test shape over inventing parallel structure. If an existing fixture, table, scenario helper, or assertion helper already carries the behavior, add the missing assertion there rather than creating a separate test.
+- For DI, configuration, module, or wiring code, avoid exhaustive provider-registration, pointer-projection, or container-resolution tests unless they protect a distinct repository-owned public contract that is not covered by a higher-level consumer path.
 - Use test doubles mainly at true boundaries: network calls, databases, clocks, filesystem, subprocesses, randomness, third-party services, slow infrastructure, or hard-to-trigger failures. Avoid stubbing internal collaborators unless it makes the test more deterministic, focused, or practical without hiding the behavior under test.
 - Treat coverage as a useful signal, not a blind target: preserve existing meaningful coverage where practical, improve it when new or risky behavior is under-tested, and explain when coverage cannot reasonably be added.
 - Just because production code is written in one language does not mean new tests should be written in that language; follow the dominant relevant test harness when the repository tests behavior from another language or feature layer.
 - Prefer table-driven tests when covering multiple inputs, branches, edge cases, or examples, unless the repository's local style clearly uses another readable pattern.
 - Cover relevant edge cases and failure paths for changed behavior, especially empty input, boundary values, malformed input, missing files or tools, non-zero commands, path errors, permissions, parsing failures, and argument pass-through.
 - Keep tests deterministic: avoid uncontrolled network, wall-clock time, random data, ordering assumptions, real home directories, and shared mutable state.
+- Do not add build-tagged, architecture-specific, integration, service-dependent, or environment-specific tests unless the repository's normal validation or CI actually runs that mode, or the change explicitly adds that validation mode.
 - Structure tests so the setup, action, and assertion are easy to follow; use Arrange-Act-Assert or Given-When-Then when the repository does not already have a clearer local pattern.
 - Make failures obvious and descriptive. Avoid bare assertions such as `expected true but got false`; include the case, input, expected behavior, and observed behavior when the assertion framework does not do so clearly.
 - For repeated low-information assertions, do not rely only on generic framework output such as `Should be false`, `expected true but got false`, or `expected 2, got 1`. Add a short assertion message or use named subtests so the failure identifies the specific scenario. This applies especially to repeated boolean and numeric assertions.


### PR DESCRIPTION
## What

- Tighten testing guidance to favor existing local test shapes before adding standalone coverage.
- Update test-gap review and implementation gates to reject duplicate, library-only, and unrun validation-mode findings.

## Why

- Keep generated test-gap ledgers focused on repository-owned behavior and prevent stale findings from turning into noisy tests.

## Testing

- `git diff --check` - passed
- `make lint` - failed before validation with GNU Make 3.81 parse error.
- `gmake lint` - failed before lint because Bundler 4.0.10 is missing in the local Ruby environment.
