### PR TITLE
feat(skills): add sre reliability workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,10 @@ skill instead of one broad default:
 - `code-issues`: find confirmed code issues into `ISSUES.md`, then implement agreed fixes one code issue at a time.
 - `test-gaps`: find confirmed missing or weak tests into `ISSUES.md`, then implement agreed test fixes gap by gap.
 - `doc-gaps`: find confirmed missing, stale, or misleading docs/comments into `ISSUES.md`, then implement agreed doc fixes gap by gap.
+- `reliability-standards`: SRE, NALSD, production-readiness, SLO, overload,
+  observability, release-safety, recovery, and operability guidance.
+- `reliability-gaps`: find confirmed reliability gaps into `ISSUES.md`, then
+  implement agreed reliability fixes gap by gap.
 - `review-pr`: create a commit, force-push, and open a draft PR with a generated summary.
 - `shell-standards`: Bash scripting, ShellCheck, text processing, directory
   scope, and function documentation conventions.
@@ -70,6 +74,10 @@ Common composition:
   confirmed `project-workflow` context and missing, stale, or misleading
   README, docs, examples, comments, and docstrings into `ISSUES.md`, then
   implement agreed doc fixes gap by gap.
+- `reliability-gaps` orchestrates a two-phase reliability-gap workflow:
+  aggregate confirmed `project-workflow` context and SRE, NALSD, operability,
+  overload, observability, release-safety, recovery, or data-integrity gaps into
+  `ISSUES.md`, then implement agreed reliability fixes gap by gap.
 - `code-review` conditionally consults `security-audit` for security-sensitive
   review scope while keeping the review findings format.
 - `style-review` performs an optional non-blocking polish pass when explicitly
@@ -79,6 +87,10 @@ Common composition:
   `change-validation` for scanner, lint, or CI command selection.
 - `testing-standards` pairs with language standards for test idioms and
   `change-validation` for command selection.
+- `reliability-standards` pairs with `change-safety`, `security-audit`,
+  `testing-standards`, and `change-validation` when changes affect production
+  readiness, SLOs, overload, observability, release safety, recovery, or
+  operability.
 - `naming-standards` pairs with language standards when a change creates,
   reviews, or renames identifiers, commands, flags, files, tests, fixtures, or
   documentation terms.

--- a/skills/README.md
+++ b/skills/README.md
@@ -19,6 +19,10 @@ checks, and findings.
   aggregate `project-workflow` context and confirmed README, docs, examples,
   comments, and docstring gaps into `ISSUES.md`, then implement agreed
   doc fixes one gap at a time.
+- `reliability-gaps` orchestrates a two-phase reliability-gap workflow: first
+  aggregate `project-workflow` context and confirmed SRE, NALSD, operability,
+  overload, observability, release-safety, recovery, or data-integrity gaps into
+  `ISSUES.md`, then implement agreed reliability fixes one gap at a time.
 - `code-review` performs the review pass and conditionally consults
   `security-audit` for security-sensitive scope.
 - `style-review` performs an optional non-blocking polish pass when explicitly
@@ -29,6 +33,10 @@ checks, and findings.
 - `testing-standards` covers language-agnostic test design and coverage
   decisions; pair it with language standards for idioms and
   `change-validation` for command selection.
+- `reliability-standards` covers SRE, NALSD, production-readiness, SLO,
+  overload, observability, release-safety, recovery, and operability judgment;
+  pair it with `change-safety`, `security-audit`, `testing-standards`, and
+  `change-validation` as the scope requires.
 - `naming-standards` covers cross-language naming judgment for domain clarity,
   vocabulary consistency, abstraction level, ambiguity, public terminology, and
   rename safety; pair it with language standards for language-specific idioms.

