### PR TITLE
feat(make): use config flag for dev servers

### DIFF
--- a/build/make/grpc.mak
+++ b/build/make/grpc.mak
@@ -223,7 +223,7 @@ build-test:
 
 # Run in dev mode with air; builds and runs "$(NAME) server" using test config.
 dev:
-	@air --build.cmd "make dep build" --build.bin "./$(NAME) server -i file:test/.config/server.yml"
+	@air --build.cmd "make dep build" --build.bin "./$(NAME) server -config file:test/.config/server.yml"
 
 # Build a test docker image tagged alexfalkowski/$(NAME):test.$(platform).
 build-docker:

--- a/build/make/http.mak
+++ b/build/make/http.mak
@@ -195,7 +195,7 @@ build-test:
 
 # Run in dev mode with air; builds and runs "$(NAME) server" using test config.
 dev:
-	@air --build.cmd "make dep build" --build.bin "./$(NAME) server -i file:test/.config/server.yml"
+	@air --build.cmd "make dep build" --build.bin "./$(NAME) server -config file:test/.config/server.yml"
 
 # Build a test docker image tagged alexfalkowski/$(NAME):test.$(platform).
 build-docker:


### PR DESCRIPTION
## What

- Update HTTP and gRPC dev targets to start servers with `-config file:test/.config/server.yml`.

## Why

- Keep the reusable dev commands aligned with the server config flag expected by downstream projects.

## Testing

- `make -n -f build/make/http.mak NAME=example dev` - passed; expanded the expected `air` command, with the downstream-layout `go.mod` warning in this repo root.
- `make -n -f build/make/grpc.mak NAME=example dev` - passed; expanded the expected `air` command, with the downstream-layout `go.mod` warning in this repo root.
- `make lint` - passed.
- `git diff --check` - passed.
