### PR TITLE
feat(skills): separate doc polish from doc findings

### DIFF
--- a/skills/style-review/SKILL.md
+++ b/skills/style-review/SKILL.md
@@ -27,13 +27,18 @@ security, compatibility, testing, or documentation findings.
    missing tests, missing docs, or broken public contracts as style notes.
    Recommend `$code-review`, `$security-audit`, `$test-gaps`, or `$doc-gaps`
    instead when those are the real issue.
-6. Prefer concrete suggestions over taste. Each note should explain why the
+6. Treat GoDoc link syntax, comment wording, and local readability as style
+   notes only when the existing documentation is accurate enough. If the note
+   would add, remove, or materially change public API behavior, safety
+   constraints, panic/error behavior, lifecycle semantics, defaults, or
+   operational guidance, route it to `$doc-gaps` or `$code-review` instead.
+7. Prefer concrete suggestions over taste. Each note should explain why the
    change would make the code easier to read, maintain, or align with local
    patterns.
-7. Do not create or update `ISSUES.md`; style notes are not ledger findings.
-8. When style-review is the final response, use the exact structure below; do
+8. Do not create or update `ISSUES.md`; style notes are not ledger findings.
+9. When style-review is the final response, use the exact structure below; do
    not add, remove, rename, or reorder sections.
-9. When another skill embeds style notes, preserve the non-blocking nature,
+10. When another skill embeds style notes, preserve the non-blocking nature,
    file references, suggestions, and rationale in the caller's output format.
 
 ## Output Format

--- a/skills/style-review/agents/openai.yaml
+++ b/skills/style-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Style Review"
   short_description: "Review non-blocking code polish"
-  default_prompt: "Use $style-review for non-blocking readability, consistency, idiom, naming-polish, and cleanup suggestions that should not be reported as code-review findings."
+  default_prompt: "Use $style-review for non-blocking readability, consistency, idiom, naming-polish, doc-polish, and cleanup suggestions that should not be reported as code-review or doc-gap findings."


### PR DESCRIPTION
## What

- Add a style-review guardrail that keeps GoDoc/comment polish separate from substantive documentation findings.
- Update the style-review agent prompt to mention doc-polish and doc-gap boundaries.

## Why

- Prevent safety, behavior, lifecycle, default, or operational documentation changes from being treated as non-blocking style notes.

## Testing

- `make dep` - passed
- `git diff --check` - passed
- `make lint` - passed
- `make scripts-lint` - passed
- `make docker-lint` - passed
- `make sec-lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