--- a/skills/reliability-gaps/SKILL.md
+++ b/skills/reliability-gaps/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: reliability-gaps
+description: Finds concrete missing or weak reliability, operability, SLO, overload, observability, release-safety, recovery, data-integrity, disaster-readiness, or NALSD design evidence in a package or folder, records confirmed gaps in that scope's ISSUES.md, and later proposes and implements explicitly agreed fixes gap by gap. Use when the user asks to find $reliability-gaps in a package or folder, find reliability gaps in a package or folder, review production readiness for a package or folder, implement $reliability-gaps in a package or folder, or implement reliability gaps in a package or folder.
+---
+
+# Reliability Gaps
+
+Use this skill in two distinct modes:
+
+- **Find mode**: `Find $reliability-gaps in <package/folder>` or `Find reliability gaps in <package/folder>`.
+- **Implement mode**: `Implement $reliability-gaps in <package/folder>` or `Implement reliability gaps in <package/folder>`.
+
+Do not combine the two modes in one pass.
+
+## Operating Stance
+
+Operate as a production-readiness triager: record only confirmed reliability
+gaps with concrete evidence, credible user or operator impact, and an actionable
+fix. Reject speculative scalability advice, generic SRE checklists, and findings
+that depend on undocumented future requirements.
+
+## Find Mode
+
+1. Identify the requested package or folder scope. If no scope is provided, stop and ask for the package or folder.
+2. Use `ISSUES.md` in the requested package or folder as the review ledger, for example `<package/folder>/ISSUES.md`.
+3. If `ISSUES.md` already exists in the requested package or folder, stop. Tell the user the existing scoped ledger must be resolved first, or the human must delete that scoped `ISSUES.md` before a new find pass there.
+4. Use `$project-workflow` to discover repository entrypoints, CI expectations, documented commands, operational docs, release/config surfaces, and `./bin` wiring before planning reliability review agents or validation.
+5. Treat `Find $reliability-gaps in <package/folder>` or `Find reliability gaps in <package/folder>` as the user's explicit request to delegate reliability review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
+6. Use sub-agents for Find mode whenever the active runtime provides them and the runtime permits delegation for the request. Do not treat sub-agents as optional based on scope size, and do not perform the reliability-gap review locally first.
+7. Do not claim that extra delegation wording is needed before launching review agents. The Find mode invocation is the explicit delegation request.
+8. If the runtime still requires an approval step before launching sub-agents, ask once with the concrete read-only agent plan. If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
+9. Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, destructive operations, or non-read-only validation. Without that permission, agents should inspect code, config, tests, docs, and CI only and suggest validation.
+10. Exclude generated files and folders, vendored dependencies, caches, build output, generated API docs, and generated lockfile churn unless the requested scope is explicitly about them.
+11. Launch at least one sub-agent covering the requested root package/folder. Split agent assignments across:
+   - files directly under the requested root package/folder.
+   - operational docs, config, deployment, CI, scripts, or Make targets directly under the requested root package/folder.
+   - each first-level subpackage/subfolder under the requested root.
+12. Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough `$reliability-standards` review for its assigned scope, pairing with:
+   - `$change-safety` for public APIs, commands, flags, env vars, file formats, migrations, config, deployment, or documented operator behavior.
+   - `$security-audit` for auth, secrets, privilege, attacker-driven failure, DoS, logging privacy, supply chain, or incident containment.
+   - `$testing-standards` and `$change-validation` for likely failure-path tests and validation commands.
+13. Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
+14. Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity.
+15. Wait for all agents to finish before aggregating results.
+16. Deduplicate overlapping findings and resolve conflicting agent conclusions by re-checking the code, config, tests, docs, and CI directly.
+17. Confirm each candidate gap against current evidence before recording it. A gap must name the affected reliability promise or operational expectation, the failure mode, the missing or weak control, and the likely user or operator impact.
+18. Record reliability gaps only when they involve repository-owned behavior or documented/implicit operational contracts, such as:
+   - missing or weak SLO, SLI, alertability, dashboard, runbook, or operator diagnostic coverage for behavior the repository claims or owns.
+   - unbounded or unsafe timeouts, retries, backoff, jitter, concurrency, queues, subprocesses, files, disk, memory, network, or worker resources.
+   - missing backpressure, load shedding, graceful degradation, or fallback for a meaningful dependency or overload failure mode.
+   - release, config, feature-flag, rollback, migration, or post-deploy behavior that can strand users or operators.
+   - missing idempotency, replay, deduplication, ordering, reconciliation, backup, restore, or data-integrity controls for stateful behavior.
+   - missing health/readiness/shutdown/drain behavior for long-running services or workers.
+   - missing concrete NALSD assumptions, capacity estimates, bottleneck analysis, or failure-domain reasoning where the code or docs already make scale or availability claims.
+19. Do not record generic advice to add monitoring, runbooks, autoscaling, retries, queues, circuit breakers, chaos testing, load tests, Kubernetes probes, or dashboards unless a concrete current failure mode and repository-owned fix are identified.
+20. Do not record reliability gaps whose only support is an undocumented future scale target, hypothetical product direction, or architecture preference.
+21. Do not record confirmed production bugs, security issues, compatibility breaks, or violated public contracts as reliability gaps. If broken behavior is discovered during review, report it as out of scope for the reliability-gap ledger and recommend `$code-issues`, `$security-audit`, or `$change-safety` as appropriate.
+22. Do not record standalone missing, weak, flaky, misleading, or wrong-layer tests as reliability gaps. Use `$test-gaps` when missing failure-path coverage is the finding.
+23. Do not record standalone missing, weak, stale, misleading, or wrong-location operational docs as reliability gaps. Use `$doc-gaps` when documentation itself is the finding.
+24. Do not report optional maturity improvements, cloud-architecture preferences, private implementation preferences, or "best practice" checkboxes as findings by themselves. List them only as optional follow-up notes when relevant.
+25. If no confirmed reliability gaps are found, report that no reliability gaps were found and do not create `ISSUES.md`.
+26. If confirmed reliability gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
+27. Assign every finding a unique ID for the session in the form `REL-<number>`.
+28. Present the scoped `ISSUES.md` and a proposed reliability-fix plan to the user.
+29. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
+
+## `ISSUES.md` Format
+
+Use this structure:
+
+```markdown
+# Issues
+
+## REL-1: Short concrete title
+
+- Type: Reliability Gap
+- Severity: Critical|High|Medium|Low
+- Scope: path/to/file-or-folder
+- Impact: User, operator, incident, availability, recovery, data-integrity, or scaling risk.
+- Evidence: Concrete file and line references, command behavior, config, docs, tests, missing control, failure mode, or calculation gap.
+- Proposed fix: Smallest credible reliability improvement using established local patterns.
+- Validation: Suggested checks for the reliability change.
+```
+
+Keep optional follow-up notes separate from findings:
+
+```markdown
+## Optional Reliability Follow-Ups
+
+- Optional or non-blocking note.
+```
+
+## Implement Mode
+
+1. Identify the requested package or folder scope. If no scope is provided, stop and ask for the package or folder.
+2. Read `ISSUES.md` in the requested package or folder first and treat it as the working reliability-gap ledger.
+   If scoped `ISSUES.md` does not exist, stop and ask whether to run Find mode first for that scope.
+3. Use `$project-workflow` before proposing or running validation so repository entrypoints, CI expectations, documented commands, operational docs, release/config surfaces, and `./bin` wiring are current.
+4. Work through findings sequentially by ID unless the human explicitly names a different finding.
+5. Before proposing a fix for each finding, re-check the current code, config, tests, docs, and CI. Treat the ledger as something that can go stale: dismiss or revise findings that are already addressed, no longer have a concrete failure mode, duplicate another issue, or belong in `$code-issues`, `$security-audit`, `$test-gaps`, or `$doc-gaps`.
+6. For each finding, first present:
+   - the issue ID and current evidence.
+   - the affected reliability promise or operational expectation.
+   - the proposed reliability solution.
+   - code, config, docs, test-layer, validation, compatibility, rollout, rollback, and operator tradeoffs.
+   - the intended validation.
+7. Stop after proposing the solution. Do not edit files, update `ISSUES.md`, or start validation until the human explicitly agrees to that finding's solution.
+8. Ask questions when SLOs, expected failure behavior, operator workflow, compatibility, rollout, validation, or user intent is ambiguous. Treat silence or a broad "implement reliability gaps" request as permission to start the proposal workflow, not as permission to edit.
+9. Once the solution for the current finding is agreed, implement only that finding with the smallest clear reliability change.
+10. Use `$reliability-standards` for reliability design, `$change-safety` for public or operational compatibility, `$testing-standards` for failure-path tests, and `$change-validation` for checks. Pair with `$security-audit` when the fix touches auth, secrets, privilege, DoS, logs, supply chain, or incident containment.
+11. Validate the reliability change using checks appropriate to the changed behavior. Prefer repository Make targets and documented entrypoints.
+12. Report the result for that finding and ask the human to verify and explicitly say `REL-<number> is done`.
+13. Do not move to the next finding until the human says `REL-<number> is done`.
+14. After the human confirms a finding is done, remove that finding from scoped `ISSUES.md`. If a finding is deemed invalid or not actually a reliability gap, remove it only after explaining why and getting human agreement.
+15. Then propose the solution for the next remaining finding and repeat the same agreement gate.
+16. Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
+17. Summarize what changed, which reliability gaps were resolved or dismissed, and which validation steps were run or still need to be carried out by the human.
+
+## References
+
+- Use `../references/finding-severity.md` for confidence filtering and severity.
+- Use `$reliability-standards` for SRE, NALSD, resilience, recovery, overload, observability, release-safety, and production-readiness judgment.
+- Use `$project-workflow` for repository command discovery, CI expectations, documented entrypoints, operational docs, and `./bin` wiring before review planning or validation.
+- Use `$change-safety` when reliability changes affect public contracts, compatibility, migrations, config, deployment, security expectations, or documented operational behavior.
+- Use `$testing-standards` when reliability fixes need failure-path or recovery tests.
+- Use `$change-validation` when selecting validation commands for implemented reliability fixes.
+- Use `$security-audit` when the confirmed problem is primarily security-sensitive.
+- Use `$code-issues`, `$test-gaps`, or `$doc-gaps` when the confirmed problem belongs to those ledgers instead of reliability.

