### PR TITLE
feat(make): protect forced branch updates

### DIFF
--- a/build/make/git.mak
+++ b/build/make/git.mak
@@ -21,6 +21,10 @@ master:
 pull:
 	@git pull --rebase
 
+# Fetch remote refs.
+fetch:
+	@git fetch origin
+
 # Stage all changes (tracked + untracked).
 add:
 	@git add -A
@@ -88,9 +92,9 @@ delete:
 done: branch latest delete
 	@printf "bin: done with branch '%s'\n" "$$BRANCH"
 
-# Rebase the current branch onto origin/master.
-sync:
-	@git fetch && git rebase -X theirs origin/master
+# Fetch remote refs and rebase the current branch onto origin/master.
+sync: fetch
+	@git rebase -X theirs origin/master
 
 # Amend the last commit with staged changes (no message edit).
 amend: add
@@ -104,11 +108,11 @@ edit-amend: add
 commit: add
 	@$(BIN_ROOT)/build/git/commit
 
-# Force-push the current branch to origin.
+# Force-push the current branch to origin with a lease and inclusion check.
 push:
-	@git push -f origin "$$BRANCH"
+	@git push --force-with-lease --force-if-includes origin "$$BRANCH"
 
-# Amend the last commit and force-push.
+# Amend the last commit and force-push with a lease and inclusion check.
 force: amend push
 
 # Create a draft PR for the current branch (gh pr create --draft).
@@ -123,10 +127,10 @@ pr:
 merge:
 	@gh pr merge --auto --squash
 
-# Commit, force-push, and open a draft PR.
+# Commit, force-push with a lease and inclusion check, and open a draft PR.
 review: commit push draft
 
-# Commit, force-push, open PR, and enable auto-merge.
+# Commit, force-push with a lease and inclusion check, open PR, and enable auto-merge.
 ready: commit push pr merge
 
 # Checkout master, pull, and update submodules.


### PR DESCRIPTION
## What

- Add a shared `fetch` target and have `sync` fetch remote refs before rebasing onto `origin/master`.
- Replace unconditional forced branch updates with `--force-with-lease --force-if-includes` for `push`, `force`, `review`, and `ready` flows.
- Keep the existing target names and downstream command surface intact while tightening remote-update safety.

## Why

- Downstream CI jobs call `make sync push`; an unconditional `git push -f` can overwrite branch commits that landed after the job started.
- The lease and inclusion checks reject stale forced updates while preserving the normal local and CI workflow when the remote branch has not moved unexpectedly.

## Testing

- `gmake -n sync push` - passed
- Local bare-repo simulation for stale branch overwrite rejection and new branch push - passed
- `gmake scripts-lint` - passed
- `gmake skills-lint` - passed
- `gmake docker-lint` - passed
- `gmake sec` - passed
- `docker run --rm alexfalkowski/release:8.13 git --version` - passed
- `docker run --rm alexfalkowski/release:8.13 sh -lc 'git push -h > /tmp/gitpush.out 2>&1; grep -q force-if-includes /tmp/gitpush.out'` - passed
- `git diff --check` - passed
- `gmake dep` - failed before dependency setup because the local Ruby environment could not activate Bundler `4.0.10` from `Gemfile.lock`.
- `gmake lint` - failed before RuboCop because the local Ruby environment could not activate Bundler `4.0.10` from `Gemfile.lock`.
