### PR TITLE
feat(make): detect stale generated protobufs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,7 +177,7 @@ Only rely on a command if you can find it being invoked in the relevant `.mak`/s
     - `build/make/git.mak`: branch/workflow helpers and conventional-ish commit prefixing.
     - `build/make/go.mak`: go deps, lint, tests, coverage, security.
     - `build/make/{http,grpc,client}.mak`: project templates combining Go + Ruby test harness.
-    - `build/make/buf.mak`: buf lint/generate/push/breaking.
+    - `build/make/buf.mak`: buf lint/generate/stale/push/breaking.
 - `build/docker/`
   - `go/Dockerfile`: multi-stage Go build into distroless runtime.
   - `env`: helper that clones/updates a sibling `../docker` repo and runs `make …` there.

--- a/build/make/buf.mak
+++ b/build/make/buf.mak
@@ -20,6 +20,10 @@ update-all-dep:
 generate:
 	@buf generate
 
+# Check whether generated protobuf outputs are stale.
+stale: generate
+	@git diff --exit-code
+
 # Push module to the Buf Schema Registry (buf push).
 push:
 	@buf push

--- a/build/make/grpc.mak
+++ b/build/make/grpc.mak
@@ -29,6 +29,10 @@ proto-breaking:
 proto-generate:
 	@make -C api generate
 
+# Check whether generated code from api/ protobufs is stale.
+proto-stale:
+	@make -C api stale
+
 # Push the api/ module to the Buf Schema Registry (buf push).
 proto-push:
 	@make -C api push

--- a/skills/project-workflow/references/make-fragments.md
+++ b/skills/project-workflow/references/make-fragments.md
@@ -34,15 +34,16 @@ Use this reference after you have identified which shared `bin/build/make/*.mak`
 
 ### `buf.mak`
 
-- Especially relevant targets: `lint`, `fix-lint`, `format`, `generate`, `breaking`, `push`, `update-all-dep`.
+- Especially relevant targets: `lint`, `fix-lint`, `format`, `generate`, `stale`, `breaking`, `push`, `update-all-dep`.
 - `breaking` compares against `https://github.com/alexfalkowski/$(NAME).git#branch=master`, so branch and remote assumptions matter.
-- `generate` and `push` depend on the consuming repository's Buf configuration.
+- `generate`, `stale`, and `push` depend on the consuming repository's Buf configuration.
+- `stale` runs `buf generate` from the Buf module directory that included the fragment, then runs `git diff --exit-code`; Git checks the whole worktree, so generated outputs outside that child directory are still detected.
 - `push` updates remote state and requires explicit user permission.
 
 ### `http.mak`, `grpc.mak`, And `client.mak`
 
 - These are project-template fragments that combine Go, Ruby test harness, Docker, security, coverage, and helper targets.
-- `grpc.mak` also includes proto lint, format, generate, breaking, and push targets.
+- `grpc.mak` also includes proto lint, format, generate, stale, breaking, and push targets.
 - `features` and `benchmarks` depend on downstream test/build layout and wrappers under `BIN_ROOT/quality/ruby/...`.
 - `specs`, coverage, and report cleanup assume downstream `test/reports/` paths.
 - Docker and certificate helper targets depend on external CLIs such as Docker, `mkcert`, `dot`, and `air` depending on the target.
@@ -59,7 +60,7 @@ Use this reference after you have identified which shared `bin/build/make/*.mak`
 
 - If the root `Makefile` includes `ruby.mak`, expect Ruby lint and cucumber-style feature flows.
 - If it includes `go.mak`, expect Go lint, test, coverage, and security flows.
-- If it includes `buf.mak`, expect Buf lint, format, generate, push, and breaking-change flows.
+- If it includes `buf.mak`, expect Buf lint, format, generate, stale-output, push, and breaking-change flows.
 - If it includes `http.mak`, `grpc.mak`, or `client.mak`, expect combined Go/Ruby validation and downstream test harness assumptions.
 - If the repo exposes both `features` and `specs`, choose the target that best matches the area under change.
 - If the repo overrides a target after including a fragment, trust the root `Makefile` behavior over the fragment default.


### PR DESCRIPTION
## What

- Add a `stale` target to `buf.mak` that runs `buf generate` and fails when generated protobuf outputs leave a worktree diff.
- Expose the downstream service target as `proto-stale` from `grpc.mak`.
- Document the new Buf stale-output flow in the shared project workflow references and repository overview.

## Why

- Give downstream repositories a reusable CI check for stale committed protobuf outputs.
- Complement Buf compatibility checks with generated-output freshness validation for Go, Ruby, or other generated artifacts.
- Keep the target layout-independent by relying on plain `git diff --exit-code` from the Buf module directory.

## Testing

- `git diff --check` - passed
- `gmake -n -f /Users/alejandro/code/bin/build/make/buf.mak stale` from Bezeichner `api`, nonnative `test`, and go-service `internal/test` - passed
- `gmake -n -f /Users/alejandro/code/bin/build/make/grpc.mak proto-stale` from Bezeichner root - passed
- `gmake -f /Users/alejandro/code/bin/build/make/buf.mak stale` from a clean temporary Bezeichner `api` worktree - passed
- Simulated a proto-only Bezeichner change in a temporary worktree; `gmake -f /Users/alejandro/code/bin/build/make/buf.mak stale` failed as expected with generated Go and Ruby diffs
- `make lint` - failed before linting because `/usr/bin/make` is GNU Make 3.81 and cannot parse the shared make fragments in this environment
- `gmake lint` - failed before linting because Ruby could not find the Bundler 4.0.10 version pinned by `Gemfile.lock`