--- a/skills/reliability-gaps/agents/openai.yaml
+++ b/skills/reliability-gaps/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Reliability Gaps"
+  short_description: "Find scoped SRE readiness gaps"
+  default_prompt: "Use $reliability-gaps to find scoped reliability, operability, SLO, overload, observability, release-safety, recovery, or NALSD gaps, store confirmed findings in that scope's ISSUES.md, or propose and implement agreed reliability fixes one gap at a time."

--- a/skills/reliability-standards/SKILL.md
+++ b/skills/reliability-standards/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: reliability-standards
+description: Applies SRE, NALSD, and secure/reliable systems standards to code, designs, scripts, Make targets, services, jobs, deployment/config, observability, incident, recovery, capacity, and production-readiness work. Use when reviewing or changing reliability-sensitive behavior, retries, timeouts, backpressure, SLOs, SLIs, error budgets, monitoring, alerting, runbooks, release safety, overload handling, cascading failures, data integrity, disaster recovery, or concrete NALSD design estimates; pair with $reliability-gaps for scoped reliability-gap discovery.
+---
+
+# Reliability Standards
+
+## Operating Stance
+
+Operate as a practical SRE reviewer: connect reliability concerns to concrete
+user impact, operator burden, production failure modes, and observable code,
+config, docs, or workflow evidence. Reject broad architecture advice that cannot
+be tied to a current requirement, documented promise, code path, or operational
+risk.
+
+## Steps
+
+1. Identify the reliability surface in scope: services, APIs, CLIs, jobs,
+   scripts, queues, storage, migrations, config, deployment, CI, docs, runbooks,
+   dashboards, or shared tooling used by downstream projects.
+2. Read the smallest matching reference before applying detailed standards:
+   - `references/sre.md` for SLOs, monitoring, alerting, toil, automation,
+     release engineering, overload, cascading failures, data integrity,
+     incident response, postmortems, or launches.
+   - `references/nalsd.md` for system design, capacity planning, scaling,
+     bottleneck estimates, failure domains, graceful degradation, and concrete
+     resource assumptions.
+   - `references/secure-reliable.md` for security/reliability tradeoffs,
+     resilience, recovery, least privilege, change safety, DoS, deployment,
+     investigation, disaster planning, crisis response, or breakglass behavior.
+   - `references/nfr-capture.md` for turning reliability concerns into
+     specific, measurable, testable non-functional requirements and for choosing
+     how to implement cross-cutting reliability controls consistently.
+3. Use `$project-workflow` before selecting validation or reasoning about
+   repository entrypoints, CI, shared `./bin` wiring, or Make targets.
+4. Pair with `$change-safety` when reliability-sensitive behavior touches public
+   APIs, commands, flags, environment variables, file formats, migrations,
+   deployment, config, auth, or documented operator behavior.
+5. Pair with `$testing-standards` and `$change-validation` when reliability work
+   needs failure-path tests, smoke checks, load checks, linting, CI, or manual
+   validation guidance.
+6. Pair with `$security-audit` when the reliability concern depends on attacker
+   behavior, auth, secrets, privilege, supply chain, DoS, logging privacy, or
+   incident containment.
+7. Before reporting a reliability concern, identify the requirement or promise
+   it affects, the failure mode, the existing control or missing control, and
+   the likely user/operator impact.
+8. Prefer small, locally consistent fixes: bounded retries before new
+   infrastructure, useful logs before broad telemetry redesigns, rollback-safe
+   migrations before process-only mitigations, and documented runbook steps
+   before vague operational advice.
+9. Report uncertainty explicitly. When scale, SLO, traffic, durability, or
+   recovery targets are unknown, ask for the missing assumption or record the
+   need for a concrete assumption only when the code or docs already imply one.
+
+## Review Questions
+
+Use these questions selectively; do not turn them into a checklist finding
+without concrete evidence.
+
+- **SLOs and user impact**: What user-visible reliability promise is affected?
+  Are SLIs, SLOs, error budgets, latency bounds, freshness bounds, or durability
+  expectations documented or implied?
+- **Failure modes**: What happens when a dependency is slow, down, stale,
+  partially successful, duplicated, reordered, or returns malformed data?
+- **Timeouts and retries**: Are deadlines propagated? Are retries bounded, using
+  backoff and jitter, and safe for idempotency and downstream load?
+- **Overload and backpressure**: Are request, queue, worker, memory, file,
+  subprocess, and network resources bounded? Can the system shed load or degrade
+  intentionally?
+- **Cascading failures**: Can one failing component exhaust shared pools,
+  retries, locks, queues, ports, disk, memory, or credentials used by unrelated
+  work?
+- **Observability and alerting**: Can operators detect symptoms, correlate
+  causes, distinguish user impact from noise, and avoid alerting on non-actionable
+  conditions?
+- **Recovery**: Can state be rebuilt, replayed, rolled back, drained, or
+  reconciled? Are data loss, duplication, and corruption boundaries explicit?
+- **Release safety**: Are deploys, config changes, migrations, feature flags,
+  canaries, rollbacks, and post-deploy checks safe for partial completion?
+- **Operational usability**: Are health checks, readiness, runbooks, emergency
+  access, diagnostics, and remediation steps available where the repository owns
+  them?
+- **NALSD fit**: For system design, are workload assumptions, growth factors,
+  bottlenecks, resource estimates, failure domains, and graceful degradation
+  concrete enough to evaluate?
+
+## Boundaries
+
+- Use `$reliability-gaps` when the user asks to find or implement scoped
+  reliability gaps through an `ISSUES.md` ledger.
+- Use `$code-review` or `$code-issues` when the finding is a concrete bug,
+  violated contract, or broken behavior rather than a missing reliability
+  control.
+- Use `$security-audit` when exploitability, secrets, auth, privilege, or
+  attacker-driven behavior is the primary concern.
+- Use `$test-gaps` when the only confirmed issue is missing failure-path or
+  reliability test coverage.
+- Use `$doc-gaps` when the only confirmed issue is missing, stale, or misleading
+  operational documentation.
+
+## References
+
+- Read `references/sre.md` for distilled SRE book standards.
+- Read `references/nalsd.md` for Non-Abstract Large System Design review
+  prompts.
+- Read `references/secure-reliable.md` for secure and reliable systems standards.
+- Read `references/nfr-capture.md` for non-functional requirement capture and
+  cross-cutting reliability-control implementation guidance.

