### PR TITLE
feat(make): reject reserved manifest references

### DIFF
--- a/build/docker/manifest
+++ b/build/docker/manifest
@@ -15,7 +15,13 @@ die() {
 # Validate Docker image reference components before invoking Docker.
 validate() {
   [[ "$name" =~ ^[a-z0-9]+([._-][a-z0-9]+)*$ ]] || die "invalid image name: $name"
+  if [[ "$name" =~ ^(test|latest)$ ]]; then
+    die "reserved image name: $name"
+  fi
   [[ "$latest_tag" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]] || die "invalid image tag: $latest_tag"
+  if [[ "$latest_tag" =~ ^(test|latest)$ ]]; then
+    die "reserved image tag: $latest_tag"
+  fi
 }
 
 if [[ -f "$version_file" ]]; then


### PR DESCRIPTION
## What

- Adds reserved image-name and release-tag validation to the Docker manifest helper.
- Keeps existing manifest behavior for valid releases: creating the versioned multi-arch manifest and the latest alias manifest.
- Rejects reserved manifest inputs before Docker manifest create or push commands run.

## Why

- Prevents release manifest publishing from accepting ambiguous reserved values such as test or latest as service names or release versions.
- Aligns manifest publishing validation with the hardened build, scan, and push image flows.

## Testing

- `make scripts-lint` - passed
- `bash -n build/docker/manifest` - passed
- `git diff --check` - passed
- Stubbed `APP_VERSION_FILE=/private/tmp/bin-manifest-version-ok.txt build/docker/manifest web` - passed; verified versioned and latest-alias manifest commands for 1.2.3.
- Stubbed `APP_VERSION_FILE=/private/tmp/bin-manifest-version-latest.txt build/docker/manifest web` - passed; verified reserved tag latest is rejected before Docker runs.
- Stubbed `APP_VERSION_FILE=/private/tmp/bin-manifest-version-name.txt build/docker/manifest test` - passed; verified reserved image name test is rejected before Docker runs.
- Real Docker manifest create or push commands were not run locally.

AI-assisted-by: [Codex](https://openai.com/codex/)
