### PR TITLE
feat(skills): add polish review guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,8 @@ skill instead of one broad default:
 - `naming-standards`: cross-language naming judgment for domain clarity,
   consistency, abstraction level, public terminology, and rename safety.
 - `code-review`: review findings, risk assessment, and missing coverage.
+- `style-review`: non-blocking readability, consistency, idiom, and polish
+  suggestions that should not be reported as code-review findings.
 - `security-audit`: security reviews, vulnerability checks, unsafe shell/filesystem/network/auth inspection, and Go/Ruby/shell audit guidance.
 - `code-issues`: find confirmed code issues into `ISSUES.md`, then implement agreed fixes one code issue at a time.
 - `test-gaps`: find confirmed missing or weak tests into `ISSUES.md`, then implement agreed test fixes gap by gap.
@@ -56,7 +58,7 @@ Common composition:
 
 - `review-pr` orchestrates PR preparation with `project-workflow`,
   `change-validation`, relevant language standards, `code-review`, summary
-  drafting, and the review target.
+  drafting, optional explicit `style-review`, and the review target.
 - `code-issues` orchestrates a two-phase code-issue workflow: aggregate confirmed
   `project-workflow`, `code-review`, and `security-audit` findings into
   `ISSUES.md`, then implement agreed fixes one code issue at a time.
@@ -69,6 +71,9 @@ Common composition:
   implement agreed doc fixes gap by gap.
 - `code-review` conditionally consults `security-audit` for security-sensitive
   review scope while keeping the review findings format.
+- `style-review` performs an optional non-blocking polish pass when explicitly
+  requested, after or separate from `code-review`; it must not replace bug,
+  security, compatibility, test-gap, or doc-gap review.
 - `security-audit` pairs with `change-safety` for code changes and
   `change-validation` for scanner, lint, or CI command selection.
 - `testing-standards` pairs with language standards for test idioms and

--- a/skills/README.md
+++ b/skills/README.md
@@ -8,7 +8,7 @@ checks, and findings.
 
 - `review-pr` orchestrates PR preparation with `project-workflow`,
   `change-validation`, relevant language standards, `code-review`, summary
-  drafting, and the review target.
+  drafting, optional explicit `style-review`, and the review target.
 - `code-issues` orchestrates a two-phase code-issue workflow: first aggregate confirmed
   `project-workflow`, `code-review`, and `security-audit` findings into
   `ISSUES.md`, then implement agreed fixes one code issue at a time.
@@ -21,6 +21,9 @@ checks, and findings.
   doc fixes one gap at a time.
 - `code-review` performs the review pass and conditionally consults
   `security-audit` for security-sensitive scope.
+- `style-review` performs an optional non-blocking polish pass when explicitly
+  requested, after or separate from `code-review`; it must not replace bug,
+  security, compatibility, test-gap, or doc-gap review.
 - `security-audit` pairs with `change-safety` for code changes and
   `change-validation` for scanner, lint, or CI command selection.
 - `testing-standards` covers language-agnostic test design and coverage

--- a/skills/code-issues/SKILL.md
+++ b/skills/code-issues/SKILL.md
@@ -12,6 +12,12 @@ Use this skill in two distinct modes:
 
 Do not combine the two modes in one pass.
 
+## Operating Stance
+
+Operate as a strict issue triager and ledger owner: separate confirmed code
+defects from test gaps, doc gaps, polish, and speculation; keep the scoped
+`ISSUES.md` actionable, deduplicated, and tied to user-visible or contract risk.
+
 ## Find Mode
 
 1. Identify the requested package or folder scope. If no scope is provided, stop and ask for the package or folder.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -5,6 +5,12 @@ description: Reviews changed code for bugs, regressions, risky assumptions, miss
 
 # Code Review
 
+## Operating Stance
+
+Operate as a skeptical reviewer: prioritize confirmed behavioral risk over
+style, and report only findings grounded in changed code, concrete evidence,
+and credible user, compatibility, security, maintenance, or test impact.
+
 ## Steps
 
 1. Identify the changed files or requested review scope.
@@ -12,7 +18,7 @@ description: Reviews changed code for bugs, regressions, risky assumptions, miss
 3. Inspect behavior, tests, compatibility, security, docs, and maintenance risk before style preferences.
 4. First identify high-risk review leads, especially deletions, cross-boundary drift, silent behavior changes, changed contracts, unhandled sibling cases, and error-path changes. Then verify concrete findings instead of reviewing every line uniformly.
 5. Prefer precision over recall. Do not report plausible concerns unless they survive attempts to disprove them and are grounded in changed code, concrete evidence, and credible user, compatibility, security, maintenance, or test risk.