--- a/skills/reliability-standards/agents/openai.yaml
+++ b/skills/reliability-standards/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Reliability Standards"
+  short_description: "Review SRE and production readiness"
+  default_prompt: "Use $reliability-standards to review SRE, NALSD, and production-readiness concerns for this change, focusing on concrete SLO impact, failure modes, overload behavior, observability, release safety, recovery, and operator actionability."

--- a/skills/reliability-standards/references/nalsd.md
+++ b/skills/reliability-standards/references/nalsd.md
@@ -1,0 +1,89 @@
+# NALSD Review Standards
+
+Use this reference for Non-Abstract Large System Design (NALSD) reviews and
+production-readiness questions that require concrete scale, resource, and
+failure-domain reasoning.
+
+Primary sources:
+
+- https://sre.google/workbook/non-abstract-design/
+- https://cloud.google.com/blog/products/management-tools/sre-principles-and-flashcards-to-design-nalsd
+- https://research.google/pubs/the-site-reliability-engineering-workbook-chapter-introducing-non-abstract-large-system-design-nalsd/
+- https://static.googleusercontent.com/media/sre.google/en//static/pdf/rule-of-thumb-latency-numbers-letter.pdf
+
+## NALSD Loop
+
+Apply the loop only where scale, availability, performance, freshness,
+durability, or cost assumptions matter.
+
+1. State the problem and requirements.
+2. Sketch a basic design that works in principle.
+3. Ask whether the basic design can be made simpler, faster, smaller, or more
+   efficient.
+4. Scale the requirements up to the claimed or expected production size.
+5. Check feasibility against concrete resources: CPU, memory, disk, network,
+   storage, IOPS, latency, connection counts, queue depth, request rate, data
+   volume, and cost where relevant.
+6. Check resilience: component failure, dependency failure, zone/region failure,
+   partial failure, retries, overload, stale data, and operator recovery.
+7. Iterate until the design is concrete enough to evaluate or the missing
+   assumptions are explicit.
+
+## Evidence To Look For
+
+- Workload assumptions: QPS, events/sec, data size, payload size, cardinality,
+  fanout, retention, freshness, latency, concurrency, burst behavior, and growth.
+- Resource estimates: CPU, memory, disk, network, IOPS, connections, workers,
+  queue depth, cache size, and storage retention.
+- Bottleneck reasoning: which resource saturates first and what happens next.
+- Failure domains: process, host, disk, network, dependency, queue, database,
+  zone, region, account, credential, config, and deployment boundaries.
+- Graceful degradation: what can be disabled, delayed, cached, dropped,
+  sampled, backfilled, retried later, or served stale.
+- Operator controls: feature flags, rate limits, circuit breakers, drain
+  commands, rollback, backfill, repair, and diagnostic commands.
+
+## When To Record A Gap
+
+Record a NALSD-related reliability gap only when the repository already makes a
+scale, latency, availability, freshness, durability, or production-use claim and
+the design lacks enough concrete assumptions or controls to evaluate it.
+
+Do not record a gap merely because a small tool, library, or local script lacks
+distributed-system design notes. For shared tooling, focus on downstream blast
+radius, idempotency, failure output, destructive operations, dependency
+availability, and whether failures are diagnosable.
+
+## Useful Estimation Checks
+
+- Convert rates into daily volume and retention footprint.
+- Convert fanout into downstream request pressure.
+- Convert retry policy into worst-case amplified load.
+- Compare queue capacity with producer rate and consumer drain rate.
+- Compare timeout and deadline choices with caller expectations.
+- Compare data freshness promises with batching, polling, scheduling, and
+  replication delays.
+- Compare rollback time with the expected error budget burn or user impact.
+
+## Rule-Of-Thumb Latency Numbers
+
+Use latency rule-of-thumb material for rough order-of-magnitude calibration,
+not as current hardware guarantees. Prefer measured local production data,
+benchmark output, cloud/provider documentation, or repository-owned SLOs when
+they exist.
+
+When using rule-of-thumb numbers:
+
+- Compare magnitudes, not exact values: cache, memory, local disk, SSD, network
+  transfer, same-datacenter round trips, and cross-region or cross-continent
+  round trips have very different cost profiles.
+- Identify the dominant operation before optimizing secondary costs. A design
+  dominated by seeks or remote round trips will not be fixed by small CPU-level
+  improvements.
+- Convert object size, fanout, and per-request operations into latency and
+  throughput estimates before accepting a design.
+- Re-check assumptions when hardware, cloud instance type, region distance,
+  storage class, compression, batching, or concurrency model differs from the
+  reference example.
+- Treat surprising conclusions as prompts for measurement or prototype
+  validation, not as proof by spreadsheet.

