### PR TITLE
feat(make): default root package workflows

### DIFF
--- a/build/make/client.mak
+++ b/build/make/client.mak
@@ -19,7 +19,7 @@ validate-config:
 	@ruby -e 'kind = ENV.fetch("kind", ""); valid = !kind.empty? && kind.match?(/\A[A-Za-z0-9_.-]+\z/) && !kind.include?(".."); abort("invalid kind: #{kind}") unless valid'
 
 validate-package:
-	@ruby -e 'package = ENV.fetch("package", ""); valid = !package.empty? && !package.start_with?("/") && !package.include?("..") && package.split("/").all? { |part| part.match?(/\A[A-Za-z0-9_.-]+\z/) && part != "." }; abort("invalid package: #{package}") unless valid'
+	@ruby -e 'package = ENV.fetch("package", ""); valid = !package.empty? && (package == "." || (!package.start_with?("/") && !package.include?("..") && package.split("/").all? { |part| part.match?(/\A[A-Za-z0-9_.-]+\z/) && part != "." })); abort("invalid package: #{package}") unless valid'
 
 validate-profile:
 	@ruby -e 'ARGV.each { |key| value = ENV.fetch(key, ""); next if value.empty?; valid = value.match?(/\A[A-Za-z0-9_.-]+\z/) && !value.include?(".."); abort("invalid #{key}: #{value}") unless valid }' cmd id kind
@@ -233,9 +233,18 @@ create-certs:
 	@mkcert -client -key-file test/certs/client-key.pem -cert-file test/certs/client-cert.pem localhost
 	@cp "$$(mkcert -CAROOT)/rootCA.pem" test/certs/rootCA.pem
 
-# Generate a dependency graph PNG for package=$(package) into assets/.
+# Generate a dependency graph PNG for package=$(package), or the module root when unset.
+create-diagram: override export package := $(or $(value package),.)
+
 create-diagram: validate-package
-	@goda graph "$${MODULE}/$${package}/..." | dot -Tpng -o "assets/$${package}.png"
+	@diagram_package="$${package}"; \
+	diagram_pattern="$${MODULE}/$${package}/..."; \
+	if [ "$$diagram_package" = "." ]; then \
+		diagram_package="diagram"; \
+		diagram_pattern="$${MODULE}/..."; \
+	fi; \
+	mkdir -p "$$(dirname "assets/$${diagram_package}.png")"; \
+	goda graph "$$diagram_pattern" | dot -Tpng -o "assets/$${diagram_package}.png"
 
 # Analyse binary size with gsa (non-fatal if gsa is missing/fails).
 analyse:

--- a/build/make/go.mak
+++ b/build/make/go.mak
@@ -16,7 +16,7 @@ validate-config:
 	@ruby -e 'kind = ENV.fetch("kind", ""); valid = !kind.empty? && kind.match?(/\A[A-Za-z0-9_.-]+\z/) && !kind.include?(".."); abort("invalid kind: #{kind}") unless valid'
 
 validate-package:
-	@ruby -e 'package = ENV.fetch("package", ""); valid = !package.empty? && !package.start_with?("/") && !package.include?("..") && package.split("/").all? { |part| part.match?(/\A[A-Za-z0-9_.-]+\z/) && part != "." }; abort("invalid package: #{package}") unless valid'
+	@ruby -e 'package = ENV.fetch("package", ""); valid = !package.empty? && (package == "." || (!package.start_with?("/") && !package.include?("..") && package.split("/").all? { |part| part.match?(/\A[A-Za-z0-9_.-]+\z/) && part != "." })); abort("invalid package: #{package}") unless valid'
 
 download:
 	@go mod download
@@ -84,18 +84,24 @@ format:
 specs:
 	@gotestsum --format testdox --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
 
-# Run benchmarks for package=$(package) and write $(BENCHMARK_PROFILE).
+# Run benchmarks for package=$(package), or the module root when unset.
 # Set benchtime=<duration-or-count> to pass -benchtime to go test.
+benchmark benchmark-pprof: override export package := $(or $(value package),.)
+
 benchmark: validate-package
