### PR TITLE
feat(skills): clarify finding severity ratings

### DIFF
--- a/skills/code-issues/SKILL.md
+++ b/skills/code-issues/SKILL.md
@@ -35,17 +35,18 @@ defects from test gaps, doc gaps, polish, and speculation; keep the scoped
    - each first-level subpackage/subfolder under the requested root.
 12. Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough and accurate `$code-review` and `$security-audit` for its assigned scope, using `$testing-standards` for concrete missing-coverage or weak-test analysis and `$change-validation` for likely validation commands.
 13. Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
-14. Wait for all agents to finish before aggregating results.
-15. Deduplicate overlapping findings and resolve conflicting agent conclusions by re-checking the code directly.
-16. Confirm each candidate finding against the code before recording it. Findings must be concrete bugs, security issues, compatibility breaks, or violated public contracts with user-visible impact.
-17. Do not record standalone missing, weak, flaky, misleading, or wrong-layer tests as code issues unless they are tied to a confirmed bug, security issue, compatibility break, or violated public contract. Use `$test-gaps` for standalone missing or weak test coverage passes.
-18. Do not record standalone missing, weak, stale, misleading, or wrong-location documentation, README, example, comment, or docstring gaps as code issues unless they reveal a confirmed bug, security issue, compatibility break, or violated public contract. Use `$doc-gaps` for standalone documentation review passes.
-19. Do not report optional regression tests, unused convenience aliases, API symmetry, or documentation polish as findings by themselves. List them only as testing gaps, doc gaps, or optional follow-up notes when relevant.
-20. If no confirmed code issues are found, report that no code issues were found and do not create `ISSUES.md`.
-21. If confirmed code issues are found, write all findings to the scoped `ISSUES.md` before making any fixes.
-22. Assign every finding a unique ID for the session in the form `ISSUE-<number>`.
-23. Present the scoped `ISSUES.md` and a proposed fix plan to the user.
-24. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
+14. Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity.
+15. Wait for all agents to finish before aggregating results.
+16. Deduplicate overlapping findings and resolve conflicting agent conclusions by re-checking the code directly.
+17. Confirm each candidate finding against the code before recording it. Findings must be concrete bugs, security issues, compatibility breaks, or violated public contracts with user-visible impact.
+18. Do not record standalone missing, weak, flaky, misleading, or wrong-layer tests as code issues unless they are tied to a confirmed bug, security issue, compatibility break, or violated public contract. Use `$test-gaps` for standalone missing or weak test coverage passes.
+19. Do not record standalone missing, weak, stale, misleading, or wrong-location documentation, README, example, comment, or docstring gaps as code issues unless they reveal a confirmed bug, security issue, compatibility break, or violated public contract. Use `$doc-gaps` for standalone documentation review passes.
+20. Do not report optional regression tests, unused convenience aliases, API symmetry, or documentation polish as findings by themselves. List them only as testing gaps, doc gaps, or optional follow-up notes when relevant.
+21. If no confirmed code issues are found, report that no code issues were found and do not create `ISSUES.md`.
+22. If confirmed code issues are found, write all findings to the scoped `ISSUES.md` before making any fixes.
+23. Assign every finding a unique ID for the session in the form `ISSUE-<number>`.
+24. Present the scoped `ISSUES.md` and a proposed fix plan to the user.
+25. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
 
 ## `ISSUES.md` Format
 
@@ -98,6 +99,7 @@ Keep optional follow-up notes separate from findings:
 
 ## References
 
+- Use `../references/finding-severity.md` for confidence filtering and severity.
 - Use `$code-review` for review rigor and finding quality.
 - Use `$security-audit` for security-sensitive review scope.
 - Use `$testing-standards` when deciding or reviewing regression coverage.

--- a/skills/code-review/references/findings-format.md
+++ b/skills/code-review/references/findings-format.md
@@ -14,12 +14,14 @@ Use this reference when the user asks for a review.
 
 ## Severity
 
-- `critical`: Near-certain production breakage, data loss or corruption, remote code execution, credential exposure, auth bypass, or a change that makes the project unusable for its primary path.
-- `high`: Likely user-visible regression, compatibility break, security issue, CI or release blocker, or broken primary workflow with a clear trigger.
-- `medium`: Real bug, missing validation, edge-case regression, or maintainability risk that can affect users but is scoped, recoverable, or not on the primary path.
-- `low`: Minor correctness issue, hardening gap, confusing behavior, missing docs or tests for a low-risk path, or maintainability concern with limited impact.
-- Do not inflate severity for style preferences, speculative risks, or missing tests without a concrete failure mode.
-- If severity depends on assumptions about downstream use, state the triggering scenario in `Impact` or `Evidence`.
+- Use `../../references/finding-severity.md` to filter low-confidence
+  candidates before assigning severity.
+- For code-review output, write severity values in lowercase:
+  `critical`, `high`, `medium`, or `low`.
+- Do not inflate severity for style preferences, speculative risks, or missing
+  tests without a concrete failure mode.
+- If severity depends on assumptions about downstream use, state the triggering
+  scenario in `Impact` or `Evidence`.
 
 ## Output Format
 

