### PR TITLE
feat(skills): clarify go import ownership

### DIFF
--- a/skills/go-standards/SKILL.md
+++ b/skills/go-standards/SKILL.md
@@ -9,10 +9,11 @@ description: Applies this repository ecosystem's Go coding, documentation, impor
 
 1. Confirm the task is in a Go repository or touches Go code, Go tests, Go documentation, or Go package APIs.
 2. Read `references/conventions.md` before editing exported APIs, documentation, imports, naming, method layout, or tests.
-3. Preserve the repository's existing Go package shape and public API style.
-4. Add or update Go tests when behavior changes and the repository supports tests.
-5. Pair this skill with `$testing-standards` when designing, reviewing, or refactoring Go test coverage.
-6. Pair this skill with `change-validation` when selecting Go test, lint, coverage, or benchmark commands.
+3. Before adding, changing, or reviewing imports, inspect nearby package ownership, wrappers, and dependency direction so import choices follow the repository's package model while code is written and reviewed.
+4. Preserve the repository's existing Go package shape and public API style.
+5. Add or update Go tests when behavior changes and the repository supports tests.
+6. Pair this skill with `$testing-standards` when designing, reviewing, or refactoring Go test coverage.
+7. Pair this skill with `change-validation` when selecting Go test, lint, coverage, or benchmark commands.
 
 ## References
 

--- a/skills/go-standards/references/conventions.md
+++ b/skills/go-standards/references/conventions.md
@@ -38,7 +38,14 @@ Use this reference when working in Go repositories.
 
 ## Imports And Naming
 
+- Apply these import rules while writing or reviewing code, before adding, approving, or keeping a direct import or alias.
 - Do not alias a Go import unless there is a real collision or required disambiguation.
-- If a project package has the same name as a standard-library package, keep the project package unaliased and alias only the standard-library import.
-- If the collision is at identifier level rather than import level, alias or rename only the referenced standard-library type, function, or variable.
-- Keep aliases short, obvious, and specific to the standard-library package they disambiguate.
+- If a project package has the same name as a standard-library package, keep the project package unaliased. Prefer adding missing wrapper functionality to the project package over importing the standard-library package directly. If the standard-library import is still needed, alias only that import.
+- If a project package wraps or centralizes another project, standard-library, or external package, prefer the project wrapper package and add missing surface there when that matches the repository's API shape.
+- If two project packages have the same package name or would collide in one file, inspect their dependency direction and domain ownership before choosing aliases. Keep the base or depended-on package unaliased, and alias the more-specific dependent package with its qualifier, such as `transportmeta` for `transport/meta` when it depends on `meta`.
+- If a project and external package overlap conceptually, prefer the project-owned domain package. For example, telemetry wrappers should own imports from OpenTelemetry or external metrics packages when that is the repository pattern.
+- Treat named packages in these rules as examples, not a fixed list. Apply the same ownership, wrapper, and dependency-direction checks to any package pair.
+- If there is no collision, use the package's declared name and do not alias it.
+- If the collision is at identifier level rather than import level, alias or rename only the referenced non-project type, function, or variable when possible.
+- Keep required aliases short, obvious, and specific to the package or domain they disambiguate.
+- If ownership, dependency direction, or wrapper intent is unclear, ask before choosing an import alias or bypassing a project package.


### PR DESCRIPTION
## What

- Clarify Go import ownership guidance for project packages, wrappers, and package-name collisions.
- Make the import rules apply while writing and reviewing code.

## Why

- Avoid unnecessary aliases when project packages share names with standard-library or external packages.
- Prefer repository-owned wrapper packages and dependency-direction-aware aliases when collisions are real.

## Testing

- `git diff --check` - passed
- `make lint` - passed
