### PR TITLE
feat(skills): clarify review summary expectations

### DIFF
--- a/skills/review-pr/references/summary-format.md
+++ b/skills/review-pr/references/summary-format.md
@@ -18,15 +18,27 @@ Use this reference when drafting the `msg` and `desc` values for `make review`.
 ```markdown
 ## What
 
-- Describe the concrete change.
+- Describe what changed in terms of behavior, documentation, commands,
+  configuration, or public/reviewer-visible outcomes.
+- Mention the context the code cannot fully tell the reviewer, such as scope,
+  intentional boundaries, compatibility notes, non-goals, or user-facing effect.
+- Avoid implementation mechanics unless they are the observable change.
 
 ## Why
 
-- Describe why the change was made.
+- Explain why the PR matters: the problem, risk, workflow gap, maintenance
+  benefit, or user value it addresses.
+- Make this the selling point of the PR.
+- Do not repeat the What section or rely on the diff to imply motivation.
 
 ## Testing
 
 - `command` - passed
+- Mention new or changed tests and what behavior, edge case, or risk they cover.
+- Mention expected CI coverage only as additional verification, not as a
+  replacement for unrun local checks.
+- Call out validation gaps, manual verification still needed, or intentionally
+  scoped testing.
 ```
 
 - Do not add markdown, labels, bullets, quotes, or surrounding commentary to `msg`.


### PR DESCRIPTION
## What

- Expands review-pr summary guidance for What, Why, and Testing so PR bodies explain reviewer-visible scope, motivation, and validation expectations.
- Keeps the existing three-section format unchanged and clarifies that implementation details only belong when they are observable.

## Why

- Helps future review PRs carry the context the diff cannot show on its own, especially why the change matters and what validation gaps remain.
- Gives reviewers a better signal for approval without adding extra PR sections or changing the review workflow.

## Testing

- `git diff --check -- skills/review-pr/references/summary-format.md` - passed
- `make dep` - passed
- `make clean-dep` - passed
- `make scripts-lint` - passed
- `make docker-lint` - passed
- `make lint` - passed after dependency cleanup
- `make sec-lint` - passed
- No new tests were added because this change updates Markdown guidance only; CI will run the standard repo checks again.
- No manual verification gaps identified.
