### PR TITLE
feat(make): extract shared helper scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ include build/make/git.mak
 
 # Lint all scripts.
 scripts-lint:
-	@shellcheck build/docker/build build/docker/env build/docker/push build/docker/manifest build/sec/* build/go/clean build/go/lint quality/go/covfilter quality/ruby/feature quality/ruby/benchmark
+	@quality/shell/lint
 
 # Lint all docker files.
 docker-lint:

--- a/build/go/benchmark
+++ b/build/go/benchmark
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Run Go benchmarks for package, defaulting to the module root.
+
+set -eo pipefail
+
+package="${package:-.}"
+export package
+
+"$(dirname "$0")/validate-package"
+
+profile_package="$package"
+if [[ $profile_package == "." ]]; then
+  profile_package="benchmark"
+fi
+
+profile="test/reports/$profile_package.prof"
+args=()
+
+if [[ -n ${benchtime:-} ]]; then
+  args+=("-benchtime=$benchtime")
+fi
+
+mkdir -p "$(dirname "$profile")"
+go test -vet=off -mod vendor -bench=. -run=Benchmark -benchmem "${args[@]}" -memprofile "$profile" "./$package"

--- a/build/go/benchmark-pprof
+++ b/build/go/benchmark-pprof
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Open the benchmark memory profile for package, defaulting to the module root.
+
+set -eo pipefail
+
+package="${package:-.}"
+export package
+
+"$(dirname "$0")/validate-package"
+
+profile_package="$package"
+if [[ $profile_package == "." ]]; then
+  profile_package="benchmark"
+fi
+
+go tool pprof "test/reports/$profile_package.prof"

--- a/build/go/create-diagram
+++ b/build/go/create-diagram
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Generate a dependency graph for package, defaulting to the module root.
+
+set -eo pipefail
+
+package="${package:-.}"
+module="${MODULE:-$(head -n 1 go.mod | sed 's/module //')}"
+export package
+
+"$(dirname "$0")/validate-package"
+
+diagram_package="$package"
+diagram_pattern="$module/$package/..."
+
+if [[ $diagram_package == "." ]]; then
+  diagram_package="diagram"
+  diagram_pattern="$module/..."
+fi
+
+output="assets/$diagram_package.png"
+
+mkdir -p "$(dirname "$output")"
+goda graph "$diagram_pattern" | dot -Tpng -o "$output"

--- a/build/go/pprof
+++ b/build/go/pprof
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Open a Go profile from test/reports after validating profile components.
+
+set -eo pipefail
+
+readonly profile="$1"
+shift
+
+"$(dirname "$0")/validate-profile" "$@"
+
+go tool pprof "test/reports/$profile"

--- a/build/go/validate-package
+++ b/build/go/validate-package
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Validate the Go package path supplied through package.
+
+set -eo pipefail
+
+validate_part() {
+  local part="$1"
+
+  [[ -n $part && $part != "." && $part =~ ^[A-Za-z0-9_.-]+$ ]]
+}
+
+readonly value="${package:-}"
+
+if [[ -z $value || $value == /* || $value == *..* ]]; then
+  echo "invalid package: $value" >&2
+  exit 1
+fi
+
+if [[ $value == "." ]]; then
+  exit 0
+fi
+
+remaining="$value"
+while [[ $remaining == */* ]]; do
+  part="${remaining%%/*}"
+
+  if ! validate_part "$part"; then
+    echo "invalid package: $value" >&2
+    exit 1
+  fi
+
+  remaining="${remaining#*/}"
+done
+
+if ! validate_part "$remaining"; then
+  echo "invalid package: $value" >&2
+  exit 1
+fi

--- a/build/go/validate-profile
+++ b/build/go/validate-profile
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Validate profile filename components supplied through environment variables.
+
+set -eo pipefail
+
+for key in "$@"; do
+  value="${!key:-}"
+
+  if [[ -z $value ]]; then
+    continue
+  fi
+
+  if [[ ! $value =~ ^[A-Za-z0-9_.-]+$ || $value == *..* ]]; then
+    echo "invalid $key: $value" >&2
+    exit 1
+  fi
+done