--- a/skills/reliability-standards/references/nfr-capture.md
+++ b/skills/reliability-standards/references/nfr-capture.md
@@ -1,0 +1,104 @@
+# Non-Functional Requirement Capture
+
+Use this reference when a reliability concern needs to become an explicit
+requirement, acceptance criterion, design constraint, validation target, or
+consistent cross-cutting implementation pattern.
+
+Primary source:
+
+- https://microsoft.github.io/code-with-engineering-playbook/design/design-patterns/non-functional-requirements-capture-guide/
+
+Related implementation note:
+
+- https://jessemcdowell.ca/2024/05/Cross-Cutting-Concerns/
+
+## Requirement Quality
+
+Capture reliability requirements as concrete engineering constraints, not broad
+aspirations.
+
+- Tie the requirement to business, user, operator, or downstream-system impact.
+- Name the affected component, workflow, API, command, job, or operational path.
+- Make the requirement measurable or testable when practical.
+- Define the expected condition, threshold, boundary, or behavior under failure.
+- Identify who owns implementation, verification, and operational response.
+- Record tradeoffs when availability, latency, integrity, security, cost,
+  usability, or delivery speed pull in different directions.
+
+Prefer:
+
+- "Dashboard freshness is less than 5 minutes for 99.9% of successful reads."
+- "Worker retries stop after 3 attempts with exponential backoff and jitter."
+- "The migration can be safely rerun after interruption without duplicating rows."
+
+Avoid:
+
+- "The dashboard should be reliable."
+- "Add observability."
+- "Make retries robust."
+- "Improve scalability."
+
+## Reliability NFR Categories
+
+Use these categories to discover missing precision:
+
+- **Availability**: What must keep working, for whom, and at what tolerance?
+- **Latency**: Which path has a deadline, percentile, or timeout expectation?
+- **Freshness**: How stale may data become before users or operators are harmed?
+- **Durability**: What data must survive process, host, dependency, or disaster
+  failure?
+- **Integrity**: What duplication, loss, corruption, ordering, or reconciliation
+  behavior is acceptable?
+- **Recoverability**: What are the expected recovery time and recovery point?
+- **Scalability**: What workload, burst, cardinality, retention, or fanout is
+  expected?
+- **Operability**: What logs, metrics, alerts, runbooks, commands, or dashboards
+  let operators detect and remediate failure?
+- **Release safety**: How can deploys, config changes, migrations, and feature
+  changes be rolled out, verified, disabled, or rolled back?
+- **Security/reliability interaction**: How do auth, least privilege, audit,
+  secret rotation, DoS controls, or breakglass behavior affect availability and
+  recovery?
+
+## Acceptance Criteria
+
+Turn reliability NFRs into acceptance criteria that can be validated. Use one or
+more of these forms:
+
+- **Behavioral**: Given a dependency timeout, the command exits non-zero with an
+  actionable error and does not leave partial output.
+- **Metric**: 99.9% of requests complete under the documented latency target.
+- **Bounded resource**: Queue length, concurrency, retries, memory, subprocesses,
+  or file handles are capped with a defined overflow behavior.
+- **Recovery**: Interrupted work can be resumed, replayed, restored, or rolled
+  back without data loss beyond the stated boundary.
+- **Operational**: Logs, metrics, or docs expose enough context for the named
+  operator action.
+- **Release**: The change has a rollback or disablement path and a post-deploy
+  verification signal.
+
+## Cross-Cutting Controls
+
+Reliability controls often span many code paths: logging, tracing, metrics,
+timeouts, retry policy, authorization failure handling, idempotency, error
+classification, rate limiting, and health checks.
+
+When implementing a cross-cutting reliability control:
+
+- Prefer established local mechanisms before adding a new abstraction.
+- Centralize policy where consistency matters and the repository has a natural
+  integration point, such as middleware, client wrappers, shared command helpers,
+  framework hooks, libraries, or Make/script helpers.
+- Keep the mechanism understandable during debugging and incidents. Avoid hidden
+  behavior that operators and maintainers cannot trace.
+- Allow explicit exceptions near the policy so reviewers can see why a path is
+  different.
+- Use tests or static checks to enforce consistency only when the policy cannot
+  be centralized safely.
+- Do nothing deliberately when the scope is small, the risk is low, and a shared
+  abstraction would add more maintenance cost than reliability value.
+
+Do not record cross-cutting abstraction advice as a reliability gap by itself.
+Record a gap only when inconsistent implementation creates a concrete
+reliability failure mode or prevents a required reliability NFR from being
+verified.

