### PR TITLE
feat(make): use air entrypoint for live reload

### DIFF
--- a/build/make/grpc.mak
+++ b/build/make/grpc.mak
@@ -223,7 +223,7 @@ build-test:
 
 # Run in dev mode with air; builds and runs "$(NAME) server" using test config.
 dev:
-	@air --build.cmd "make dep build" --build.bin "./$(NAME) server -config file:test/.config/server.yml"
+	@air -c /dev/null --build.cmd "make dep build" --build.entrypoint "$(CURDIR)/$(NAME)" --build.args_bin "server,-config,file:test/.config/server.yml" --build.exclude_dir "assets,bin,vendor,test"
 
 # Build a test docker image tagged alexfalkowski/$(NAME):test.$(platform).
 build-docker:

--- a/build/make/http.mak
+++ b/build/make/http.mak
@@ -195,7 +195,7 @@ build-test:
 
 # Run in dev mode with air; builds and runs "$(NAME) server" using test config.
 dev:
-	@air --build.cmd "make dep build" --build.bin "./$(NAME) server -config file:test/.config/server.yml"
+	@air -c /dev/null --build.cmd "make dep build" --build.entrypoint "$(CURDIR)/$(NAME)" --build.args_bin "server,-config,file:test/.config/server.yml" --build.exclude_dir "assets,bin,vendor,test"
 
 # Build a test docker image tagged alexfalkowski/$(NAME):test.$(platform).
 build-docker:


### PR DESCRIPTION
## What

- Updated HTTP and gRPC dev targets to run Air with `build.entrypoint` and `build.args_bin` instead of deprecated `build.bin`.
- Added watcher exclusions for `assets`, `bin`, `vendor`, and `test`.
- Load `/dev/null` as an empty Air config so Air does not warn from its default deprecated `build.bin` setting.

## Why

- Prevents Air from treating command arguments as part of the executable path.
- Avoids reloads triggered by vendored tooling or test files.

## Testing

- `make -n -f build/make/http.mak dev` - passed
- `make -n -f build/make/grpc.mak dev` - passed
- `make -n -C /Users/alejandro/code/bezeichner -f /Users/alejandro/code/bin/build/make/http.mak dev` - passed
- `make lint` - passed
- `git diff --check` - passed