-	@profile="test/reports/$${package}.prof"; \
+	@profile_package="$${package}"; \
+	if [ "$$profile_package" = "." ]; then profile_package="benchmark"; fi; \
+	profile="test/reports/$${profile_package}.prof"; \
 	mkdir -p "$$(dirname "$$profile")"; \
 	set --; \
 	if [ -n "$$benchtime" ]; then set -- "-benchtime=$$benchtime"; fi; \
 	go test -vet=off -mod vendor -bench=. -run=Benchmark -benchmem "$$@" -memprofile "$$profile" "./$${package}"
 
-# Inspect benchmark memprofile via pprof (test/reports/$(package).prof).
+# Inspect benchmark memprofile via pprof for package=$(package), or the module root when unset.
 benchmark-pprof: validate-package
-	@go tool pprof "test/reports/$${package}.prof"
+	@profile_package="$${package}"; \
+	if [ "$$profile_package" = "." ]; then profile_package="benchmark"; fi; \
+	go tool pprof "test/reports/$${profile_package}.prof"
 
 remove-generated-coverage:
 	@$(PWD)/bin/quality/go/covfilter
@@ -140,9 +146,18 @@ create-certs:
 	@mkcert -client -key-file test/certs/client-key.pem -cert-file test/certs/client-cert.pem localhost
 	@cp "$$(mkcert -CAROOT)/rootCA.pem" test/certs/rootCA.pem
 
-# Generate a dependency graph PNG for package=$(package) into assets/.
+# Generate a dependency graph PNG for package=$(package), or the module root when unset.
+create-diagram: override export package := $(or $(value package),.)
+
 create-diagram: validate-package
-	@goda graph "$${MODULE}/$${package}/..." | dot -Tpng -o "assets/$${package}.png"
+	@diagram_package="$${package}"; \
+	diagram_pattern="$${MODULE}/$${package}/..."; \
+	if [ "$$diagram_package" = "." ]; then \
+		diagram_package="diagram"; \
+		diagram_pattern="$${MODULE}/..."; \
+	fi; \
+	mkdir -p "$$(dirname "assets/$${diagram_package}.png")"; \
+	goda graph "$$diagram_pattern" | dot -Tpng -o "assets/$${diagram_package}.png"
 
 # Analyse binary size with gsa (non-fatal if gsa is missing/fails).
 analyse:

--- a/build/make/grpc.mak
+++ b/build/make/grpc.mak
@@ -18,7 +18,7 @@ validate-config:
 	@ruby -e 'kind = ENV.fetch("kind", ""); valid = !kind.empty? && kind.match?(/\A[A-Za-z0-9_.-]+\z/) && !kind.include?(".."); abort("invalid kind: #{kind}") unless valid'
 
 validate-package:
-	@ruby -e 'package = ENV.fetch("package", ""); valid = !package.empty? && !package.start_with?("/") && !package.include?("..") && package.split("/").all? { |part| part.match?(/\A[A-Za-z0-9_.-]+\z/) && part != "." }; abort("invalid package: #{package}") unless valid'
+	@ruby -e 'package = ENV.fetch("package", ""); valid = !package.empty? && (package == "." || (!package.start_with?("/") && !package.include?("..") && package.split("/").all? { |part| part.match?(/\A[A-Za-z0-9_.-]+\z/) && part != "." })); abort("invalid package: #{package}") unless valid'
 
 validate-profile:
 	@ruby -e 'ARGV.each { |key| value = ENV.fetch(key, ""); next if value.empty?; valid = value.match?(/\A[A-Za-z0-9_.-]+\z/) && !value.include?(".."); abort("invalid #{key}: #{value}") unless valid }' id kind
@@ -264,9 +264,18 @@ create-certs:
 	@mkcert -client -key-file test/certs/client-key.pem -cert-file test/certs/client-cert.pem localhost
 	@cp "$$(mkcert -CAROOT)/rootCA.pem" test/certs/rootCA.pem
 
-# Generate a dependency graph PNG for package=$(package) into assets/.
+# Generate a dependency graph PNG for package=$(package), or the module root when unset.
+create-diagram: override export package := $(or $(value package),.)
+
 create-diagram: validate-package