--- a/skills/doc-gaps/SKILL.md
+++ b/skills/doc-gaps/SKILL.md
@@ -39,17 +39,18 @@ private-code commentary that do not reduce real use or maintenance risk.
    - `$naming-standards` when documentation terminology, command/API names, examples, comments, or public vocabulary are unclear or inconsistent.
    - `$change-validation` for likely validation commands.
 13. Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
-14. Wait for all agents to finish before aggregating results.
-15. Deduplicate overlapping findings and resolve conflicting agent conclusions by re-checking the code and docs directly.
-16. Confirm each candidate gap against the code, current docs, examples, and documented interfaces before recording it. Gaps must be concrete missing, weak, stale, misleading, or wrong-location documentation with credible risk to users, operators, maintainers, public APIs, documented command behavior, onboarding, setup, or contribution workflows.
-17. Do not record confirmed production bugs, security issues, compatibility breaks, or violated public contracts as doc gaps. If broken behavior is discovered during review, report it as out of scope for the doc-gap ledger and recommend `$code-issues`; use this skill when unclear, missing, stale, or misleading documentation is the finding.
-18. Do not record standalone missing, weak, flaky, misleading, or wrong-layer tests as doc gaps. Recommend `$test-gaps` when the unprotected behavior is the finding.
-19. Do not report arbitrary wording preferences, style nits, exhaustive private implementation comments, or optional documentation polish as findings by themselves. List them only as optional follow-up notes when relevant.
-20. If no confirmed doc gaps are found, report that no doc gaps were found and do not create `ISSUES.md`.
-21. If confirmed doc gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
-22. Assign every finding a unique ID for the session in the form `DOC-<number>`.
-23. Present the scoped `ISSUES.md` and a proposed doc-fix plan to the user.
-24. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
+14. Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity.
+15. Wait for all agents to finish before aggregating results.
+16. Deduplicate overlapping findings and resolve conflicting agent conclusions by re-checking the code and docs directly.
+17. Confirm each candidate gap against the code, current docs, examples, and documented interfaces before recording it. Gaps must be concrete missing, weak, stale, misleading, or wrong-location documentation with credible risk to users, operators, maintainers, public APIs, documented command behavior, onboarding, setup, or contribution workflows.
+18. Do not record confirmed production bugs, security issues, compatibility breaks, or violated public contracts as doc gaps. If broken behavior is discovered during review, report it as out of scope for the doc-gap ledger and recommend `$code-issues`; use this skill when unclear, missing, stale, or misleading documentation is the finding.
+19. Do not record standalone missing, weak, flaky, misleading, or wrong-layer tests as doc gaps. Recommend `$test-gaps` when the unprotected behavior is the finding.
+20. Do not report arbitrary wording preferences, style nits, exhaustive private implementation comments, or optional documentation polish as findings by themselves. List them only as optional follow-up notes when relevant.
+21. If no confirmed doc gaps are found, report that no doc gaps were found and do not create `ISSUES.md`.
+22. If confirmed doc gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
+23. Assign every finding a unique ID for the session in the form `DOC-<number>`.
+24. Present the scoped `ISSUES.md` and a proposed doc-fix plan to the user.
+25. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
 
 ## Documentation Review Standards
 
@@ -113,6 +114,7 @@ Keep optional follow-up notes separate from findings:
 
 ## References
 
+- Use `../references/finding-severity.md` for confidence filtering and severity.
 - Use `$project-workflow` for repository command discovery, documented entrypoints, CI expectations, examples, and `./bin` wiring before review planning or validation.
 - Use relevant language standards for code comments, public API docs, and examples.
 - Use `$naming-standards` when documentation terminology, command/API names, examples, comments, or public vocabulary are unclear, inconsistent, or misleading.

