### PR TITLE
feat(skills): align testing principle summary

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -54,14 +54,15 @@ In brief: inspect the repository's existing tests, fixtures, helpers,
 entrypoints, CI targets, and dominant test harness before adding new structure.
 Prefer the narrowest established test layer that credibly covers changed
 behavior through a public or documented surface; private-surface tests need
-explicit human approval. For behavior-changing code, prefer a test-first loop:
-add or update the focused test first in TDD-style projects, or the focused
+explicit human approval. Treat tests as executable specifications for observable
+repository behavior, and for behavior-changing code prefer a small test-first
+loop: add or update the focused test first in TDD-style projects, or the focused
 scenario, feature, or spec first in BDD-style projects. Run it red when
 practical, make the smallest implementation change to go green, then refactor
 while keeping tests green. Report that trace in the final update so the workflow
-is auditable. Preserve meaningful coverage where practical, check whether new or
-risky behavior needs better coverage, and explain unavoidable gaps. Keep tests
-readable, edge-aware, deterministic, and descriptive when they fail.
+is auditable. Preserve meaningful coverage where practical, verify coverage
+claims when useful, scan for mutation-style gaps, and avoid coverage theater.
+Keep tests readable, edge-aware, deterministic, and descriptive when they fail.
 
 ## Network And Remote Commands
 


### PR DESCRIPTION
## What

- Updates the shared skills README testing principle to match the expanded testing standards guidance.
- Calls out tests as executable specifications, small test-first loops, coverage claim checks, mutation-style gap scans, and avoiding coverage theater.

## Why

- Keeps the high-level skill index aligned with the detailed testing standards skill so agents and downstream readers see the same testing expectations before opening the full skill.
- Reduces the chance that future test work follows the older summary and misses the newly added review checks.

## Testing

- `make dep` - passed
- `make lint` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