--- a/skills/reliability-standards/references/secure-reliable.md
+++ b/skills/reliability-standards/references/secure-reliable.md
@@ -1,0 +1,78 @@
+# Secure And Reliable Systems Standards
+
+Use this reference when reliability overlaps with security, resilience,
+recovery, deployment, investigation, or crisis response.
+
+Primary source:
+
+- https://google.github.io/building-secure-and-reliable-systems/raw/toc.html
+
+## Design Tradeoffs
+
+- Treat reliability and security as product qualities, not late-stage add-ons.
+- Identify nonfunctional requirements explicitly: availability, integrity,
+  latency, freshness, recovery time, recovery point, confidentiality, audit, and
+  operator control.
+- Prefer designs whose safety properties are understandable and enforceable by
+  common frameworks or shared libraries.
+- Make tradeoffs explicit when security controls can reduce availability or
+  when reliability controls can weaken security.
+
+## Resilience
+
+- Use defense in depth for critical paths: one missed check, failed dependency,
+  bad config, or compromised component should not create total failure.
+- Control degradation deliberately. Define what gets slower, stale, disabled,
+  queued, dropped, or isolated.
+- Control blast radius through role separation, location separation, time
+  separation, bounded credentials, and scoped permissions where relevant.
+- Continuously validate important assumptions with tests, smoke checks, audits,
+  or operational exercises.
+
+## Recovery
+
+- Define what the system is recovering from: random errors, accidental errors,
+  software defects, malicious action, dependency failure, data corruption, or
+  disaster.
+- Know intended state well enough to rebuild, verify, revoke, rotate, replay,
+  restore, or reconcile it.
+- Keep recovery paths testable. Untested backup, restore, breakglass, and
+  incident procedures are weak controls.
+- Reduce dependency on wall-clock timing when recovery correctness depends on
+  event ordering, expiry, revocation, or coordination.
+
+## Deployment And Change
+
+- Prefer automated, reviewable, reproducible deployment and config paths.
+- Verify artifacts and deployed state, not only the person or command that
+  triggered deployment.
+- Treat config as code when it controls reliability, security, routing,
+  credentials, limits, or operational behavior.
+- Include rollback, breakglass, post-deploy verification, and actionable errors
+  for high-impact deployment paths.
+
+## Investigation And Logging
+
+- Collect logs and events that help operators answer what happened, who or what
+  caused it, which users or data were affected, and what mitigation occurred.
+- Preserve privacy and least privilege in logs. Do not add sensitive data just
+  to make diagnosis easier.
+- Make debugging access reliable enough for incidents and constrained enough to
+  avoid creating a new security or availability problem.
+
+## Disaster And Crisis Readiness
+
+- Define severity, ownership, escalation, communication, and handoff
+  expectations when the repository owns incident or recovery workflows.
+- Pre-stage people, access, systems, and procedures before incidents.
+- Validate plans through nonintrusive tabletop exercises, smoke checks, restore
+  tests, red-team-style checks, or production exercises where appropriate and
+  authorized.
+
+## DoS And Abuse
+
+- Check both hostile and self-inflicted overload: client retries, batch jobs,
+  cron overlap, thundering herds, fanout, expensive queries, and unbounded
+  queues can all create denial of service.
+- Prefer defendable services: resource limits, quotas, admission control,
+  rate limiting, load shedding, prioritization, and useful monitoring.