-6. Pair with relevant language standards (`$go-standards`, `$ruby-standards`, `$shell-standards`) when reviewing language-specific code, APIs, docs, tests, or tooling behavior. Pair with `$naming-standards` when names create concrete ambiguity, misuse risk, public contract confusion, inconsistent vocabulary, or maintenance cost. Treat idiomatic style concerns as findings only when they create concrete readability, maintenance, correctness, compatibility, or public API risk.
+6. Pair with relevant language standards (`$go-standards`, `$ruby-standards`, `$shell-standards`) when reviewing language-specific code, APIs, docs, tests, or tooling behavior. Pair with `$naming-standards` when names create concrete ambiguity, misuse risk, public contract confusion, inconsistent vocabulary, or maintenance cost. Treat idiomatic style concerns as findings only when they create concrete readability, maintenance, correctness, compatibility, or public API risk; use `$style-review` instead for non-blocking polish when the user asks for style nits or a readability pass.
 7. Use `$testing-standards` when judging whether tests are missing, weak, overfit to internals, hard to read, or at the wrong layer.
 8. If the review scope includes security-sensitive code, configuration, dependencies, shell execution, filesystem writes/deletes, network/auth/TLS behavior, secrets/env handling, Docker helpers, or CI/security tooling, consult `$security-audit` and the smallest matching security reference; keep this skill's findings format.
 9. Verify claims against concrete file and line references whenever possible.
@@ -23,3 +29,4 @@ description: Reviews changed code for bugs, regressions, risky assumptions, miss
 
 - Read `references/findings-format.md` for review priorities, output format, and what to say when no issues are found.
 - Use relevant language standards for idiomatic code, API, docs, test, and tooling conventions.
+- Use `$style-review` for non-blocking style, readability, consistency, idiom, or cleanup suggestions that do not rise to code-review findings.

--- a/skills/code-review/references/findings-format.md
+++ b/skills/code-review/references/findings-format.md
@@ -6,7 +6,8 @@ Use this reference when the user asks for a review.
 
 - Prioritize bugs, behavioral regressions, risky assumptions, and missing coverage.
 - Flag missing tests, compatibility breaks, unsafe defaults, and missing docs when they materially affect the change.
-- Focus on user-visible impact and maintenance risk before style nits.
+- Focus on user-visible impact and maintenance risk. Do not report style nits
+  as findings; use `$style-review` when the user asks for non-blocking polish.
 - Prefer concrete findings over broad summaries.
 - Ground each finding in the inspected code and describe the consequence, not just the preference.
 - Avoid broad "consider checking" comments. Each finding needs a concrete changed location, behavior at risk, evidence, and a clear place to start fixing.

--- a/skills/doc-gaps/SKILL.md
+++ b/skills/doc-gaps/SKILL.md
@@ -12,6 +12,12 @@ Use this skill in two distinct modes:
 
 Do not combine the two modes in one pass.
 
+## Operating Stance
+
+Operate as a documentation triager: protect users, operators, and maintainers
+from concrete misunderstanding, and reject wording preferences or exhaustive
+private-code commentary that do not reduce real use or maintenance risk.
+
 ## Find Mode
 
 1. Identify the requested package or folder scope. If no scope is provided, stop and ask for the package or folder.

--- a/skills/naming-standards/SKILL.md
+++ b/skills/naming-standards/SKILL.md
@@ -9,6 +9,12 @@ Use this skill when names are part of the work: public APIs, packages, modules,
 commands, flags, environment variables, files, tests, fixtures, domain objects,
 helper functions, or documentation terminology.
 
+## Operating Stance
+
+Operate as a domain vocabulary steward: prefer names that make the concept,
+contract, and audience obvious, and treat a rename as worthwhile only when it
+reduces ambiguity, misuse risk, compatibility risk, or maintenance cost.
+
 ## Steps
 
 1. Identify the named thing's role, audience, and stability: public API,

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -18,31 +18,34 @@ description: Reviews, validates, commits, force-pushes, and opens a draft pull r
 9. If the changed paths include shell scripts, Bash helpers, ShellCheck config/directives, shell docs, or script behavior, also use `$shell-standards`.
 10. If the changed paths include tests, test helpers, fixtures, or changes that raise test coverage or test-design questions, also use `$testing-standards`.
 11. Use `$code-review` to inspect the current change before drafting PR text.