--- a/skills/references/finding-severity.md
+++ b/skills/references/finding-severity.md
@@ -1,0 +1,44 @@
+# Finding Severity
+
+Use this reference whenever a skill assigns severity to code, test, doc, or
+security findings.
+
+## Confidence And Actionability
+
+Filter candidates before assigning severity. A finding should have concrete
+evidence, a trigger condition, credible impact, and a plausible fix direction.
+
+Discard candidates that are likely false positives, vague suggestions,
+unsupported guesses, style-only preferences, nitpicks, or comments whose impact
+cannot be explained from the inspected code, tests, docs, or command behavior.
+Do not classify uncertain or low-confidence candidates as `Low`; `Low` still
+means a real finding with limited impact.
+
+## Severity
+
+- `Critical`: Near-certain severe production breakage, data loss or corruption,
+  remote code execution, credential exposure, auth bypass, project unusability
+  on its primary path, or a public contract violation with broad severe impact.
+- `High`: Likely user-visible regression, compatibility break, security issue,
+  CI or release blocker, broken primary workflow, or high-risk test or doc gap
+  with a clear trigger.
+- `Medium`: Real bug, missing validation, edge-case regression, weak test
+  coverage, stale or misleading documentation, or maintainability risk that can
+  affect users but is scoped, recoverable, or not on the primary path.
+- `Low`: Minor correctness issue, hardening gap, confusing behavior, missing
+  docs or tests for a low-risk path, or maintainability concern with limited
+  impact.
+
+## Domain Notes
+
+- For code findings, severity tracks the behavior or contract at risk, not how
+  easy the fix is.
+- For test gaps, severity tracks the risk created by missing, weak, misleading,
+  flaky, or wrong-layer coverage, not the amount of test code needed.
+- For doc gaps, severity tracks the risk of user, operator, API, setup, or
+  maintenance misunderstanding, not wording preference.
+- For security findings, use the security-audit reference for domain-specific
+  examples and reporting values; those examples should still follow this
+  impact-based scale.
+- If severity depends on assumptions about downstream use, state the triggering
+  scenario in the finding's impact or evidence.

--- a/skills/security-audit/references/shared.md
+++ b/skills/security-audit/references/shared.md
@@ -55,6 +55,10 @@ Use this reference for any security audit, then load language-specific reference
 
 ## Severity
 
+Use these security-specific examples after filtering out low-confidence or
+unsupported candidates. They align with `../../references/finding-severity.md`,
+but this security-audit report format uses only `High`, `Medium`, and `Low`.
+
 - High: likely secret exposure, auth bypass, command injection, arbitrary file write/delete, path traversal to sensitive files, remote code execution, or exploitable critical dependency issue.
 - Medium: constrained injection, sensitive information disclosure, unsafe TLS/auth defaults, dangerous local-only behavior likely to be copied into production, or scanner coverage gaps on security-sensitive changes.
 - Low: hardening issue, defense-in-depth improvement, unclear validation gap, or risky pattern without a demonstrated exploit path.

--- a/skills/test-gaps/SKILL.md
+++ b/skills/test-gaps/SKILL.md
@@ -35,22 +35,23 @@ dependency semantics, private implementation detail, or coverage vanity.
    - each first-level subpackage/subfolder under the requested root.
 12. Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough and accurate `$testing-standards` review for its assigned scope, pairing with relevant language standards and `$change-validation` for likely validation commands.
 13. Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally. Each finding must name the repository-owned behavior being protected; reject findings that only test dependency semantics, aliases, or pass-through wrappers.