--- a/skills/reliability-standards/references/sre.md
+++ b/skills/reliability-standards/references/sre.md
@@ -1,0 +1,67 @@
+# SRE Reliability Standards
+
+Use this reference for practical SRE concerns. It distills review prompts from
+the public Google SRE book without copying the source text.
+
+Primary source:
+
+- https://sre.google/sre-book/table-of-contents/
+
+## Core Areas
+
+- **Risk and SLOs**: Identify the user-visible behavior, the SLI that would
+  measure it, the SLO or error budget if one exists, and the business or user
+  tradeoff of accepting failure.
+- **Monitoring and alerting**: Prefer symptom-based, actionable alerts tied to
+  user impact. Avoid alerting only on internal causes unless the alert has a
+  clear operator action.
+- **Toil and automation**: Look for recurring manual work caused by code,
+  deployment, release, diagnosis, recovery, or maintenance gaps. Automation
+  should reduce toil without hiding failure or removing human control where it
+  is still needed.
+- **Simplicity**: Prefer simpler reliability controls that operators can
+  understand during incidents. Complexity is itself a reliability cost.
+- **Release engineering**: Check whether changes can be built, reviewed,
+  deployed, rolled back, verified after deploy, and traced to source.
+- **On-call and incident response**: Check whether responders can detect,
+  triage, mitigate, communicate, and hand off incidents using repository-owned
+  logs, metrics, docs, and commands.
+- **Postmortems and outage tracking**: Favor mechanisms that preserve evidence,
+  support blameless analysis, and make follow-up work trackable.
+- **Testing for reliability**: Exercise failure paths, recovery paths,
+  dependency errors, overload behavior, data integrity, and release paths through
+  the narrowest credible established test layer.
+- **Overload and cascading failures**: Check for resource bounds, admission
+  control, backpressure, load shedding, queue limits, retry budgets, and failure
+  isolation.
+- **Critical state and data integrity**: Check whether state is durable,
+  recoverable, idempotent, reconciled, and protected against corruption,
+  duplication, loss, and stale reads according to the repository's promises.
+- **Launch readiness**: Check whether new or changed behavior has rollout,
+  rollback, observability, capacity, dependency, and support readiness.
+
+## Review Prompts
+
+- What are users or downstream systems unable to do when this path fails?
+- What condition would page an operator, and what action would they take?
+- What can saturate first: CPU, memory, disk, network, file descriptors,
+  subprocesses, goroutines/threads, database connections, queues, or retries?
+- What happens during dependency slowness, dependency outage, partial failure,
+  stale data, duplicate delivery, process restart, or deploy interruption?
+- Can the system fail small, shed load, degrade intentionally, or preserve core
+  behavior when optional behavior fails?
+- Can state be replayed, rebuilt, reconciled, rolled back, or restored?
+- Does the release path make failures discoverable quickly and reversible safely?
+
+## Anti-Patterns
+
+- Treating retries as reliability without deadlines, backoff, jitter,
+  idempotency, and downstream load awareness.
+- Treating logs as observability without clear fields, correlation, retention,
+  and operator queries.
+- Treating tests as reliability when they do not exercise the actual failure
+  mode or recovery path.
+- Treating manual runbooks as sufficient when the repository could make the
+  operation bounded, safer, or self-validating.
+- Treating "no SLO exists" as proof that user impact does not matter when code,
+  docs, or product behavior imply an operational promise.