-12. Resolve any blocking review findings before continuing; if findings remain intentionally unresolved, call them out in the PR summary.
-13. If `$code-review` reports security findings or security validation gaps, resolve them or document them in the PR summary before `make review`.
-14. Read `references/summary-format.md`, then draft a lowercase, unprefixed `msg` and multiline Markdown `desc` from the current working tree.
-15. Follow the commit-subject rules: `make review` adds the branch-derived `type(scope):` prefix, so treat branch words as routing metadata rather than message source material and do not repeat the type or scope in `msg`.
-16. Keep `desc` in the summary format, including honest testing details.
-17. When attribution is appropriate or requested, append this footer to the summary instead of a `Co-authored-by:` trailer:
+12. If the user explicitly asks for style nits, polish, readability review, or non-blocking cleanup comments before the PR, also use `$style-review` after the code-review pass.
+13. Resolve any blocking review findings before continuing. Do not run `make review` while blocking findings remain unless the human explicitly says to open a draft PR with those findings unresolved; in that case, call them out in the PR summary.
+14. If `$code-review` reports security findings or security validation gaps, resolve them or document them in the PR summary before `make review`.
+15. Treat `$style-review` notes as non-blocking unless the user explicitly asks to resolve them before opening the PR.
+16. Read `references/summary-format.md`, then draft a lowercase, unprefixed `msg` and multiline Markdown `desc` from the current working tree.
+17. Follow the commit-subject rules: `make review` adds the branch-derived `type(scope):` prefix, so treat branch words as routing metadata rather than message source material and do not repeat the type or scope in `msg`.
+18. Keep `desc` in the summary format, including honest testing details.
+19. When attribution is appropriate or requested, append this footer to the summary instead of a `Co-authored-by:` trailer:
 
 ```text
 AI-assisted-by: [Codex](https://openai.com/codex/)
 ```
 
-18. Run the review target with the drafted values:
+20. Run the review target with the drafted values:
 
 ```bash
 make msg="unprefixed subject" desc="summary" review
 ```
 
-19. Pass `desc` as the multiline Markdown summary; do not flatten the summary into a single line.
-20. Read `references/output-format.md`, then report the result using that exact structure; do not add, remove, rename, or reorder sections.
+21. Pass `desc` as the multiline Markdown summary; do not flatten the summary into a single line.
+22. Read `references/output-format.md`, then report the result using that exact structure; do not add, remove, rename, or reorder sections.
 
 ## References
 
 - Read `references/summary-format.md` before drafting the `msg` and `desc` values.
 - Read `references/output-format.md` before producing the final review PR report.
 - Use `$project-workflow` for repository command discovery, CI expectations, and `./bin` wiring before validation and `make review`.
+- Use `$style-review` only when the user explicitly asks for non-blocking polish before the PR.
 
 ## Notes
 

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -5,6 +5,12 @@ description: Reviews security-sensitive code, scripts, Makefile glue, Docker hel
 
 # Security Audit
 
+## Operating Stance
+
+Operate as a practical security auditor: follow concrete data and control flow,
+rank exploitable paths first, and avoid checklist findings that do not have a
+specific trigger in the audited code or configuration.
+
 ## Steps
 
 1. Identify the audit scope: changed files, whole repository, language-specific code, or a named command path.