-	@goda graph "$${MODULE}/$${package}/..." | dot -Tpng -o "assets/$${package}.png"
+	@diagram_package="$${package}"; \
+	diagram_pattern="$${MODULE}/$${package}/..."; \
+	if [ "$$diagram_package" = "." ]; then \
+		diagram_package="diagram"; \
+		diagram_pattern="$${MODULE}/..."; \
+	fi; \
+	mkdir -p "$$(dirname "assets/$${diagram_package}.png")"; \
+	goda graph "$$diagram_pattern" | dot -Tpng -o "assets/$${diagram_package}.png"
 
 # Analyse binary size with gsa (non-fatal if gsa is missing/fails).
 analyse:

--- a/build/make/http.mak
+++ b/build/make/http.mak
@@ -18,7 +18,7 @@ validate-config:
 	@ruby -e 'kind = ENV.fetch("kind", ""); valid = !kind.empty? && kind.match?(/\A[A-Za-z0-9_.-]+\z/) && !kind.include?(".."); abort("invalid kind: #{kind}") unless valid'
 
 validate-package:
-	@ruby -e 'package = ENV.fetch("package", ""); valid = !package.empty? && !package.start_with?("/") && !package.include?("..") && package.split("/").all? { |part| part.match?(/\A[A-Za-z0-9_.-]+\z/) && part != "." }; abort("invalid package: #{package}") unless valid'
+	@ruby -e 'package = ENV.fetch("package", ""); valid = !package.empty? && (package == "." || (!package.start_with?("/") && !package.include?("..") && package.split("/").all? { |part| part.match?(/\A[A-Za-z0-9_.-]+\z/) && part != "." })); abort("invalid package: #{package}") unless valid'
 
 validate-profile:
 	@ruby -e 'ARGV.each { |key| value = ENV.fetch(key, ""); next if value.empty?; valid = value.match?(/\A[A-Za-z0-9_.-]+\z/) && !value.include?(".."); abort("invalid #{key}: #{value}") unless valid }' id kind
@@ -236,9 +236,18 @@ create-certs:
 	@mkcert -client -key-file test/certs/client-key.pem -cert-file test/certs/client-cert.pem localhost
 	@cp "$$(mkcert -CAROOT)/rootCA.pem" test/certs/rootCA.pem
 
-# Generate a dependency graph PNG for package=$(package) into assets/.
+# Generate a dependency graph PNG for package=$(package), or the module root when unset.
+create-diagram: override export package := $(or $(value package),.)
+
 create-diagram: validate-package
-	@goda graph "$${MODULE}/$${package}/..." | dot -Tpng -o "assets/$${package}.png"
+	@diagram_package="$${package}"; \
+	diagram_pattern="$${MODULE}/$${package}/..."; \
+	if [ "$$diagram_package" = "." ]; then \
+		diagram_package="diagram"; \
+		diagram_pattern="$${MODULE}/..."; \
+	fi; \
+	mkdir -p "$$(dirname "assets/$${diagram_package}.png")"; \
+	goda graph "$$diagram_pattern" | dot -Tpng -o "assets/$${diagram_package}.png"
 
 # Analyse binary size with gsa (non-fatal if gsa is missing/fails).
 analyse:


### PR DESCRIPTION
## What

- Default benchmark and dependency diagram targets to the module root when package is not supplied.
- Write root benchmark profiles to test/reports/benchmark.prof and root diagrams to assets/diagram.png instead of deriving filenames from a dot package.
- Keep explicit nested packages supported while continuing to reject unsafe package values such as parent-directory traversal.

## Why

- Downstream repositories such as alexfalkowski/go-sync call make benchmark without package=..., so requiring a non-empty package broke the existing CI workflow.
- Diagram generation has the same root-package shape, and normalizing the root case avoids awkward MODULE/./... graph inputs and dot-derived output names.

## Testing

- `make dep` - passed
- `make lint` - passed
- `make scripts-lint` - passed
- `git diff --check` - passed
- `make -n msg="default root package workflows" desc_file=/tmp/review-pr-dry-run review` - passed
- Temporary Go fixture verified plain `make benchmark`, `package=internal/worker make benchmark`, and rejection of `package=../bad`.
- Temporary fake `goda`/`dot` fixture verified root and nested `create-diagram` behavior for go, client, grpc, and http make fragments, including unsafe package rejection.
