### PR TITLE
feat(skills): clarify wrapper import decisions

### DIFF
--- a/skills/go-standards/references/conventions.md
+++ b/skills/go-standards/references/conventions.md
@@ -39,9 +39,12 @@ Use this reference when working in Go repositories.
 ## Imports And Naming
 
 - Apply these import rules while writing or reviewing code, before adding, approving, or keeping a direct import or alias.
+- Resolve wrapper ownership before deciding import aliases: first decide whether code should use or expand a project wrapper, then decide whether any remaining import needs an alias.
 - Do not alias a Go import unless there is a real collision or required disambiguation.
 - If a project package has the same name as a standard-library package, keep the project package unaliased. Prefer adding missing wrapper functionality to the project package over importing the standard-library package directly. If the standard-library import is still needed, alias only that import.
 - If a project package wraps or centralizes another project, standard-library, or external package, prefer the project wrapper package and add missing surface there when that matches the repository's API shape.
+- When a project package wraps or centralizes an external package, prefer expanding the project wrapper with a narrow missing constant, helper, constructor, or contract-checking function before importing the external package directly from nearby code or tests. Keep the added wrapper surface within the package's documented responsibility. Import the external package directly only when the needed API is outside that responsibility, too broad to wrap honestly, or would make the project wrapper misleading.
+  For example, if `crypto/bcrypt` wraps `golang.org/x/crypto/bcrypt` and a test needs `Cost` or `DefaultCost` to verify the wrapper's hashing contract, add `crypto/bcrypt.Cost` or `crypto/bcrypt.DefaultCost` instead of importing `golang.org/x/crypto/bcrypt` in the test.
 - If two project packages have the same package name or would collide in one file, inspect their dependency direction and domain ownership before choosing aliases. Keep the base or depended-on package unaliased, and alias the more-specific dependent package with its qualifier, such as `transportmeta` for `transport/meta` when it depends on `meta`.
 - If a project and external package overlap conceptually, prefer the project-owned domain package. For example, telemetry wrappers should own imports from OpenTelemetry or external metrics packages when that is the repository pattern.
 - Treat named packages in these rules as examples, not a fixed list. Apply the same ownership, wrapper, and dependency-direction checks to any package pair.


### PR DESCRIPTION
## What

- Clarify Go import guidance to resolve wrapper ownership before alias decisions.
- Add guidance to expand narrow project wrapper surface before importing wrapped external packages in nearby code or tests.

## Why

- Reduce duplicate upstream imports when project wrappers already own the domain.
- Make contract-checking cases like bcrypt cost validation easier to apply consistently.

## Testing

- `git diff --check` - passed
- `make lint` - failed before linting because BSD make could not parse the GNU Make fragment
- `gmake lint` - failed before linting because Bundler 4.0.10 is missing in the local Ruby environment

AI-assisted-by: [Codex](https://openai.com/codex/)
