### PR TITLE
feat(skills): prevent guessed go import aliases

### DIFF
--- a/skills/go-standards/SKILL.md
+++ b/skills/go-standards/SKILL.md
@@ -9,11 +9,12 @@ description: Applies this repository ecosystem's Go coding, documentation, impor
 
 1. Confirm the task is in a Go repository or touches Go code, Go tests, Go documentation, or Go package APIs.
 2. Read `references/conventions.md` before editing exported APIs, documentation, imports, naming, method layout, or tests.
-3. Before adding, changing, or reviewing imports, inspect nearby package ownership, wrappers, and dependency direction so import choices follow the repository's package model while code is written and reviewed.
-4. Preserve the repository's existing Go package shape and public API style.
-5. Add or update Go tests when behavior changes and the repository supports tests.
-6. Pair this skill with `$testing-standards` when designing, reviewing, or refactoring Go test coverage.
-7. Pair this skill with `change-validation` when selecting Go test, lint, coverage, or benchmark commands.
+3. Before writing Go code that adds or changes imports, inspect nearby files in the same package and adjacent packages for existing import names, package ownership, wrappers, and dependency direction.
+4. Do not invent Go import aliases while writing code. Add an alias only after confirming the package's declared name would collide or create required disambiguation, and document that choice in your reasoning.
+5. Preserve the repository's existing Go package shape and public API style.
+6. Add or update Go tests when behavior changes and the repository supports tests.
+7. Pair this skill with `$testing-standards` when designing, reviewing, or refactoring Go test coverage.
+8. Pair this skill with `change-validation` when selecting Go test, lint, coverage, or benchmark commands.
 
 ## References
 

--- a/skills/go-standards/agents/openai.yaml
+++ b/skills/go-standards/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Go Standards"
-  short_description: "Apply Go conventions for these repos"
-  default_prompt: "Use $go-standards when changing Go code in this repository."
+  short_description: "Apply Go conventions, including no guessed import aliases"
+  default_prompt: "Use $go-standards when changing Go code in this repository. Before writing imports, inspect nearby files for existing package names and wrappers. Do not invent import aliases; use an alias only for a confirmed collision or required disambiguation."

--- a/skills/go-standards/references/conventions.md
+++ b/skills/go-standards/references/conventions.md
@@ -39,8 +39,9 @@ Use this reference when working in Go repositories.
 ## Imports And Naming
 
 - Apply these import rules while writing or reviewing code, before adding, approving, or keeping a direct import or alias.
+- Before writing code that adds or changes imports, inspect nearby files in the same package and adjacent packages for existing import names and package patterns. Match the existing unaliased package name unless a real collision requires otherwise.
 - Resolve wrapper ownership before deciding import aliases: first decide whether code should use or expand a project wrapper, then decide whether any remaining import needs an alias.
-- Do not alias a Go import unless there is a real collision or required disambiguation.
+- Do not alias a Go import unless there is a real collision or required disambiguation. Do not preemptively alias imports for readability, brevity, style, or guesswork.
 - If a project package has the same name as a standard-library package, keep the project package unaliased. Prefer adding missing wrapper functionality to the project package over importing the standard-library package directly. If the standard-library import is still needed, alias only that import.
 - If a project package wraps or centralizes another project, standard-library, or external package, prefer the project wrapper package and add missing surface there when that matches the repository's API shape.
 - When a project package wraps or centralizes an external package, prefer expanding the project wrapper with a narrow missing constant, helper, constructor, or contract-checking function before importing the external package directly from nearby code or tests. Keep the added wrapper surface within the package's documented responsibility. Import the external package directly only when the needed API is outside that responsibility, too broad to wrap honestly, or would make the project wrapper misleading.


### PR DESCRIPTION
## What

- Require Go-writing agents to inspect nearby package patterns before adding imports.
- Make guessed Go import aliases explicitly disallowed in the skill workflow, conventions, and OpenAI prompt metadata.

## Why

- Agents were still inventing aliases during code-writing even though review guidance could catch them later.
- Moving the rule into the active workflow and default prompt makes the constraint visible before code is generated.

## Testing

- yaml ok - passed
- Inspecting 3 files
...

3 files inspected, no offenses detected - passed
