### PR TITLE
feat(make): preserve guarded branch pushes

### DIFF
--- a/build/git/sync
+++ b/build/git/sync
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Rebase the current branch for guarded force-pushes after remote refs are fetched.
+
+set -eo pipefail
+
+readonly branch="${BRANCH:-$(git branch --show-current)}"
+
+# The push target uses --force-with-lease --force-if-includes, so after fetch Git
+# rejects a forced update if origin/$branch moved and this checkout has not
+# integrated that remote tip. Rebase onto origin/$branch first so remote branch
+# updates are included in the history we rewrite, then rebase that combined
+# history onto origin/master.
+if [[ -n $branch ]] && git show-ref --verify --quiet "refs/remotes/origin/$branch"; then
+  git rebase "origin/$branch"
+fi
+
+git rebase -X theirs origin/master

--- a/build/make/git.mak
+++ b/build/make/git.mak
@@ -92,9 +92,10 @@ delete:
 done: branch latest delete
 	@printf "bin: done with branch '%s'\n" "$$BRANCH"
 
-# Fetch remote refs and rebase the current branch onto origin/master.
+# Fetch remote refs, integrate the current remote branch when present, and
+# rebase the current branch onto origin/master.
 sync: fetch
-	@git rebase -X theirs origin/master
+	@$(BIN_ROOT)/build/git/sync
 
 # Amend the last commit with staged changes (no message edit).
 amend: add


### PR DESCRIPTION
## What

- Move the branch integration step for `sync` into a dedicated `build/git/sync` helper.
- Keep `make sync` responsible for fetching remote refs before invoking the helper.
- Rebase onto the current remote branch when it exists before rebasing onto `origin/master`, preserving guarded force-push behavior.
- Document why the remote-branch rebase is required for `--force-with-lease --force-if-includes`.

## Why

- CI can see `origin/$BRANCH` move during `make sync push`; rebasing only onto `origin/master` leaves the local branch without that fetched remote tip.
- Including the remote branch tip before the master rebase lets the protected push proceed without weakening the overwrite guard.
- Keeping the behavior in a helper keeps the Make target small while making the non-obvious git sequencing easier to review.

## Testing

- `make -n sync push` - passed
- stale remote-branch simulation for `make sync push` - passed
- `git diff --check` - passed
- `make dep` - passed
- `make scripts-lint` - passed
- `make skills-lint` - passed
- `make docker-lint` - passed
- `make lint` - passed
- `make sec` - passed