### PR DESCRIPTION
## What

- Add reliability standards and reliability gaps skills for SRE, NALSD, production-readiness, operability, overload, observability, release-safety, recovery, and data-integrity review.
- Add reliability reference material for SRE, NALSD, secure/reliable systems, non-functional requirement capture, and bounded cross-cutting reliability controls.
- Update the shared skill index and repository agent guidance so the new skills are discoverable and composed with the existing review, validation, safety, security, test, and doc workflows.

## Why

- Gives agents a scoped way to review reliability concerns without turning ordinary code review into a generic SRE checklist.
- Keeps gap discovery evidence-based by requiring concrete requirements, failure modes, controls, impact, and validation before recording REL-* findings.
- Captures NFR and cross-cutting-control guidance so reliability requirements become measurable, testable, and consistently implemented where the repository owns the behavior.

## Testing

- `make dep` - passed
- `make clean-dep` - passed
- `make lint` - passed
- `make scripts-lint` - passed
- `make docker-lint` - passed
- `make sec` - passed
- `ruby -e ... skills/reliability-standards/SKILL.md skills/reliability-gaps/SKILL.md` - passed
- `ruby -e ... skills/reliability-standards/agents/openai.yaml skills/reliability-gaps/agents/openai.yaml` - passed
- `rg -n "[^\\x00-\\x7F]|TODO|Structuring This Skill" skills/reliability-standards skills/reliability-gaps` - passed with no matches
- `quick_validate.py skills/reliability-standards` and `quick_validate.py skills/reliability-gaps` did not complete because this Python environment is missing the `yaml` module.

AI-assisted-by: [Codex](https://openai.com/codex/)