--- a/build/make/client.mak
+++ b/build/make/client.mak
@@ -16,13 +16,13 @@ override export id := $(value id)
 override export kind := $(value kind)
 
 validate-config:
-	@ruby -e 'kind = ENV.fetch("kind", ""); valid = !kind.empty? && kind.match?(/\A[A-Za-z0-9_.-]+\z/) && !kind.include?(".."); abort("invalid kind: #{kind}") unless valid'
+	@$(PWD)/bin/build/test/validate-config
 
 validate-package:
-	@ruby -e 'package = ENV.fetch("package", ""); valid = !package.empty? && (package == "." || (!package.start_with?("/") && !package.include?("..") && package.split("/").all? { |part| part.match?(/\A[A-Za-z0-9_.-]+\z/) && part != "." })); abort("invalid package: #{package}") unless valid'
+	@$(PWD)/bin/build/go/validate-package
 
 validate-profile:
-	@ruby -e 'ARGV.each { |key| value = ENV.fetch(key, ""); next if value.empty?; valid = value.match?(/\A[A-Za-z0-9_.-]+\z/) && !value.include?(".."); abort("invalid #{key}: #{value}") unless valid }' cmd id kind
+	@$(PWD)/bin/build/go/validate-profile cmd id kind
 
 download:
 	@go mod download
@@ -130,8 +130,8 @@ specs:
 	@gotestsum --format testdox --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
 
 # Open pprof for a captured profile under test/reports/ (set cmd/id/kind).
-pprof: validate-profile
-	@go tool pprof "test/reports/$${NAME}-$${cmd}-$${id}-$${kind}.prof"
+pprof:
+	@$(PWD)/bin/build/go/pprof "$${NAME}-$${cmd}-$${id}-$${kind}.prof" cmd id kind
 
 # Fetch a Go module (set module=<path>).
 go-get:
@@ -224,8 +224,8 @@ manifest-docker:
 	@$(PWD)/bin/build/docker/manifest "$${NAME}"
 
 # Base64-encode test/$(kind).yml as a single line.
-encode-config: validate-config
-	@cat "test/$${kind}.yml" | base64 -w 0
+encode-config:
+	@$(PWD)/bin/build/test/encode-config
 
 # Create server and client TLS certs under test/certs/ using mkcert.
 create-certs:
@@ -234,17 +234,8 @@ create-certs:
 	@cp "$$(mkcert -CAROOT)/rootCA.pem" test/certs/rootCA.pem
 
 # Generate a dependency graph PNG for package=$(package), or the module root when unset.
-create-diagram: override export package := $(or $(value package),.)
-
-create-diagram: validate-package
-	@diagram_package="$${package}"; \
-	diagram_pattern="$${MODULE}/$${package}/..."; \
-	if [ "$$diagram_package" = "." ]; then \
-		diagram_package="diagram"; \
-		diagram_pattern="$${MODULE}/..."; \
-	fi; \
-	mkdir -p "$$(dirname "assets/$${diagram_package}.png")"; \
-	goda graph "$$diagram_pattern" | dot -Tpng -o "assets/$${diagram_package}.png"
+create-diagram:
+	@$(PWD)/bin/build/go/create-diagram
 
 # Analyse binary size with gsa (non-fatal if gsa is missing/fails).
 analyse:

--- a/build/make/go.mak
+++ b/build/make/go.mak
@@ -13,10 +13,10 @@ override export package := $(value package)
 override export benchtime := $(value benchtime)
 
 validate-config:
-	@ruby -e 'kind = ENV.fetch("kind", ""); valid = !kind.empty? && kind.match?(/\A[A-Za-z0-9_.-]+\z/) && !kind.include?(".."); abort("invalid kind: #{kind}") unless valid'
+	@$(PWD)/bin/build/test/validate-config
 
 validate-package:
-	@ruby -e 'package = ENV.fetch("package", ""); valid = !package.empty? && (package == "." || (!package.start_with?("/") && !package.include?("..") && package.split("/").all? { |part| part.match?(/\A[A-Za-z0-9_.-]+\z/) && part != "." })); abort("invalid package: #{package}") unless valid'
+	@$(PWD)/bin/build/go/validate-package
 
 download:
 	@go mod download
@@ -86,22 +86,12 @@ specs:
 
 # Run benchmarks for package=$(package), or the module root when unset.
 # Set benchtime=<duration-or-count> to pass -benchtime to go test.
-benchmark benchmark-pprof: override export package := $(or $(value package),.)
-
-benchmark: validate-package
-	@profile_package="$${package}"; \
-	if [ "$$profile_package" = "." ]; then profile_package="benchmark"; fi; \
-	profile="test/reports/$${profile_package}.prof"; \
-	mkdir -p "$$(dirname "$$profile")"; \
-	set --; \
-	if [ -n "$$benchtime" ]; then set -- "-benchtime=$$benchtime"; fi; \
-	go test -vet=off -mod vendor -bench=. -run=Benchmark -benchmem "$$@" -memprofile "$$profile" "./$${package}"
+benchmark:
+	@$(PWD)/bin/build/go/benchmark
 
 # Inspect benchmark memprofile via pprof for package=$(package), or the module root when unset.
-benchmark-pprof: validate-package
-	@profile_package="$${package}"; \
-	if [ "$$profile_package" = "." ]; then profile_package="benchmark"; fi; \
-	go tool pprof "test/reports/$${profile_package}.prof"
+benchmark-pprof:
+	@$(PWD)/bin/build/go/benchmark-pprof
 
 remove-generated-coverage:
 	@$(PWD)/bin/quality/go/covfilter
@@ -137,8 +127,8 @@ trivy-repo:
 sec: govulncheck trivy-repo
 
 # Base64-encode test/$(kind).yml as a single line.
-encode-config: validate-config
-	@cat "test/$${kind}.yml" | base64 -w 0
+encode-config:
+	@$(PWD)/bin/build/test/encode-config
 
 # Create server and client TLS certs under test/certs/ using mkcert.
 create-certs:
@@ -147,17 +137,8 @@ create-certs:
 	@cp "$$(mkcert -CAROOT)/rootCA.pem" test/certs/rootCA.pem
 
 # Generate a dependency graph PNG for package=$(package), or the module root when unset.
-create-diagram: override export package := $(or $(value package),.)
-
-create-diagram: validate-package
-	@diagram_package="$${package}"; \
-	diagram_pattern="$${MODULE}/$${package}/..."; \
-	if [ "$$diagram_package" = "." ]; then \
-		diagram_package="diagram"; \
-		diagram_pattern="$${MODULE}/..."; \
-	fi; \
-	mkdir -p "$$(dirname "assets/$${diagram_package}.png")"; \
-	goda graph "$$diagram_pattern" | dot -Tpng -o "assets/$${diagram_package}.png"
+create-diagram:
+	@$(PWD)/bin/build/go/create-diagram
 
 # Analyse binary size with gsa (non-fatal if gsa is missing/fails).
 analyse:

--- a/build/make/grpc.mak
+++ b/build/make/grpc.mak
@@ -15,13 +15,13 @@ override export id := $(value id)
 override export kind := $(value kind)
 
 validate-config:
-	@ruby -e 'kind = ENV.fetch("kind", ""); valid = !kind.empty? && kind.match?(/\A[A-Za-z0-9_.-]+\z/) && !kind.include?(".."); abort("invalid kind: #{kind}") unless valid'
+	@$(PWD)/bin/build/test/validate-config
 
 validate-package:
-	@ruby -e 'package = ENV.fetch("package", ""); valid = !package.empty? && (package == "." || (!package.start_with?("/") && !package.include?("..") && package.split("/").all? { |part| part.match?(/\A[A-Za-z0-9_.-]+\z/) && part != "." })); abort("invalid package: #{package}") unless valid'
+	@$(PWD)/bin/build/go/validate-package
 
 validate-profile:
-	@ruby -e 'ARGV.each { |key| value = ENV.fetch(key, ""); next if value.empty?; valid = value.match?(/\A[A-Za-z0-9_.-]+\z/) && !value.include?(".."); abort("invalid #{key}: #{value}") unless valid }' id kind
+	@$(PWD)/bin/build/go/validate-profile id kind
 
 download:
 	@go mod download
@@ -153,8 +153,8 @@ specs:
 	@gotestsum --format testdox --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
 
 # Open pprof for a captured profile under test/reports/ (set id/kind).
-pprof: validate-profile
-	@go tool pprof "test/reports/$${NAME}-server-$${id}-$${kind}.prof"
+pprof:
+	@$(PWD)/bin/build/go/pprof "$${NAME}-server-$${id}-$${kind}.prof" id kind
 
 # Fetch a Go module (set module=<path>).
 go-get:
@@ -255,8 +255,8 @@ manifest-docker:
 	@$(PWD)/bin/build/docker/manifest "$${NAME}"
 
 # Base64-encode test/$(kind).yml as a single line.
-encode-config: validate-config
-	@cat "test/$${kind}.yml" | base64 -w 0
+encode-config:
+	@$(PWD)/bin/build/test/encode-config
 
 # Create server and client TLS certs under test/certs/ using mkcert.
 create-certs:
@@ -265,17 +265,8 @@ create-certs:
 	@cp "$$(mkcert -CAROOT)/rootCA.pem" test/certs/rootCA.pem
 
 # Generate a dependency graph PNG for package=$(package), or the module root when unset.
-create-diagram: override export package := $(or $(value package),.)
-
-create-diagram: validate-package
-	@diagram_package="$${package}"; \
-	diagram_pattern="$${MODULE}/$${package}/..."; \
-	if [ "$$diagram_package" = "." ]; then \
-		diagram_package="diagram"; \
-		diagram_pattern="$${MODULE}/..."; \
-	fi; \
-	mkdir -p "$$(dirname "assets/$${diagram_package}.png")"; \
-	goda graph "$$diagram_pattern" | dot -Tpng -o "assets/$${diagram_package}.png"
+create-diagram:
+	@$(PWD)/bin/build/go/create-diagram
 
 # Analyse binary size with gsa (non-fatal if gsa is missing/fails).
 analyse:

--- a/build/make/http.mak
+++ b/build/make/http.mak
@@ -15,13 +15,13 @@ override export id := $(value id)
 override export kind := $(value kind)
 
 validate-config:
-	@ruby -e 'kind = ENV.fetch("kind", ""); valid = !kind.empty? && kind.match?(/\A[A-Za-z0-9_.-]+\z/) && !kind.include?(".."); abort("invalid kind: #{kind}") unless valid'
+	@$(PWD)/bin/build/test/validate-config
 
 validate-package:
-	@ruby -e 'package = ENV.fetch("package", ""); valid = !package.empty? && (package == "." || (!package.start_with?("/") && !package.include?("..") && package.split("/").all? { |part| part.match?(/\A[A-Za-z0-9_.-]+\z/) && part != "." })); abort("invalid package: #{package}") unless valid'
+	@$(PWD)/bin/build/go/validate-package
 
 validate-profile:
-	@ruby -e 'ARGV.each { |key| value = ENV.fetch(key, ""); next if value.empty?; valid = value.match?(/\A[A-Za-z0-9_.-]+\z/) && !value.include?(".."); abort("invalid #{key}: #{value}") unless valid }' id kind
+	@$(PWD)/bin/build/go/validate-profile id kind
 
 download:
 	@go mod download
@@ -129,8 +129,8 @@ specs:
 	@gotestsum --format testdox --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
 
 # Open pprof for a captured profile under test/reports/ (set id/kind).
-pprof: validate-profile
-	@go tool pprof "test/reports/$${NAME}-server-$${id}-$${kind}.prof"
+pprof:
+	@$(PWD)/bin/build/go/pprof "$${NAME}-server-$${id}-$${kind}.prof" id kind
 
 # Fetch a Go module (set module=<path>).
 go-get:
@@ -227,8 +227,8 @@ manifest-docker:
 	@$(PWD)/bin/build/docker/manifest "$${NAME}"
 
 # Base64-encode test/$(kind).yml as a single line.
-encode-config: validate-config
-	@cat "test/$${kind}.yml" | base64 -w 0
+encode-config:
+	@$(PWD)/bin/build/test/encode-config
 
 # Create server and client TLS certs under test/certs/ using mkcert.
 create-certs:
@@ -237,17 +237,8 @@ create-certs:
 	@cp "$$(mkcert -CAROOT)/rootCA.pem" test/certs/rootCA.pem
 
 # Generate a dependency graph PNG for package=$(package), or the module root when unset.
-create-diagram: override export package := $(or $(value package),.)
-
-create-diagram: validate-package
-	@diagram_package="$${package}"; \
-	diagram_pattern="$${MODULE}/$${package}/..."; \
-	if [ "$$diagram_package" = "." ]; then \
-		diagram_package="diagram"; \
-		diagram_pattern="$${MODULE}/..."; \
-	fi; \
-	mkdir -p "$$(dirname "assets/$${diagram_package}.png")"; \
-	goda graph "$$diagram_pattern" | dot -Tpng -o "assets/$${diagram_package}.png"
+create-diagram:
+	@$(PWD)/bin/build/go/create-diagram
 
 # Analyse binary size with gsa (non-fatal if gsa is missing/fails).
 analyse:

--- a/build/test/encode-config
+++ b/build/test/encode-config
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Base64-encode the test configuration selected by kind.
+
+set -eo pipefail
+
+"$(dirname "$0")/validate-config"
+
+readonly kind_value="${kind:-}"
+
+base64 -w 0 "test/$kind_value.yml"

--- a/build/test/validate-config
+++ b/build/test/validate-config
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Validate the test configuration name supplied through kind.
+
+set -eo pipefail
+
+readonly value="${kind:-}"
+
+if [[ -z $value || ! $value =~ ^[A-Za-z0-9_.-]+$ || $value == *..* ]]; then
+  echo "invalid kind: $value" >&2
+  exit 1
+fi

--- a/quality/shell/lint
+++ b/quality/shell/lint
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Run ShellCheck over Bash scripts under build/ and quality/.
+
+set -eo pipefail
+
+files=()
+
+while IFS= read -r -d '' file; do
+  first_line=""
+  IFS= read -r first_line < "$file" || true
+
+  if [[ $first_line == "#!/usr/bin/env bash" || $first_line == "#!/bin/bash" ]]; then
+    files+=("$file")
+  fi
+done < <(find build quality -type f -print0)
+
+if ((${#files[@]} > 0)); then
+  shellcheck "${files[@]}"
+fi


### PR DESCRIPTION
## What

- Move repeated benchmark, diagram, profile, package validation, and test-config shell logic out of reusable fragments into focused helpers under build/go and build/test.
- Replace the root scripts-lint hardcoded file list with quality/shell/lint, which discovers Bash scripts by shebang under build/ and quality/.
- Keep the existing public targets and caller-facing variables intact while making the reusable fragments thinner wrappers around shared scripts.

## Why

- The reusable fragments had started carrying duplicated shell bodies, which made root-package defaults and validation behavior harder to keep consistent across go, client, grpc, and http templates.
- Centralizing the behavior lets downstream projects keep the same target names while future shell helpers are linted automatically without editing the root lint target.

## Testing

- `make dep` - passed
- `make lint` - passed
- `make scripts-lint` - passed
- `make docker-lint` - passed
- `make sec-lint` - passed
- `git diff --check` - passed
- `make -n msg="extract shared helper scripts" desc_file=/tmp/review-pr-dry-run review` - passed
- Downstream-style fixture with a bin symlink verified benchmark root and nested package behavior, diagram output paths for go/client/grpc/http fragments, config encoding, profile command construction, and invalid input rejection.
