### PR TITLE
feat(skills): tighten routing metadata

### DIFF
--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: Reviews changed code for bugs, regressions, risky assumptions, missing tests, compatibility breaks, missing documentation, and language-specific maintainability or idiom risks. Use when the user asks for a general code review, diff review, PR check, or pre-merge issue pass; delegate explicit security scope to security-audit.
+description: Reviews changed code for bugs, regressions, risky assumptions, missing tests, compatibility breaks, missing documentation, and language-specific maintainability or idiom risks. Use when the user asks for a general code review, diff review, PR check, or pre-merge issue pass; delegate explicit security scope to $security-audit.
 ---
 
 # Code Review

--- a/skills/doc-gaps/SKILL.md
+++ b/skills/doc-gaps/SKILL.md
@@ -28,7 +28,10 @@ Do not combine the two modes in one pass.
    - documentation files directly under the requested root package/folder.
    - source files directly under the requested root package/folder whose comments or docstrings are in scope.
    - each first-level subpackage/subfolder under the requested root.
-12. Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough documentation review for its assigned scope, pairing with relevant language standards (`$go-standards`, `$ruby-standards`, `$shell-standards`) before recording language-specific comment, docstring, or API documentation findings, `$naming-standards` for unclear or inconsistent documentation terminology, command/API names, examples, comments, or public vocabulary, and `$change-validation` for likely validation commands.
+12. Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough documentation review for its assigned scope, pairing with:
+   - relevant language standards (`$go-standards`, `$ruby-standards`, `$shell-standards`) before recording language-specific comment, docstring, or API documentation findings.
+   - `$naming-standards` when documentation terminology, command/API names, examples, comments, or public vocabulary are unclear or inconsistent.
+   - `$change-validation` for likely validation commands.
 13. Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
 14. Wait for all agents to finish before aggregating results.
 15. Deduplicate overlapping findings and resolve conflicting agent conclusions by re-checking the code and docs directly.

--- a/skills/go-standards/SKILL.md
+++ b/skills/go-standards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: go-standards
-description: Applies this repository ecosystem's Go coding, documentation, import, naming idiom, and testing conventions. Use when writing, reviewing, refactoring, or documenting Go packages in repos that use this shared ./bin tooling; pair with $naming-standards for cross-language concept clarity and rename safety.
+description: Applies this repository ecosystem's Go coding, documentation, import, naming idiom, and testing conventions. Use when writing, reviewing, refactoring, or documenting Go packages in repos that use this shared ./bin tooling; pair with $naming-standards when names or renames are part of the change.
 ---
 
 # Go Standards

--- a/skills/naming-standards/SKILL.md
+++ b/skills/naming-standards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: naming-standards
-description: Applies cross-language naming judgment for domain clarity, vocabulary consistency, abstraction level, ambiguity, boolean phrasing, public API terminology, and rename safety. Use when writing, reviewing, refactoring, documenting, or discussing names across code, tests, commands, configuration, docs, and public interfaces; pair with language standards for language-specific idioms.
+description: Applies cross-language naming judgment for domain clarity, vocabulary consistency, abstraction level, ambiguity, boolean phrasing, public API terminology, and rename safety. Use when writing, reviewing, refactoring, documenting, or discussing names across code, tests, commands, configuration, docs, and public interfaces; pair with $go-standards, $ruby-standards, or $shell-standards for language-specific idioms.
 ---
 
 # Naming Standards

--- a/skills/naming-standards/agents/openai.yaml
+++ b/skills/naming-standards/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Naming Standards"
   short_description: "Cross-language naming judgment"
-  default_prompt: "Use $naming-standards when names are part of a code, test, docs, command, configuration, or public API change; pair with language standards for language-specific idioms."
+  default_prompt: "Use $naming-standards when names are part of a code, test, docs, command, configuration, or public API change; pair with $go-standards, $ruby-standards, or $shell-standards for language-specific idioms."

--- a/skills/ruby-standards/SKILL.md
+++ b/skills/ruby-standards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ruby-standards
-description: Applies this repository ecosystem's Ruby coding, API, documentation, naming idiom, style, and test-entrypoint conventions. Use when writing, reviewing, refactoring, documenting, linting, or validating Ruby code in repos that use this shared ./bin tooling; pair with $naming-standards for cross-language concept clarity and rename safety.
+description: Applies this repository ecosystem's Ruby coding, API, documentation, naming idiom, style, and test-entrypoint conventions. Use when writing, reviewing, refactoring, documenting, linting, or validating Ruby code in repos that use this shared ./bin tooling; pair with $naming-standards when names or renames are part of the change.
 ---
 
 # Ruby Standards

--- a/skills/shell-standards/SKILL.md
+++ b/skills/shell-standards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shell-standards
-description: Applies this repository ecosystem's Bash scripting, ShellCheck, text-processing, directory-scope, naming idiom, and function documentation conventions. Use when writing, reviewing, refactoring, linting, or documenting shell scripts in repos that use this shared ./bin tooling; pair with $naming-standards for cross-language concept clarity and rename safety.
+description: Applies this repository ecosystem's Bash scripting, ShellCheck, text-processing, directory-scope, naming idiom, and function documentation conventions. Use when writing, reviewing, refactoring, linting, or documenting shell scripts in repos that use this shared ./bin tooling; pair with $naming-standards when names or renames are part of the change.
 ---
 
 # Shell Standards

--- a/skills/testing-standards/SKILL.md
+++ b/skills/testing-standards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testing-standards
-description: Applies language-agnostic test design, test-first/TDD or scenario-first/BDD workflow, coverage, fixtures, determinism, and test-layer conventions. Use when adding, reviewing, refactoring, or planning tests across languages; pair with language standards for language-specific idioms and change-validation for commands.
+description: Applies language-agnostic test design, test-first/TDD or scenario-first/BDD workflow, coverage, fixtures, determinism, and test-layer conventions. Use when adding, reviewing, refactoring, or planning tests across languages; pair with $go-standards, $ruby-standards, or $shell-standards for language-specific idioms and $change-validation for commands.
 ---
 
 # Testing Standards


### PR DESCRIPTION
## What

- Tighten skill frontmatter so composition with naming, security, validation, and language standards is explicit at routing time.
- Split the doc-gap composition step into conditional bullets for language docs, naming terminology, and validation commands.
- Align the naming standards UI prompt with the explicit language-standard routing.

## Why

- Metadata is seen before skill bodies, so routing gates need to preserve useful vocabulary while reducing over-triggering and ambiguity.
- Clearer composition points should make skill activation more predictable without rewriting the underlying workflows.

## Testing

- `git diff --check` - passed
- `ruby -e 'require "yaml"; Dir["skills/**/{SKILL.md,openai.yaml}"].sort.each { |f| YAML.load_file(f) }; puts "yaml ok"'` - passed
- `make lint` - passed
- `make sec-lint` - passed
