### PR TITLE
feat(make): scan versioned images before pushing

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,10 @@ These are used by `build/make/ruby.mak` targets `features` and `benchmarks`.
 ### Docker helpers
 
 - `build/docker/go/Dockerfile` is a multi-stage Dockerfile to build a Go binary and copy it into a distroless image.
-- `build/docker/build` builds a **test** image tagged `alexfalkowski/<name>:test.<platform>`.
-- `build/docker/push` and `build/docker/manifest` are gated: they only run if `APP_VERSION_FILE` exists (default: `/tmp/workspace/release-version.txt`).
+- `build/docker/build` builds a **test** image tagged `alexfalkowski/<name>:test.<platform>` by default; pass `production` as the third argument to build `alexfalkowski/<name>:<version>.<platform>` from `APP_VERSION_FILE`.
+- `build/sec/trivy-image` scans the **test** image by default; pass `production` as the third argument to scan the versioned image that will be pushed.
+- In service Make targets, use `test-docker` for build-and-scan branch checks and `release-docker` for build-scan-push release checks; both preserve `platform=<arch>`.
+- `build/docker/push` pushes the already-built versioned image and only allows the `production` image type; `push-docker` forces that type in service Make targets. `build/docker/manifest` creates manifests. Both are gated: they only run if `APP_VERSION_FILE` exists (default: `/tmp/workspace/release-version.txt`).
 
 ### Local environment helper
 

--- a/build/docker/build
+++ b/build/docker/build
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2155
-# Build a local test Docker image for a service and platform.
+# Build a local test or production Docker image for a service and platform.
 
 set -eo pipefail
 
 readonly name="$1"
 readonly platform="$2"
+readonly image_type="${3:-test}"
 readonly dir="$(dirname "$(readlink -f "$0")")"
 readonly dockerfile="$dir/go/Dockerfile"
-readonly image="alexfalkowski/$name:test.$platform"
+readonly version_file="${APP_VERSION_FILE:-/tmp/workspace/release-version.txt}"
 
 # Print an error and stop the script.
 die() {
@@ -19,9 +20,36 @@ die() {
 # Validate Docker image reference components before invoking Docker.
 validate() {
   [[ "$name" =~ ^[a-z0-9]+([._-][a-z0-9]+)*$ ]] || die "invalid image name: $name"
+  if [[ "$name" =~ ^(test|latest)$ ]]; then
+    die "reserved image name: $name"
+  fi
   [[ "$platform" =~ ^(amd64|arm64)$ ]] || die "invalid platform: $platform"
+  [[ "$image_type" =~ ^(test|production)$ ]] || die "invalid image type: $image_type"
+}
+
+# Validate Docker image tag components before invoking Docker.
+validate_tag() {
+  [[ "$1" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]] || die "invalid image tag: $1"
+  if [[ "$1" =~ ^(test|latest)$ ]]; then
+    die "reserved image tag: $1"
+  fi
 }
 
 # Build docker.
 validate
-docker build --platform "linux/$platform" --build-arg "name=$name" --build-arg version="latest" -t "$image" -f "$dockerfile" .
+case "$image_type" in
+  test)
+    readonly image_tag="test.$platform"
+    readonly version="latest"
+    ;;
+  production)
+    [[ -f "$version_file" ]] || exit 0
+    readonly latest_tag="$(cat "$version_file")"
+    validate_tag "$latest_tag"
+    readonly image_tag="$latest_tag.$platform"
+    readonly version="$latest_tag"
+    ;;
+esac
+
+readonly image="alexfalkowski/$name:$image_tag"
+docker build --platform "linux/$platform" --build-arg "name=$name" --build-arg "version=$version" -t "$image" -f "$dockerfile" .

--- a/build/docker/push
+++ b/build/docker/push
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2155
-# Build and push a versioned Docker image for a service and platform.
+# Push a versioned Docker image for a service and platform.
 
 set -eo pipefail
 
 readonly version_file="${APP_VERSION_FILE:-/tmp/workspace/release-version.txt}"