-14. Wait for all agents to finish before aggregating results.
-15. Deduplicate overlapping findings and resolve conflicting agent conclusions by re-checking the code and tests directly.
-16. Confirm each candidate gap against the code and existing tests before recording it. Gaps must be concrete missing, weak, misleading, flaky, or wrong-layer coverage with credible risk to changed behavior, public contracts, compatibility, release-sensitive workflows, or documented command/API behavior.
-17. For each candidate, explicitly identify the nearby existing test shape and why extending existing tests, fixtures, tables, helpers, or assertions does not already cover the behavior. Do not record a gap when the proposed fix would duplicate coverage already provided by that local shape.
-18. Do not record gaps whose only meaningful test would assert pass-through behavior to an upstream library, standard library, or framework. This includes aliases, type aliases, thin wrappers, direct option forwarding, direct global setter/getter calls, dependency injection container behavior, validator tag behavior, encoder/parser behavior, and constructors where the repository adds no branching, validation, transformation, error handling, lifecycle behavior, compatibility policy, or composition contract of its own.
-19. Only record a gap around third-party integration when the untested behavior is repository-owned. Examples include local validation/normalization before calling the dependency, local input/output mapping, local error wrapping/classification/recovery, lifecycle ordering or cleanup owned by the repository, documented compatibility behavior promised across dependency versions, or end-to-end behavior through a supported public repo entrypoint where multiple repo-owned pieces are composed.
-20. When a candidate gap touches a wrapper around a dependency, explicitly ask: "Would the proposed test fail because repository code changed, or only because the dependency's behavior/shape changed?" Record it only when repository code owns the failing behavior.
-21. Do not record gaps that require build tags, architecture-specific execution, optional services, integration environments, or other validation modes the repository does not normally run, unless the finding is explicitly that CI or the documented validation path must add that mode.
-22. Do not record confirmed production bugs, security issues, compatibility breaks, or violated public contracts as test gaps. If such broken behavior is discovered during review, report it as out of scope for the test-gap ledger and recommend `$code-issues`; use this skill when the unprotected or poorly protected behavior is the finding.
-23. Do not record standalone missing, weak, stale, misleading, or wrong-location documentation, README, example, comment, or docstring gaps as test gaps. Use `$doc-gaps` when documentation itself is the finding.
-24. Do not report optional nice-to-have tests, private implementation coverage, arbitrary coverage percentage improvements, style preferences, or docs-only validation as findings by themselves. List them only as doc gaps or optional follow-up notes when relevant.
-25. If no confirmed test gaps are found, report that no test gaps were found and do not create `ISSUES.md`.
-26. If confirmed test gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
-27. Assign every finding a unique ID for the session in the form `TEST-<number>`.
-28. Present the scoped `ISSUES.md` and a proposed test-fix plan to the user.
-29. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
+14. Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity.
+15. Wait for all agents to finish before aggregating results.
+16. Deduplicate overlapping findings and resolve conflicting agent conclusions by re-checking the code and tests directly.
+17. Confirm each candidate gap against the code and existing tests before recording it. Gaps must be concrete missing, weak, misleading, flaky, or wrong-layer coverage with credible risk to changed behavior, public contracts, compatibility, release-sensitive workflows, or documented command/API behavior.
+18. For each candidate, explicitly identify the nearby existing test shape and why extending existing tests, fixtures, tables, helpers, or assertions does not already cover the behavior. Do not record a gap when the proposed fix would duplicate coverage already provided by that local shape.
+19. Do not record gaps whose only meaningful test would assert pass-through behavior to an upstream library, standard library, or framework. This includes aliases, type aliases, thin wrappers, direct option forwarding, direct global setter/getter calls, dependency injection container behavior, validator tag behavior, encoder/parser behavior, and constructors where the repository adds no branching, validation, transformation, error handling, lifecycle behavior, compatibility policy, or composition contract of its own.
+20. Only record a gap around third-party integration when the untested behavior is repository-owned. Examples include local validation/normalization before calling the dependency, local input/output mapping, local error wrapping/classification/recovery, lifecycle ordering or cleanup owned by the repository, documented compatibility behavior promised across dependency versions, or end-to-end behavior through a supported public repo entrypoint where multiple repo-owned pieces are composed.
+21. When a candidate gap touches a wrapper around a dependency, explicitly ask: "Would the proposed test fail because repository code changed, or only because the dependency's behavior/shape changed?" Record it only when repository code owns the failing behavior.
+22. Do not record gaps that require build tags, architecture-specific execution, optional services, integration environments, or other validation modes the repository does not normally run, unless the finding is explicitly that CI or the documented validation path must add that mode.
+23. Do not record confirmed production bugs, security issues, compatibility breaks, or violated public contracts as test gaps. If such broken behavior is discovered during review, report it as out of scope for the test-gap ledger and recommend `$code-issues`; use this skill when the unprotected or poorly protected behavior is the finding.
+24. Do not record standalone missing, weak, stale, misleading, or wrong-location documentation, README, example, comment, or docstring gaps as test gaps. Use `$doc-gaps` when documentation itself is the finding.
+25. Do not report optional nice-to-have tests, private implementation coverage, arbitrary coverage percentage improvements, style preferences, or docs-only validation as findings by themselves. List them only as doc gaps or optional follow-up notes when relevant.
+26. If no confirmed test gaps are found, report that no test gaps were found and do not create `ISSUES.md`.
+27. If confirmed test gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
+28. Assign every finding a unique ID for the session in the form `TEST-<number>`.
+29. Present the scoped `ISSUES.md` and a proposed test-fix plan to the user.
+30. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
 
 ## `ISSUES.md` Format
 
@@ -106,6 +107,7 @@ Keep optional follow-up notes separate from findings:
 
 ## References
 
+- Use `../references/finding-severity.md` for confidence filtering and severity.
 - Use `$testing-standards` for cross-language test quality, coverage, fixtures, determinism, and test-layer decisions.
 - Use relevant language standards for local test idioms.
 - Use `$doc-gaps` instead when the user asks for a standalone missing, stale, misleading, or weak documentation, README, example, comment, or docstring pass.


### PR DESCRIPTION
## What

- Added a shared finding-severity reference for code, test, doc, and security findings.
- Clarified that vague, low-confidence, style-only, or unsupported comments should be discarded before assigning severity.
- Pointed code-review, code-issues, test-gaps, doc-gaps, and security-audit guidance at the shared impact-based scale while preserving their existing output formats.

## Why

- Gives review and ledger workflows a consistent meaning for Critical, High, Medium, and Low.
- Keeps confidence and actionability separate from impact so Low means a real limited-impact finding, not a likely false positive.
- Reduces severity drift across shared skills without changing generated issue formats.

## Testing

- `make dep` - passed
- `make lint` - passed
- `make scripts-lint` - passed
- `make docker-lint` - passed
- `make sec-lint` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