--- a/skills/style-review/SKILL.md
+++ b/skills/style-review/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: style-review
+description: Reviews code, tests, docs-adjacent comments, scripts, and diffs for non-blocking style polish, readability, local consistency, idiom, small simplifications, naming polish, and maintainability cleanup suggestions. Use when the user asks for style nits, polish, readability review, cleanup suggestions, non-blocking review comments, idiomatic cleanup, or a softer pass after code-review; do not use for bugs, security issues, compatibility breaks, or missing test/doc findings.
+---
+
+# Style Review
+
+## Operating Stance
+
+Operate as a non-blocking polish reviewer: prefer local consistency and
+readability over personal taste, and never present style notes as correctness,
+security, compatibility, testing, or documentation findings.
+
+## Steps
+
+1. Identify the changed files or requested style-review scope.
+2. Inspect nearby code, tests, docs, scripts, and project conventions before
+   suggesting style changes.
+3. Pair with relevant language standards (`$go-standards`, `$ruby-standards`,
+   `$shell-standards`) for language-specific idiom. Pair with
+   `$naming-standards` when a style note depends on name clarity, vocabulary, or
+   consistency.
+4. Keep this skill limited to non-blocking polish: readability, structure,
+   local consistency, unnecessary cleverness, small simplifications, comment
+   clarity, naming polish, assertion clarity, fixture readability, and idiom.
+5. Do not report bugs, regressions, security risks, compatibility breaks,
+   missing tests, missing docs, or broken public contracts as style notes.
+   Recommend `$code-review`, `$security-audit`, `$test-gaps`, or `$doc-gaps`
+   instead when those are the real issue.
+6. Prefer concrete suggestions over taste. Each note should explain why the
+   change would make the code easier to read, maintain, or align with local
+   patterns.
+7. Do not create or update `ISSUES.md`; style notes are not ledger findings.
+8. When style-review is the final response, use the exact structure below; do
+   not add, remove, rename, or reorder sections.
+9. When another skill embeds style notes, preserve the non-blocking nature,
+   file references, suggestions, and rationale in the caller's output format.
+
+## Output Format
+
+Use exactly this Markdown structure:
+
+```markdown
+## Style Notes
+
+- path/to/file:line - Non-blocking note title.
+  Why: Explain the readability, consistency, idiom, or maintenance benefit.
+  Suggestion: Describe the smallest clear polish change.
+
+## Optional Cleanups
+
+- Optional cleanup that is not worth blocking the change.
+```
+
+Use `- None.` for any empty section. Keep notes short and explicitly
+non-blocking. If a concern would be worth blocking a change, it belongs in
+another review skill instead.
+
+## References
+
+- Use relevant language standards for language-specific readability, idiom, and
+  local convention checks.
+- Use `$naming-standards` when names create unclear or inconsistent style.
+- Use `$code-review` instead when a concern has correctness, compatibility,
+  maintenance-risk, security, documentation, or testing impact strong enough to
+  be a finding.

--- a/skills/style-review/agents/openai.yaml
+++ b/skills/style-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Style Review"
+  short_description: "Review non-blocking code polish"
+  default_prompt: "Use $style-review for non-blocking readability, consistency, idiom, naming-polish, and cleanup suggestions that should not be reported as code-review findings."

--- a/skills/test-gaps/SKILL.md
+++ b/skills/test-gaps/SKILL.md
@@ -12,6 +12,12 @@ Use this skill in two distinct modes:
 
 Do not combine the two modes in one pass.
 
+## Operating Stance
+
+Operate as a coverage triager: protect repository-owned behavior through the
+narrowest credible established test layer, and reject gaps that only test
+dependency semantics, private implementation detail, or coverage vanity.
+
 ## Find Mode
 
 1. Identify the requested package or folder scope. If no scope is provided, stop and ask for the package or folder.

--- a/skills/testing-standards/SKILL.md
+++ b/skills/testing-standards/SKILL.md
@@ -5,6 +5,12 @@ description: Applies language-agnostic test design, test-first/TDD or scenario-f
 
 # Testing Standards
 
+## Operating Stance
+
+Operate as a behavior-focused test designer: make tests describe observable
+repository-owned behavior, prefer established local test shapes, and keep
+coverage useful, deterministic, and readable rather than mechanically broad.
+
 ## Steps
 
 1. Confirm the task involves adding tests, changing tests, reviewing test quality, planning coverage, or deciding where behavior should be exercised.


### PR DESCRIPTION
## What

- Add a dedicated `style-review` workflow for non-blocking polish notes.
- Add operating stances to review, audit, gap, testing, and naming workflows.
- Wire polish review into the review PR flow as an explicit opt-in and keep blocking review findings gated.

## Why

- Keep bug, security, test, and documentation findings separate from style nits.
- Give future agents clearer judgment posture for triage and review workflows.

## Testing

- `make dep` - passed
- `make lint` - passed
- `make sec-lint` - passed
- `make scripts-lint` - passed
- `make docker-lint` - passed
- `git diff --check` - passed
- Ruby YAML parsing for touched skill frontmatter and metadata - passed
- `quick_validate.py skills/style-review` - not run successfully; PyYAML is unavailable in this Python environment

AI-assisted-by: [Codex](https://openai.com/codex/)
