### PR TITLE
feat(security): harden shared tooling workflows

### DIFF
--- a/build/docker/build
+++ b/build/docker/build
@@ -24,4 +24,4 @@ validate() {
 
 # Build docker.
 validate
-docker build --build-arg "name=$name" --build-arg version="latest" -t "$image" -f "$dockerfile" .
+docker build --platform "linux/$platform" --build-arg "name=$name" --build-arg version="latest" -t "$image" -f "$dockerfile" .

--- a/build/docker/push
+++ b/build/docker/push
@@ -29,5 +29,5 @@ if [[ -f "$version_file" ]]; then
 
   # Build and push docker.
   validate
-  docker build --build-arg "name=$name" --build-arg "version=$latest_tag" -t "$image" -f "$dockerfile" --push .
+  docker build --platform "linux/$platform" --build-arg "name=$name" --build-arg "version=$latest_tag" -t "$image" -f "$dockerfile" --push .
 fi

--- a/build/make/client.mak
+++ b/build/make/client.mak
@@ -1,10 +1,28 @@
-.PHONY: vendor
+.PHONY: validate-config validate-package validate-profile vendor
 
 NAME:=$(shell basename $(CURDIR))
 MODULE:=$(shell head -n 1 go.mod | sed 's/module //')
-SOURCE:=$(shell find . -name '*.go' -not -path './bin*/*' -not -path './test*/*' -not -path './vendor/*' -type f | sort)
+SOURCE:=$(shell find . -name '*.go' -not -path './bin/*' -not -path './test/*' -not -path './vendor/*' -type f | sort)
 PACKAGES=$(shell go list $(sort $(dir $(SOURCE))))
 COVER_PACKAGES=$(shell echo $(PACKAGES) | tr ' ' ',')
+
+export MODULE NAME
+override export gem := $(value gem)
+override export package := $(value package)
+override export platform := $(value platform)
+override export module := $(value module)
+override export cmd := $(value cmd)
+override export id := $(value id)
+override export kind := $(value kind)
+
+validate-config:
+	@ruby -e 'kind = ENV.fetch("kind", ""); valid = !kind.empty? && kind.match?(/\A[A-Za-z0-9_.-]+\z/) && !kind.include?(".."); abort("invalid kind: #{kind}") unless valid'
+
+validate-package:
+	@ruby -e 'package = ENV.fetch("package", ""); valid = !package.empty? && !package.start_with?("/") && !package.include?("..") && package.split("/").all? { |part| part.match?(/\A[A-Za-z0-9_.-]+\z/) && part != "." }; abort("invalid package: #{package}") unless valid'
+
+validate-profile:
+	@ruby -e 'ARGV.each { |key| value = ENV.fetch(key, ""); next if value.empty?; valid = value.match?(/\A[A-Za-z0-9_.-]+\z/) && !value.include?(".."); abort("invalid #{key}: #{value}") unless valid }' cmd id kind
 
 download:
 	@go mod download
@@ -112,12 +130,12 @@ specs:
 	@gotestsum --format testdox --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
 
 # Open pprof for a captured profile under test/reports/ (set cmd/id/kind).
-pprof:
-	@go tool pprof test/reports/$(NAME)-$(cmd)-$(id)-$(kind).prof
+pprof: validate-profile
+	@go tool pprof "test/reports/$${NAME}-$${cmd}-$${id}-$${kind}.prof"
 
 # Fetch a Go module (set module=<path>).
 go-get:
-	@go get $(module)
+	@go get "$$module"
 
 # Update one Go module (module=<path>) and re-vendor.
 go-update-dep: go-get tidy vendor
@@ -131,7 +149,7 @@ go-dep: download tidy vendor
 
 # Update a single gem in test/ (set gem=<name>).
 ruby-update-dep:
-	@make -C test gem=$(gem) update-dep
+	@make -C test gem="$${gem}" update-dep
 
 # Install gem dependencies in test/.
 ruby-dep:
@@ -176,7 +194,7 @@ go-sec:
 
 # Scan the test image with Trivy (CRITICAL severity).
 trivy-image:
-	@$(PWD)/bin/build/sec/trivy-image $(NAME) $(platform)
+	@$(PWD)/bin/build/sec/trivy-image "$${NAME}" "$${platform}"
 
 # Scan the repository with Trivy (CRITICAL severity).
 trivy-repo:
@@ -187,27 +205,27 @@ sec: go-sec trivy-repo
 
 # Build a static-ish release binary named $(NAME).
 build:
-	@go build -ldflags="-s -w" -buildvcs=false -tags netgo -a -o $(NAME) .
+	@go build -ldflags="-s -w" -buildvcs=false -tags netgo -a -o "$${NAME}" .
 
 # Build a test binary with -tags features and coverage instrumentation.
 build-test:
-	@go test -vet=off -race -mod vendor -c -tags features -covermode=atomic -coverpkg=$(COVER_PACKAGES) -o $(NAME) $(MODULE)
+	@go test -vet=off -race -mod vendor -c -tags features -covermode=atomic -coverpkg=$(COVER_PACKAGES) -o "$${NAME}" "$${MODULE}"
 
 # Build a test docker image tagged alexfalkowski/$(NAME):test.$(platform).
 build-docker:
-	@$(PWD)/bin/build/docker/build $(NAME) $(platform)
+	@$(PWD)/bin/build/docker/build "$${NAME}" "$${platform}"
 
 # Push the image to docker hub (only if the version file exists).
 push-docker:
-	@$(PWD)/bin/build/docker/push $(NAME) $(platform)
+	@$(PWD)/bin/build/docker/push "$${NAME}" "$${platform}"
 
 # Create and push multi-arch manifests (only if the version file exists).
 manifest-docker:
-	@$(PWD)/bin/build/docker/manifest $(NAME)
+	@$(PWD)/bin/build/docker/manifest "$${NAME}"
 
 # Base64-encode test/$(kind).yml as a single line.
-encode-config:
-	@cat test/$(kind).yml | base64 -w 0
+encode-config: validate-config
+	@cat "test/$${kind}.yml" | base64 -w 0
 
 # Create server and client TLS certs under test/certs/ using mkcert.
 create-certs:
@@ -216,12 +234,12 @@ create-certs:
 	@cp "$$(mkcert -CAROOT)/rootCA.pem" test/certs/rootCA.pem
 
 # Generate a dependency graph PNG for package=$(package) into assets/.
-create-diagram:
-	@goda graph github.com/alexfalkowski/$(NAME)/$(package)/... | dot -Tpng -o assets/$(package).png
+create-diagram: validate-package
+	@goda graph "$${MODULE}/$${package}/..." | dot -Tpng -o "assets/$${package}.png"
 
 # Analyse binary size with gsa (non-fatal if gsa is missing/fails).
 analyse:
-	@gsa $(NAME) || true
+	@gsa "$${NAME}" || true
 
 # Report cost statistics with scc.
 cost:

--- a/build/make/git.mak
+++ b/build/make/git.mak
@@ -2,11 +2,14 @@
 
 USER:=$(shell ruby -e 'require "etc"; print "#{Etc.getpwuid(Process.uid).name}-#{Random.rand(0...100_000)}"')
 BRANCH:=$(shell git branch --show-current)
+export BRANCH
 NEW_BRANCH:=$(subst $() ,-,$(name))
-PREFIX:=$(shell ruby -e '_, t, n = (ARGV[0] || "").split("/"); print "#{t}(#{n}):" unless t.nil?' $(BRANCH))
+PREFIX:=$(shell ruby -e '_, t, n = (ENV["BRANCH"] || "").split("/"); print "#{t}(#{n}):" unless t.nil?')
+export PREFIX
 
 override export msg := $(value msg)
 override export desc := $(value desc)
+override export desc_file := $(value desc_file)
 
 # Checkout the master branch.
 master:
@@ -38,7 +41,7 @@ update-submodule:
 
 # Print the current git branch.
 branch:
-	@echo "bin: current branch '$(BRANCH)'"
+	@printf "bin: current branch '%s'\n" "$$BRANCH"
 
 # Create and checkout a new branch named $(USER)/$(branch).
 checkout:
@@ -77,11 +80,11 @@ new-release: new-branch
 
 # Delete the current branch.
 delete:
-	@git branch -D $(BRANCH)
+	@git branch -D "$$BRANCH"
 
 # Update from master and delete the current branch.
 done: branch latest delete
-	@echo "bin: done with branch '$(BRANCH)'"
+	@printf "bin: done with branch '%s'\n" "$$BRANCH"
 
 # Rebase the current branch onto origin/master.
 sync:
@@ -95,24 +98,28 @@ amend: add
 edit-amend: add
 	@git commit --amend
 
-# Commit all changes with a prefix derived from the branch (set msg/desc).
+# Commit all changes with a prefix derived from the branch (set msg and desc or desc_file).
 commit: add
-	@printf '%s\n\n%s\n' "$(PREFIX) $${msg}" "$${desc}" | git commit -a -F -
+	@file="$$(mktemp)"; \
+	trap 'rm -f "$$file"' EXIT; \
+	printf '%s\n\n' "$${PREFIX} $${msg}" > "$$file"; \
+	if [ -n "$${desc_file}" ]; then cat "$${desc_file}"; else printf '%s\n' "$${desc}"; fi >> "$$file"; \
+	git commit -a -F "$$file"
 
 # Force-push the current branch to origin.
 push:
-	@git push -f origin $(BRANCH)
+	@git push -f origin "$$BRANCH"
 
 # Amend the last commit and force-push.
 force: amend push
 
 # Create a draft PR for the current branch (gh pr create --draft).
 draft:
-	@gh pr create -d -a @me --fill-first --head $(BRANCH)
+	@gh pr create -d -a @me --fill-first --head "$$BRANCH"
 
 # Create a PR for the current branch (gh pr create).
 pr:
-	@gh pr create -a @me --fill-first --head $(BRANCH)
+	@gh pr create -a @me --fill-first --head "$$BRANCH"
 
 # Enable auto squash-merge for the current PR.
 merge:

--- a/build/make/go.mak
+++ b/build/make/go.mak
@@ -1,11 +1,22 @@
-.PHONY: vendor sync
+.PHONY: validate-config validate-package vendor sync
 
 NAME:=$(shell basename $(CURDIR))
 MODULE:=$(shell head -n 1 go.mod | sed 's/module //')
-SOURCE:=$(shell find . -name '*.go' -not -path './bin*/*' -not -path './test*/*' -not -path './vendor/*' -type f | sort)
+SOURCE:=$(shell find . -name '*.go' -not -path './bin/*' -not -path './test/*' -not -path './vendor/*' -type f | sort)
 PACKAGES=$(shell go list $(sort $(dir $(SOURCE))))
 COVER_PACKAGES=$(shell echo $(PACKAGES) | tr ' ' ',')
-BENCHMARK_PROFILE=test/reports/$(package).prof
+
+export MODULE NAME
+override export kind := $(value kind)
+override export module := $(value module)
+override export package := $(value package)
+override export benchtime := $(value benchtime)
+
+validate-config:
+	@ruby -e 'kind = ENV.fetch("kind", ""); valid = !kind.empty? && kind.match?(/\A[A-Za-z0-9_.-]+\z/) && !kind.include?(".."); abort("invalid kind: #{kind}") unless valid'
+
+validate-package:
+	@ruby -e 'package = ENV.fetch("package", ""); valid = !package.empty? && !package.start_with?("/") && !package.include?("..") && package.split("/").all? { |part| part.match?(/\A[A-Za-z0-9_.-]+\z/) && part != "." }; abort("invalid package: #{package}") unless valid'
 
 download:
 	@go mod download
@@ -17,7 +28,7 @@ vendor:
 	@go mod vendor
 
 get:
-	@go get $(module)
+	@go get "$$module"
 
 get-all:
 	@go get -u all
@@ -75,13 +86,16 @@ specs:
 
 # Run benchmarks for package=$(package) and write $(BENCHMARK_PROFILE).
 # Set benchtime=<duration-or-count> to pass -benchtime to go test.
-benchmark:
-	@mkdir -p $(dir $(BENCHMARK_PROFILE))
-	@go test -vet=off -mod vendor -bench=. -run=Benchmark -benchmem $(if $(benchtime),-benchtime=$(benchtime),) -memprofile $(BENCHMARK_PROFILE) ./$(package)
+benchmark: validate-package
+	@profile="test/reports/$${package}.prof"; \
+	mkdir -p "$$(dirname "$$profile")"; \
+	set --; \
+	if [ -n "$$benchtime" ]; then set -- "-benchtime=$$benchtime"; fi; \
+	go test -vet=off -mod vendor -bench=. -run=Benchmark -benchmem "$$@" -memprofile "$$profile" "./$${package}"
 
-# Inspect benchmark memprofile via pprof ($(BENCHMARK_PROFILE)).
-benchmark-pprof:
-	@go tool pprof $(BENCHMARK_PROFILE)
+# Inspect benchmark memprofile via pprof (test/reports/$(package).prof).
+benchmark-pprof: validate-package
+	@go tool pprof "test/reports/$${package}.prof"
 
 remove-generated-coverage:
 	@$(PWD)/bin/quality/go/covfilter
@@ -117,8 +131,8 @@ trivy-repo:
 sec: govulncheck trivy-repo
 
 # Base64-encode test/$(kind).yml as a single line.
-encode-config:
-	@cat test/$(kind).yml | base64 -w 0
+encode-config: validate-config
+	@cat "test/$${kind}.yml" | base64 -w 0
 
 # Create server and client TLS certs under test/certs/ using mkcert.
 create-certs:
@@ -127,12 +141,12 @@ create-certs:
 	@cp "$$(mkcert -CAROOT)/rootCA.pem" test/certs/rootCA.pem
 
 # Generate a dependency graph PNG for package=$(package) into assets/.
-create-diagram:
-	@goda graph $(MODULE)/$(package)/... | dot -Tpng -o assets/$(package).png
+create-diagram: validate-package
+	@goda graph "$${MODULE}/$${package}/..." | dot -Tpng -o "assets/$${package}.png"
 
 # Analyse binary size with gsa (non-fatal if gsa is missing/fails).
 analyse:
-	@gsa $(NAME) || true
+	@gsa "$${NAME}" || true
 
 # Report cost statistics with scc.
 cost:

--- a/build/make/grpc.mak
+++ b/build/make/grpc.mak
@@ -1,10 +1,27 @@
-.PHONY: vendor
+.PHONY: validate-config validate-package validate-profile vendor
 
 NAME:=$(shell basename $(CURDIR))
 MODULE:=$(shell head -n 1 go.mod | sed 's/module //')
-SOURCE:=$(shell find . -name '*.go' -not -path './bin*/*' -not -path './test*/*' -not -path './vendor/*' -type f | sort)
+SOURCE:=$(shell find . -name '*.go' -not -path './bin/*' -not -path './test/*' -not -path './vendor/*' -type f | sort)
 PACKAGES=$(shell go list $(sort $(dir $(SOURCE))))
 COVER_PACKAGES=$(shell echo $(PACKAGES) | tr ' ' ',')
+
+export MODULE NAME
+override export gem := $(value gem)
+override export package := $(value package)
+override export platform := $(value platform)
+override export module := $(value module)
+override export id := $(value id)
+override export kind := $(value kind)
+
+validate-config:
+	@ruby -e 'kind = ENV.fetch("kind", ""); valid = !kind.empty? && kind.match?(/\A[A-Za-z0-9_.-]+\z/) && !kind.include?(".."); abort("invalid kind: #{kind}") unless valid'
+
+validate-package:
+	@ruby -e 'package = ENV.fetch("package", ""); valid = !package.empty? && !package.start_with?("/") && !package.include?("..") && package.split("/").all? { |part| part.match?(/\A[A-Za-z0-9_.-]+\z/) && part != "." }; abort("invalid package: #{package}") unless valid'
+
+validate-profile:
+	@ruby -e 'ARGV.each { |key| value = ENV.fetch(key, ""); next if value.empty?; valid = value.match?(/\A[A-Za-z0-9_.-]+\z/) && !value.include?(".."); abort("invalid #{key}: #{value}") unless valid }' id kind
 
 download:
 	@go mod download
@@ -136,12 +153,12 @@ specs:
 	@gotestsum --format testdox --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
 
 # Open pprof for a captured profile under test/reports/ (set id/kind).
-pprof:
-	@go tool pprof test/reports/$(NAME)-server-$(id)-$(kind).prof
+pprof: validate-profile
+	@go tool pprof "test/reports/$${NAME}-server-$${id}-$${kind}.prof"
 
 # Fetch a Go module (set module=<path>).
 go-get:
-	@go get $(module)
+	@go get "$$module"
 
 # Update one Go module (module=<path>) and re-vendor.
 go-update-dep: go-get tidy vendor
@@ -155,7 +172,7 @@ go-dep: download tidy vendor
 
 # Update a single gem in test/ (set gem=<name>).
 ruby-update-dep:
-	@make -C test gem=$(gem) update-dep
+	@make -C test gem="$${gem}" update-dep
 
 # Install gem dependencies in test/.
 ruby-dep:
@@ -204,7 +221,7 @@ go-sec:
 
 # Scan the test image with Trivy (CRITICAL severity).
 trivy-image:
-	@$(PWD)/bin/build/sec/trivy-image $(NAME) $(platform)
+	@$(PWD)/bin/build/sec/trivy-image "$${NAME}" "$${platform}"
 
 # Scan the repository with Trivy (CRITICAL severity).
 trivy-repo:
@@ -215,11 +232,11 @@ sec: go-sec trivy-repo
 
 # Build a static-ish release binary named $(NAME).
 build:
-	@go build -ldflags="-s -w" -buildvcs=false -tags netgo -a -o $(NAME) .
+	@go build -ldflags="-s -w" -buildvcs=false -tags netgo -a -o "$${NAME}" .
 
 # Build a test binary with -tags features and coverage instrumentation.
 build-test:
-	@go test -vet=off -race -mod vendor -c -tags features -covermode=atomic -coverpkg=$(COVER_PACKAGES) -o $(NAME) $(MODULE)
+	@go test -vet=off -race -mod vendor -c -tags features -covermode=atomic -coverpkg=$(COVER_PACKAGES) -o "$${NAME}" "$${MODULE}"
 
 # Run in dev mode with air; builds and runs "$(NAME) server" using test config.
 dev:
@@ -227,19 +244,19 @@ dev:
 
 # Build a test docker image tagged alexfalkowski/$(NAME):test.$(platform).
 build-docker:
-	@$(PWD)/bin/build/docker/build $(NAME) $(platform)
+	@$(PWD)/bin/build/docker/build "$${NAME}" "$${platform}"
 
 # Push the image to docker hub (only if the version file exists).
 push-docker:
-	@$(PWD)/bin/build/docker/push $(NAME) $(platform)
+	@$(PWD)/bin/build/docker/push "$${NAME}" "$${platform}"
 
 # Create and push multi-arch manifests (only if the version file exists).
 manifest-docker:
-	@$(PWD)/bin/build/docker/manifest $(NAME)
+	@$(PWD)/bin/build/docker/manifest "$${NAME}"
 
 # Base64-encode test/$(kind).yml as a single line.
-encode-config:
-	@cat test/$(kind).yml | base64 -w 0
+encode-config: validate-config
+	@cat "test/$${kind}.yml" | base64 -w 0
 
 # Create server and client TLS certs under test/certs/ using mkcert.
 create-certs:
@@ -248,12 +265,12 @@ create-certs:
 	@cp "$$(mkcert -CAROOT)/rootCA.pem" test/certs/rootCA.pem
 
 # Generate a dependency graph PNG for package=$(package) into assets/.
-create-diagram:
-	@goda graph github.com/alexfalkowski/$(NAME)/$(package)/... | dot -Tpng -o assets/$(package).png
+create-diagram: validate-package
+	@goda graph "$${MODULE}/$${package}/..." | dot -Tpng -o "assets/$${package}.png"
 
 # Analyse binary size with gsa (non-fatal if gsa is missing/fails).
 analyse:
-	@gsa $(NAME) || true
+	@gsa "$${NAME}" || true
 
 # Report cost statistics with scc.
 cost:

--- a/build/make/http.mak
+++ b/build/make/http.mak
@@ -1,10 +1,27 @@
-.PHONY: vendor
+.PHONY: validate-config validate-package validate-profile vendor
 
 NAME:=$(shell basename $(CURDIR))
 MODULE:=$(shell head -n 1 go.mod | sed 's/module //')
-SOURCE:=$(shell find . -name '*.go' -not -path './bin*/*' -not -path './test*/*' -not -path './vendor/*' -type f | sort)
+SOURCE:=$(shell find . -name '*.go' -not -path './bin/*' -not -path './test/*' -not -path './vendor/*' -type f | sort)
 PACKAGES=$(shell go list $(sort $(dir $(SOURCE))))
 COVER_PACKAGES=$(shell echo $(PACKAGES) | tr ' ' ',')
+
+export MODULE NAME
+override export gem := $(value gem)
+override export package := $(value package)
+override export platform := $(value platform)
+override export module := $(value module)
+override export id := $(value id)
+override export kind := $(value kind)
+
+validate-config:
+	@ruby -e 'kind = ENV.fetch("kind", ""); valid = !kind.empty? && kind.match?(/\A[A-Za-z0-9_.-]+\z/) && !kind.include?(".."); abort("invalid kind: #{kind}") unless valid'
+
+validate-package:
+	@ruby -e 'package = ENV.fetch("package", ""); valid = !package.empty? && !package.start_with?("/") && !package.include?("..") && package.split("/").all? { |part| part.match?(/\A[A-Za-z0-9_.-]+\z/) && part != "." }; abort("invalid package: #{package}") unless valid'
+
+validate-profile:
+	@ruby -e 'ARGV.each { |key| value = ENV.fetch(key, ""); next if value.empty?; valid = value.match?(/\A[A-Za-z0-9_.-]+\z/) && !value.include?(".."); abort("invalid #{key}: #{value}") unless valid }' id kind
 
 download:
 	@go mod download
@@ -112,12 +129,12 @@ specs:
 	@gotestsum --format testdox --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
 
 # Open pprof for a captured profile under test/reports/ (set id/kind).
-pprof:
-	@go tool pprof test/reports/$(NAME)-server-$(id)-$(kind).prof
+pprof: validate-profile
+	@go tool pprof "test/reports/$${NAME}-server-$${id}-$${kind}.prof"
 
 # Fetch a Go module (set module=<path>).
 go-get:
-	@go get $(module)
+	@go get "$$module"
 
 # Update one Go module (module=<path>) and re-vendor.
 go-update-dep: go-get tidy vendor
@@ -131,7 +148,7 @@ go-dep: download tidy vendor
 
 # Update a single gem in test/ (set gem=<name>).
 ruby-update-dep:
-	@make -C test gem=$(gem) update-dep
+	@make -C test gem="$${gem}" update-dep
 
 # Install gem dependencies in test/.
 ruby-dep:
@@ -176,7 +193,7 @@ go-sec:
 
 # Scan the test image with Trivy (CRITICAL severity).
 trivy-image:
-	@$(PWD)/bin/build/sec/trivy-image $(NAME) $(platform)
+	@$(PWD)/bin/build/sec/trivy-image "$${NAME}" "$${platform}"
 
 # Scan the repository with Trivy (CRITICAL severity).
 trivy-repo:
@@ -187,11 +204,11 @@ sec: go-sec trivy-repo
 
 # Build a static-ish release binary named $(NAME).
 build:
-	@go build -ldflags="-s -w" -buildvcs=false -tags netgo -a -o $(NAME) .
+	@go build -ldflags="-s -w" -buildvcs=false -tags netgo -a -o "$${NAME}" .
 
 # Build a test binary with -tags features and coverage instrumentation.
 build-test:
-	@go test -vet=off -race -mod vendor -c -tags features -covermode=atomic -coverpkg=$(COVER_PACKAGES) -o $(NAME) $(MODULE)
+	@go test -vet=off -race -mod vendor -c -tags features -covermode=atomic -coverpkg=$(COVER_PACKAGES) -o "$${NAME}" "$${MODULE}"
 
 # Run in dev mode with air; builds and runs "$(NAME) server" using test config.
 dev:
@@ -199,19 +216,19 @@ dev:
 
 # Build a test docker image tagged alexfalkowski/$(NAME):test.$(platform).
 build-docker:
-	@$(PWD)/bin/build/docker/build $(NAME) $(platform)
+	@$(PWD)/bin/build/docker/build "$${NAME}" "$${platform}"
 
 # Push the image to docker hub (only if the version file exists).
 push-docker:
-	@$(PWD)/bin/build/docker/push $(NAME) $(platform)
+	@$(PWD)/bin/build/docker/push "$${NAME}" "$${platform}"
 
 # Create and push multi-arch manifests (only if the version file exists).
 manifest-docker:
-	@$(PWD)/bin/build/docker/manifest $(NAME)
+	@$(PWD)/bin/build/docker/manifest "$${NAME}"
 
 # Base64-encode test/$(kind).yml as a single line.
-encode-config:
-	@cat test/$(kind).yml | base64 -w 0
+encode-config: validate-config
+	@cat "test/$${kind}.yml" | base64 -w 0
 
 # Create server and client TLS certs under test/certs/ using mkcert.
 create-certs:
@@ -220,12 +237,12 @@ create-certs:
 	@cp "$$(mkcert -CAROOT)/rootCA.pem" test/certs/rootCA.pem
 
 # Generate a dependency graph PNG for package=$(package) into assets/.
-create-diagram:
-	@goda graph github.com/alexfalkowski/$(NAME)/$(package)/... | dot -Tpng -o assets/$(package).png
+create-diagram: validate-package
+	@goda graph "$${MODULE}/$${package}/..." | dot -Tpng -o "assets/$${package}.png"
 
 # Analyse binary size with gsa (non-fatal if gsa is missing/fails).
 analyse:
-	@gsa $(NAME) || true
+	@gsa "$${NAME}" || true
 
 # Report cost statistics with scc.
 cost:

--- a/quality/go/covmerge
+++ b/quality/go/covmerge
@@ -10,7 +10,7 @@ path = 'test/reports/filter'
 FileUtils.rm_rf path
 FileUtils.mkdir_p path
 
-Dir['test/reports/*.cov'].each do |f|
+Dir['test/reports/*.cov'].reject { |f| File.basename(f) == 'final.cov' }.each do |f|
   filter_file = File.join(path, File.basename(f))
 
   File.open(filter_file, 'w') do |out_file|

--- a/quality/ruby/benchmark
+++ b/quality/ruby/benchmark
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2086
 # Run benchmark-tagged Cucumber scenarios with coverage reporting enabled.
 
 set -eo pipefail
 
 readonly feature="$1"
 
-COVERAGE_NAME=benchmarks bundler exec cucumber --profile report $feature --tags @benchmark
+args=(--profile report)
+
+if [ -n "$feature" ]; then
+  args+=("$feature")
+fi
+
+args+=(--tags @benchmark)
+
+COVERAGE_NAME=benchmarks bundler exec cucumber "${args[@]}"

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -31,18 +31,18 @@ description: Reviews, validates, commits, force-pushes, and opens a draft pull r
 AI-assisted-by: [Codex](https://openai.com/codex/)
 ```
 
-20. Run the review target with the drafted values:
+20. Write the multiline Markdown `desc` to a temporary file with `mktemp`, then run the review target with the drafted subject and file path:
 
 ```bash
-make msg="unprefixed subject" desc="summary" review
+make msg="unprefixed subject" desc_file="$desc_file" review
 ```
 
-21. Pass `desc` as the multiline Markdown summary; do not flatten the summary into a single line.
+21. Pass `desc_file` as the path to the multiline Markdown summary; do not flatten the summary into a single line or pass Markdown through a quoted shell argument.
 22. Read `references/output-format.md`, then report the result using that exact structure; do not add, remove, rename, or reorder sections.
 
 ## References
 
-- Read `references/summary-format.md` before drafting the `msg` and `desc` values.
+- Read `references/summary-format.md` before drafting the `msg` value and PR summary content.
 - Read `references/output-format.md` before producing the final review PR report.
 - Use `$project-workflow` for repository command discovery, CI expectations, and `./bin` wiring before validation and `make review`.
 - Use `$style-review` only when the user explicitly asks for non-blocking polish before the PR.

--- a/skills/review-pr/references/output-format.md
+++ b/skills/review-pr/references/output-format.md
@@ -9,7 +9,7 @@ unprefixed subject
 
 ## PR Summary
 
-<multiline Markdown summary passed as desc>
+<multiline Markdown summary passed via desc_file>
 
 ## Validation
 
@@ -25,7 +25,7 @@ unprefixed subject
 
 ## Review Target
 
-- command: `make msg="..." desc="..." review`
+- command: `make msg="..." desc_file="..." review`
   result: passed
   pr: https://github.com/org/repo/pull/123
 

--- a/skills/review-pr/references/summary-format.md
+++ b/skills/review-pr/references/summary-format.md
@@ -1,6 +1,6 @@
 # Summary Format
 
-Use this reference when drafting the `msg` and `desc` values for `make review`.
+Use this reference when drafting the `msg` value and PR summary content for `make review`.
 
 ## Scope
 

--- a/skills/security-audit/references/shared.md
+++ b/skills/security-audit/references/shared.md
@@ -56,10 +56,10 @@ Use this reference for any security audit, then load language-specific reference
 ## Severity
 
 Use these security-specific examples after filtering out low-confidence or
-unsupported candidates. They align with `../../references/finding-severity.md`,
-but this security-audit report format uses only `High`, `Medium`, and `Low`.
+unsupported candidates. They align with `../../references/finding-severity.md`.
 
-- High: likely secret exposure, auth bypass, command injection, arbitrary file write/delete, path traversal to sensitive files, remote code execution, or exploitable critical dependency issue.
+- Critical: near-certain remote code execution, credential exposure, auth bypass, data loss or corruption, or exploitable critical dependency issue with broad severe impact.
+- High: likely exploitable command injection, arbitrary file write/delete, path traversal to sensitive files, sensitive information disclosure, or other serious security issue with narrower impact.
 - Medium: constrained injection, sensitive information disclosure, unsafe TLS/auth defaults, dangerous local-only behavior likely to be copied into production, or scanner coverage gaps on security-sensitive changes.
 - Low: hardening issue, defense-in-depth improvement, unclear validation gap, or risky pattern without a demonstrated exploit path.
 
@@ -70,7 +70,7 @@ but this security-audit report format uses only `High`, `Medium`, and `Low`.
 ```markdown
 ## Findings
 
-- severity: High
+- severity: Critical
   file: `path/to/file:42`
   risk: Untrusted input reaches shell execution.
   trigger: User-controlled CLI arguments are interpolated into a shell command.
@@ -88,7 +88,7 @@ but this security-audit report format uses only `High`, `Medium`, and `Low`.
 - None.
 ```
 
-- Use only these severity values for findings: `High`, `Medium`, `Low`. Use `None` only for the required no-findings entry.
+- Use only these severity values for findings: `Critical`, `High`, `Medium`, `Low`. Use `None` only for the required no-findings entry.
 - Use only these validation results: `passed`, `failed`, `not run`, `no-op`.
 - Use `file: n/a` only for repository-wide dependency, configuration, or validation findings that do not have a precise source line.
 - If there are no findings, write exactly one finding entry with `severity: None`, `file: n/a`, `risk: No findings.`, `trigger: n/a`, `impact: n/a`, and `remediation: n/a`.

--- a/skills/test-gaps/SKILL.md
+++ b/skills/test-gaps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-gaps
-description: Finds concrete missing, weak, or misleading test coverage in a package or folder, records confirmed gaps in that scope's ISSUES.md, and later proposes and implements explicitly agreed test fixes gap by gap. Use when the user asks to find $test-gaps in a package or folder, find test gaps in a package or folder, implement $test-gaps in a package or folder, or implement test gaps in a package or folder.
+description: Finds concrete missing, weak, misleading, flaky, or wrong-layer test coverage in a package or folder, records confirmed gaps in that scope's ISSUES.md, and later proposes and implements explicitly agreed test fixes gap by gap. Use when the user asks to find $test-gaps in a package or folder, find test gaps in a package or folder, find flaky tests in a package or folder, find wrong-layer tests in a package or folder, implement $test-gaps in a package or folder, or implement test gaps in a package or folder.
 ---
 
 # Test Gaps

--- a/skills/test-gaps/agents/openai.yaml
+++ b/skills/test-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Test Gaps"
-  short_description: "Find scoped missing or weak tests"
-  default_prompt: "Use $test-gaps to find scoped missing or weak tests, store confirmed gaps in that scope's ISSUES.md, or propose and implement agreed test fixes one gap at a time."
+  short_description: "Find scoped weak, flaky, or wrong-layer tests"
+  default_prompt: "Use $test-gaps to find scoped missing, weak, misleading, flaky, or wrong-layer test coverage, store confirmed gaps in that scope's ISSUES.md, or propose and implement agreed test fixes one gap at a time."


### PR DESCRIPTION
## What

- Harden shared Docker, Git, Make, coverage, and benchmark helpers against platform drift, shell interpolation, stale coverage input, and unsafe argument splitting.
- Align the review and test-gap skill guidance with file-backed PR summaries, Critical security severity, and flaky or wrong-layer test-gap routing.
- Keep public target names and caller-facing variables intact while validating or quoting values passed through shared make fragments.

## Why

- These helpers are reused through downstream ./bin submodules, so small shell and path-handling mistakes can propagate into builds, coverage reports, commits, and PR automation.
- The update makes platform-specific Docker publishing, generated coverage, branch-derived commit prefixes, and agent-facing review instructions safer without changing the expected command surface.

## Testing

- `make dep` - passed
- `make lint` - passed
- `make scripts-lint` - passed
- `make docker-lint` - passed
- `make sec-lint` - passed
- `git diff --check` - passed
- `make -n msg="harden shared tooling workflows" desc_file=/tmp/review-pr-dry-run review` - passed
- Targeted dry-runs and fixtures covered file-backed PR descriptions, Make variable validation, exact Go source exclusions, stale final.cov exclusion, module-aware diagram paths, and benchmark argv splitting.