+readonly image_type="${3:-production}"
 
 # Print an error and stop the script.
 die() {
@@ -15,19 +16,24 @@ die() {
 # Validate Docker image reference components before invoking Docker.
 validate() {
   [[ "$name" =~ ^[a-z0-9]+([._-][a-z0-9]+)*$ ]] || die "invalid image name: $name"
+  if [[ "$name" =~ ^(test|latest)$ ]]; then
+    die "reserved image name: $name"
+  fi
   [[ "$platform" =~ ^(amd64|arm64)$ ]] || die "invalid platform: $platform"
+  [[ "$image_type" == "production" ]] || die "push only supports production images: $image_type"
   [[ "$latest_tag" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]] || die "invalid image tag: $latest_tag"
+  if [[ "$latest_tag" =~ ^(test|latest)$ ]]; then
+    die "reserved image tag: $latest_tag"
+  fi
 }
 
 if [[ -f "$version_file" ]]; then
   readonly name="$1"
   readonly platform="$2"
   readonly latest_tag="$(cat "$version_file")"
-  readonly dir="$(dirname "$(readlink -f "$0")")"
-  readonly dockerfile="$dir/go/Dockerfile"
   readonly image="alexfalkowski/$name:$latest_tag.$platform"
 
-  # Build and push docker.
+  # Push docker.
   validate
-  docker build --platform "linux/$platform" --build-arg "name=$name" --build-arg "version=$latest_tag" -t "$image" -f "$dockerfile" --push .
+  docker push "$image"
 fi

--- a/build/make/_service.mak
+++ b/build/make/_service.mak
@@ -12,6 +12,7 @@ export MODULE NAME
 override export gem := $(value gem)
 override export package := $(value package)
 override export platform := $(value platform)
+override export image_type := $(value image_type)
 override export module := $(value module)
 override export id := $(value id)
 override export kind := $(value kind)
@@ -164,9 +165,9 @@ clean:
 go-sec:
 	@govulncheck -show verbose -test ./...
 
-# Scan the test image with Trivy (CRITICAL severity).
+# Scan the test image with Trivy (CRITICAL severity); set image_type=production for the versioned image.
 trivy-image:
-	@$(BIN_ROOT)/build/sec/trivy-image "$${NAME}" "$${platform}"
+	@$(BIN_ROOT)/build/sec/trivy-image "$${NAME}" "$${platform}" "$(or $(image_type),test)"
 
 # Scan the repository with Trivy (CRITICAL severity).
 trivy-repo:
@@ -183,13 +184,21 @@ build:
 build-test:
 	@go test -vet=off -race -mod vendor -c -tags features -covermode=atomic -coverpkg=$(COVER_PACKAGES) -o "$${NAME}" "$${MODULE}"
 
-# Build a test docker image tagged alexfalkowski/$(NAME):test.$(platform).
+# Build a test docker image; set image_type=production for the versioned image.
 build-docker:
-	@$(BIN_ROOT)/build/docker/build "$${NAME}" "$${platform}"
+	@$(BIN_ROOT)/build/docker/build "$${NAME}" "$${platform}" "$(or $(image_type),test)"
 
-# Push the image to docker hub (only if the version file exists).
+# Build and scan the test docker image.
+test-docker: build-docker trivy-image
+
+# Push the versioned image to docker hub (only if the version file exists).
+push-docker: override image_type := production
 push-docker:
-	@$(BIN_ROOT)/build/docker/push "$${NAME}" "$${platform}"
+	@$(BIN_ROOT)/build/docker/push "$${NAME}" "$${platform}" "$(or $(image_type),production)"
+
+# Build, scan, and push the versioned docker image.
+release-docker: override image_type := production
+release-docker: build-docker trivy-image push-docker
 
 # Create and push multi-arch manifests (only if the version file exists).
 manifest-docker:

--- a/build/sec/trivy-image
+++ b/build/sec/trivy-image
@@ -1,10 +1,50 @@
 #!/usr/bin/env bash
-# Scan a built test Docker image for critical vulnerabilities with Trivy.
+# Scan a built test or production Docker image for critical vulnerabilities with Trivy.
 
 set -eo pipefail
 
 readonly name="$1"
 readonly platform="$2"
+readonly image_type="${3:-test}"
+readonly version_file="${APP_VERSION_FILE:-/tmp/workspace/release-version.txt}"
+
+# Print an error and stop the script.
+die() {
+  printf 'error: %s\n' "$1" >&2
+  exit 1
+}
+
+# Validate Docker image reference components before invoking Trivy.
+validate() {
+  [[ "$name" =~ ^[a-z0-9]+([._-][a-z0-9]+)*$ ]] || die "invalid image name: $name"
+  if [[ "$name" =~ ^(test|latest)$ ]]; then
+    die "reserved image name: $name"
+  fi
+  [[ "$platform" =~ ^(amd64|arm64)$ ]] || die "invalid platform: $platform"
+  [[ "$image_type" =~ ^(test|production)$ ]] || die "invalid image type: $image_type"
+}
+
+# Validate Docker image tag components before invoking Trivy.
+validate_tag() {
+  [[ "$1" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]] || die "invalid image tag: $1"
+  if [[ "$1" =~ ^(test|latest)$ ]]; then
+    die "reserved image tag: $1"
+  fi
+}
 
 # Scan using trivy.
-trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --exit-code 1 --severity CRITICAL "alexfalkowski/$name:test.$platform"
+validate
+case "$image_type" in
+  test)
+    readonly image_tag="test.$platform"
+    ;;
+  production)
+    [[ -f "$version_file" ]] || exit 0
+    latest_tag="$(cat "$version_file")"
+    readonly latest_tag
+    validate_tag "$latest_tag"
+    readonly image_tag="$latest_tag.$platform"
+    ;;
+esac
+
+trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --exit-code 1 --severity CRITICAL "alexfalkowski/$name:$image_tag"


### PR DESCRIPTION
## What

- Adds test-docker and release-docker aggregate targets for service Docker workflows.
- Lets Docker build and Trivy image scanning choose between test and production image tags.
- Changes push-docker to push the already-built versioned platform image instead of rebuilding during push.
- Documents the branch and release Docker workflows in the README.

## Why

- Ensures release images are scanned before the exact tag is pushed.
- Gives CI one target for branch build-and-scan checks and one target for release build-scan-push checks while preserving platform=<arch>.

## Testing

- `make scripts-lint` - passed
- `make lint` - passed
- `bash -n build/docker/build build/docker/push build/sec/trivy-image` - passed
- `git diff --check` - passed
- Stubbed `make -f build/make/_service.mak platform=arm64 test-docker` - passed; verified test.arm64 build and scan commands.
- Stubbed `APP_VERSION_FILE=/private/tmp/bin-release-version.txt make -f build/make/_service.mak platform=amd64 release-docker` - passed; verified build, scan, and push all used the same 1.2.3.amd64 tag.
- Real Docker builds, Trivy image scans, and registry pushes were not run locally.

AI-assisted-by: [Codex](https://openai.com/codex/)
