### PR TITLE
feat(skills): tighten agent workflow guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,9 @@ Agents MUST:
   dominant test harness, local style, or documented workflow.
 - State the exact instruction being deviated from before proposing any
   deviation.
+- Re-read the selected skill and identify the governing instruction when the
+  human challenges process, asks what the skill says, or points out a suspected
+  instruction violation.
 
 Agents MUST NOT:
 
@@ -198,6 +201,11 @@ CI runs (CircleCI): `make dep`, `make clean-dep`, `make scripts-lint`, `make ski
   differs from the user's normal terminal, treat that as an environment
   mismatch or validation gap, not as evidence that the repository command is
   wrong.
+- In Codex/tool shells, verify `ruby` and `make` resolution against the
+  initialized user shell before reporting repository command failures. Compare
+  the default tool shell with `zsh -lic 'command -v ruby; command -v make'`; if
+  they differ, rerun Make targets through the initialized shell, for example
+  `zsh -lic 'make lint'`, before treating the failure as real.
 - Do not replace a Makefile target with guessed direct commands just because the
   agent environment cannot find the same tools as the user's shell.
 - When diagnosing command-environment mismatches, check the command surface

--- a/quality/skills/lint
+++ b/quality/skills/lint
@@ -5,6 +5,91 @@ set -eo pipefail
 
 missing=0
 
+check_skill_yaml() {
+  ruby <<'RUBY'
+require "yaml"
+
+ok = true
+
+Dir["skills/*/SKILL.md"].sort.each do |path|
+  text = File.read(path)
+  match = text.match(/\A---\n(.*?)\n---/m)
+  unless match
+    warn "missing frontmatter: #{path}"
+    ok = false
+    next
+  end
+
+  begin
+    data = YAML.safe_load(match[1])
+  rescue Psych::SyntaxError => e
+    warn "invalid frontmatter YAML in #{path}: #{e.message}"
+    ok = false
+    next
+  end
+
+  unless data.is_a?(Hash)
+    warn "frontmatter must be a mapping: #{path}"
+    ok = false
+    next
+  end
+
+  extra = data.keys - %w[name description]
+  unless extra.empty?
+    warn "unexpected frontmatter keys in #{path}: #{extra.join(", ")}"
+    ok = false
+  end
+
+  %w[name description].each do |key|
+    unless data[key].is_a?(String) && !data[key].strip.empty?
+      warn "missing or empty #{key} in #{path}"
+      ok = false
+    end
+  end
+end
+
+Dir["skills/*/agents/openai.yaml"].sort.each do |path|
+  skill_name = path.split("/")[1]
+
+  begin
+    data = YAML.safe_load(File.read(path))
+  rescue Psych::SyntaxError => e
+    warn "invalid agent YAML in #{path}: #{e.message}"
+    ok = false
+    next
+  end
+
+  interface = data.is_a?(Hash) ? data["interface"] : nil
+  unless interface.is_a?(Hash)
+    warn "missing interface mapping: #{path}"
+    ok = false
+    next
+  end
+
+  %w[display_name short_description default_prompt].each do |key|
+    unless interface[key].is_a?(String) && !interface[key].strip.empty?
+      warn "missing or empty interface.#{key} in #{path}"
+      ok = false
+    end
+  end
+
+  short_description = interface["short_description"]
+  if short_description.is_a?(String) && !(25..64).cover?(short_description.length)
+    warn "interface.short_description must be 25-64 chars in #{path}"
+    ok = false
+  end
+
+  default_prompt = interface["default_prompt"]
+  if default_prompt.is_a?(String) && !default_prompt.include?("$#{skill_name}")
+    warn "interface.default_prompt must mention $#{skill_name} in #{path}"
+    ok = false
+  end
+end
+
+exit(ok ? 0 : 1)
+RUBY
+}
+
 require_pattern() {
   local file="$1"
   local pattern="$2"
@@ -21,8 +106,14 @@ require_pattern() {
   fi
 }
 
+if ! check_skill_yaml; then
+  missing=1
+fi
+
 require_pattern AGENTS.md "mandatory operating rules, not advisory guidance"
 require_pattern AGENTS.md "## Local pattern binding"
+require_pattern AGENTS.md "Re-read the selected skill and identify the governing instruction"
+require_pattern AGENTS.md "rerun Make targets through the initialized"
 
 require_pattern skills/README.md "Skills are mandatory operating rules, not advisory notes."
 
@@ -31,9 +122,13 @@ require_pattern skills/project-workflow/references/bin-submodule.md "Treat the c
 
 require_pattern skills/change-validation/references/check-selection.md "Before selecting tests, identify the dominant relevant test harness"
 require_pattern skills/change-validation/references/check-selection.md "Do not add or select an ad hoc language-native test command"
+require_pattern skills/change-validation/SKILL.md "Treat validation as valid only for the file state it tested"
 
 require_pattern skills/testing-standards/SKILL.md "## Mandatory Stop Gates"
 require_pattern skills/testing-standards/SKILL.md "MUST NOT add language-native tests"
+require_pattern skills/testing-standards/SKILL.md "If the human asks to remove, skip, or simplify a test during a behavior"
+require_pattern skills/testing-standards/SKILL.md "If the intended red test or scenario passes unexpectedly"
+require_pattern skills/testing-standards/SKILL.md "If no cleanup is needed, record \`Refactor: none\`"
 
 require_pattern skills/go-standards/SKILL.md "Agents MUST NOT add an import alias"
 require_pattern skills/go-standards/SKILL.md "Agents MUST stop and explain before creating Go tests when another harness owns the behavior."
@@ -43,9 +138,15 @@ require_pattern skills/code-issues/SKILL.md "After the human agrees and before e
 require_pattern skills/test-gaps/SKILL.md "After the human agrees and before editing, state the selected local test pattern"
 require_pattern skills/doc-gaps/SKILL.md "After the human agrees and before editing, state the selected local documentation pattern"
 require_pattern skills/reliability-gaps/SKILL.md "After the human agrees and before editing, state the selected local code/config/docs pattern"
+require_pattern skills/reliability-gaps/SKILL.md "asks what the fix is for REL-<number>"
+require_pattern skills/reliability-gaps/SKILL.md "state the reliability execution checklist before editing"
+require_pattern skills/reliability-gaps/SKILL.md "\`Red\`, \`Green\`, \`Refactor\`, and \`Validation\`"
 
 require_pattern skills/project-workflow/agents/openai.yaml "Treat AGENTS.md and selected skills as mandatory rules."
 require_pattern skills/testing-standards/agents/openai.yaml "MUST identify the dominant relevant existing test harness before editing"
+require_pattern skills/testing-standards/agents/openai.yaml "stop on unexpected green tests"
 require_pattern skills/go-standards/agents/openai.yaml "MUST NOT invent import aliases for readability, caution, brevity, or personal clarity"
+require_pattern skills/reliability-gaps/agents/openai.yaml "answer REL-N follow-ups"
+require_pattern skills/change-validation/agents/openai.yaml "file changes make prior validation stale"
 
 exit "$missing"

--- a/skills/change-validation/SKILL.md
+++ b/skills/change-validation/SKILL.md
@@ -12,9 +12,10 @@ description: Chooses and reports credible validation commands for tests, linting
 3. Run the repository's setup or dependency target first when validation depends on installed dependencies or generated/vendor state.
 4. Ask for user permission before running validation commands that require SSH credentials, GitHub auth, registry auth, cloning, pushing, publishing, opening PRs, or updating remote state.
 5. Run the narrowest check that credibly exercises the changed behavior, then expand only when risk justifies it.
-6. Notice wrappers that no-op because optional tools are missing, and do not report them as full validation.
-7. Use `$testing-standards` when the task needs decisions about what tests to add or whether coverage is credible; keep this skill focused on selecting and reporting commands.
-8. When reporting standalone validation, use the exact structure in `references/check-selection.md`; when another skill embeds validation, preserve the command, result, coverage, and gap details.
+6. Treat validation as valid only for the file state it tested. If files change while a validation command is still running or after it completes, report that result as stale and rerun the relevant checks after final edits.
+7. Notice wrappers that no-op because optional tools are missing, and do not report them as full validation.
+8. Use `$testing-standards` when the task needs decisions about what tests to add or whether coverage is credible; keep this skill focused on selecting and reporting commands.
+9. When reporting standalone validation, use the exact structure in `references/check-selection.md`; when another skill embeds validation, preserve the command, result, coverage, and gap details.
 
 ## References
 

--- a/skills/change-validation/agents/openai.yaml
+++ b/skills/change-validation/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Change Validation"
   short_description: "Choose tests, lint, and CI checks"
-  default_prompt: "Use $change-validation to choose and report validation for this change. Prefer repository-defined commands, identify the dominant relevant harness, and do not invent ad hoc language-native tests when an established harness owns the behavior."
+  default_prompt: "Use $change-validation to choose and report validation for this change. Prefer repository-defined commands, run narrow checks before broad ones, detect no-op wrappers, and rerun checks when file changes make prior validation stale."

--- a/skills/reliability-gaps/SKILL.md
+++ b/skills/reliability-gaps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reliability-gaps
-description: Finds verified missing or weak reliability, operability, SLO, overload, observability, release-safety, recovery, data-integrity, disaster-readiness, or NALSD design evidence in a package or folder, records confirmed gaps in that scope's ISSUES.md, and later proposes and implements explicitly agreed fixes gap by gap. Use when the user asks to find $reliability-gaps in a package or folder, find reliability gaps in a package or folder, review production readiness for a package or folder, implement $reliability-gaps in a package or folder, or implement reliability gaps in a package or folder.
+description: Finds verified missing or weak reliability, operability, SLO, overload, observability, release-safety, recovery, data-integrity, disaster-readiness, or NALSD design evidence in a package or folder, records confirmed gaps in that scope's ISSUES.md, and later proposes and implements explicitly agreed fixes gap by gap. Use when the user asks to find $reliability-gaps in a package or folder, find reliability gaps in a package or folder, review production readiness for a package or folder, implement $reliability-gaps in a package or folder, implement reliability gaps in a package or folder, asks what the fix is for REL-<number>, asks to fix REL-<number>, asks to verify REL-<number>, or says REL-<number> is done.
 ---
 
 # Reliability Gaps
@@ -111,15 +111,22 @@ Keep optional follow-up notes separate from findings:
 7. Stop after proposing the solution. Do not edit files, update `ISSUES.md`, or start validation until the human explicitly agrees to that finding's solution.
 8. Ask questions when SLOs, expected failure behavior, operator workflow, compatibility, rollout, validation, or user intent is ambiguous. Treat silence or a broad "implement reliability gaps" request as permission to start the proposal workflow, not as permission to edit.
 9. After the human agrees and before editing, state the selected local code/config/docs pattern, dominant relevant test harness, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
-10. Once the solution for the current finding is agreed and the local-pattern gate is satisfied, implement only that finding with the smallest clear reliability change.
-11. Use `$reliability-standards` for reliability design, `$change-safety` for public or operational compatibility, `$testing-standards` for failure-path tests, and `$change-validation` for checks. Pair with `$security-audit` when the fix touches auth, secrets, privilege, DoS, logs, supply chain, or incident containment.
-12. Validate the reliability change using checks appropriate to the changed behavior. Prefer repository Make targets and documented entrypoints.
-13. Report the result for that finding and ask the human to verify and explicitly say `REL-<number> is done`.
-14. Do not move to the next finding until the human says `REL-<number> is done`.
-15. After the human confirms a finding is done, remove that finding from scoped `ISSUES.md`. If a finding is deemed invalid or not actually a reliability gap, remove it only after explaining why and getting human agreement.
-16. Then propose the solution for the next remaining finding and repeat the same agreement gate.
-17. Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
-18. Summarize what changed, which reliability gaps were resolved or dismissed, and which validation steps were run or still need to be carried out by the human.
+10. For behavior-changing fixes, state the reliability execution checklist before editing:
+   - `TDD decision`: yes/no, with the concrete reason if no.
+   - `First test/scenario`: the narrowest test, table, fixture, or scenario to add or update first.
+   - `Expected red`: the command and failure expected before production edits.
+   - `Intended green change`: the smallest code/config/docs change expected to pass.
+   - `Refactor checkpoint`: the cleanup pass planned after green, or `none`.
+   - `Validation`: the focused and expanded commands intended after refactor.
+11. Once the solution for the current finding is agreed and the local-pattern gate is satisfied, implement only that finding with the smallest clear reliability change.
+12. Use `$reliability-standards` for reliability design, `$change-safety` for public or operational compatibility, `$testing-standards` for failure-path tests, and `$change-validation` for checks. Pair with `$security-audit` when the fix touches auth, secrets, privilege, DoS, logs, supply chain, or incident containment.
+13. Validate the reliability change using checks appropriate to the changed behavior. Prefer repository Make targets and documented entrypoints.
+14. Report the result for that finding with `Red`, `Green`, `Refactor`, and `Validation` entries. Use `Refactor: none` when no cleanup was needed after green. Then ask the human to verify and explicitly say `REL-<number> is done`.
+15. Do not move to the next finding until the human says `REL-<number> is done`.
+16. After the human confirms a finding is done, remove that finding from scoped `ISSUES.md`. If a finding is deemed invalid or not actually a reliability gap, remove it only after explaining why and getting human agreement.
+17. Then propose the solution for the next remaining finding and repeat the same agreement gate.
+18. Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
+19. Summarize what changed, which reliability gaps were resolved or dismissed, and which validation steps were run or still need to be carried out by the human.
 
 ## References
 

--- a/skills/reliability-gaps/agents/openai.yaml
+++ b/skills/reliability-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Reliability Gaps"
   short_description: "Find scoped SRE readiness gaps"
-  default_prompt: "Use $reliability-gaps to find scoped reliability, operability, SLO, overload, observability, release-safety, recovery, or NALSD gaps, verify each candidate against a concrete current failure path before storing confirmed findings in that scope's ISSUES.md, or propose and implement agreed reliability fixes one gap at a time. Before editing, state the local pattern, dominant test harness, and validation path."
+  default_prompt: "Use $reliability-gaps to find scoped reliability gaps, answer REL-N follow-ups, propose agreed fixes one at a time, and implement each fix with explicit TDD decision, red, green, refactor, and validation reporting before waiting for REL-N is done."

--- a/skills/testing-standards/SKILL.md
+++ b/skills/testing-standards/SKILL.md
@@ -29,6 +29,13 @@ These are mandatory gates, not guidance.
 - Personal clarity, convenience, faster local execution, implementation
   language, or direct access to private functions are not valid reasons to
   bypass the dominant harness.
+- If the human asks to remove, skip, or simplify a test during a behavior
+  change, agents MUST NOT infer that test-first workflow or coverage is waived.
+  Ask whether to replace it with better-shaped coverage or explicitly accept no
+  test for that change.
+- If the intended red test or scenario passes unexpectedly, agents MUST stop
+  before production edits and either strengthen the test, choose a better layer,
+  or report that existing coverage already protects the behavior.
 
 ## Steps
 
@@ -40,7 +47,7 @@ These are mandatory gates, not guidance.
 6. Check whether the change should preserve, restore, or improve coverage; do not let meaningful behavior lose coverage without calling out the gap.
 7. Before adding a new standalone test, check whether the behavior is already covered by existing tests and whether the right change is to extend an existing table, fixture, helper, or assertion block.
 8. Before editing behavior-changing production code, make an explicit test-first decision. State either `TDD: yes` with the first test/scenario you will add or update, or `TDD: no` with the concrete reason test-first is not practical. Do this before production edits, not retroactively after implementation.
-9. For behavior-changing code, prefer a test-first loop. In TDD-style projects, write or update the narrowest credible test first; in BDD-style projects, write or update the narrowest credible scenario, feature, or spec first. Run it and confirm it fails for the expected reason when practical. If the test passes unexpectedly, re-check whether the behavior is already covered or whether the new assertion is too weak. Implement the smallest code change to pass it, then refactor while keeping tests green.
+9. For behavior-changing code, prefer a test-first loop. In TDD-style projects, write or update the narrowest credible test first; in BDD-style projects, write or update the narrowest credible scenario, feature, or spec first. Run it and confirm it fails for the expected reason when practical. If the test passes unexpectedly, stop before production edits and re-check whether the behavior is already covered, whether the assertion is too weak, or whether a different test layer is needed. Implement the smallest code change to pass it, then perform a refactor pass while keeping tests green.
 10. If behavior-changing production code was edited before the test-first decision, stop and correct course: add or update the narrowest credible test immediately, run it against the current state when practical, and explicitly report that the red step was missed before continuing.
 11. Choose the narrowest established test layer that credibly covers the changed behavior.
 12. Test through public or documented APIs, commands, tasks, or service entrypoints so coverage reflects real consumer behavior.
@@ -51,10 +58,11 @@ These are mandatory gates, not guidance.
 17. When tests use mocks, stubs, spies, fakes, or other test doubles, check whether each double protects a true boundary or only mirrors internal implementation; flag interaction-only tests that could pass while real behavior is broken.
 18. Before finishing test changes or reviews, do a mutation-style gap scan against changed behavior. Ask whether the tests would fail if a comparison changed, a boundary moved, a boolean flipped, an error path returned success, a collection or string operation changed, a fallback/default was removed, or an observable side effect disappeared. Strengthen the behavior test when the answer is no. Ask the human only when the correct boundary or product behavior is ambiguous.
 19. Before accepting or repeating a coverage claim, run the repository's selected coverage command when practical and inspect every metric the tool reports, not only line coverage. If coverage drops or a metric is weak, ask what repository-owned behavior is untested before adding line-targeted tests.
-20. Before finishing test changes or reviews, do a readability pass after formatting. Check that tests describe observable behavior, avoid hard-coded private implementation details unless those details are the public contract, keep setup expressions simple enough for review, and place helper functions according to the local or language-specific convention.
-21. Before finishing test changes or reviews, scan changed tests for repeated boolean or numeric assertions whose default failure output would not identify the behavior under test; add named subtests or assertion messages where needed.
-22. When reviewing test quality, evaluate whether the tests are understandable, maintainable, repeatable, atomic, necessary, granular, fast enough for their layer, and first/test-driven where that is relevant. Use scores only when the human asks for a scored review; otherwise turn the rubric into concrete findings and improvements.
-23. For behavior-changing code, report the trace in the final update using this shape: `TDD decision`, `Style detected`, `First test/scenario`, `Red`, `Green`, and `Refactor`. Include the test, scenario, feature, or spec added or updated first; whether the red step failed for the expected reason, passed unexpectedly, was not practical to run, or was missed; the implementation change that made it green; any mutation-style or coverage gap found; and any refactor after green.
+20. After green and before broad validation, perform an explicit refactor pass on changed production code and tests. Remove duplication, simplify awkward setup, align with local naming/helpers, and keep behavior unchanged. If no cleanup is needed, record `Refactor: none`.
+21. Before finishing test changes or reviews, do a readability pass after formatting. Check that tests describe observable behavior, avoid hard-coded private implementation details unless those details are the public contract, keep setup expressions simple enough for review, and place helper functions according to the local or language-specific convention.
+22. Before finishing test changes or reviews, scan changed tests for repeated boolean or numeric assertions whose default failure output would not identify the behavior under test; add named subtests or assertion messages where needed.
+23. When reviewing test quality, evaluate whether the tests are understandable, maintainable, repeatable, atomic, necessary, granular, fast enough for their layer, and first/test-driven where that is relevant. Use scores only when the human asks for a scored review; otherwise turn the rubric into concrete findings and improvements.
+24. For behavior-changing code, report the trace in the final update using this shape: `TDD decision`, `Style detected`, `First test/scenario`, `Red`, `Green`, and `Refactor`. Include the test, scenario, feature, or spec added or updated first; whether the red step failed for the expected reason, passed unexpectedly, was not practical to run, or was missed; the implementation change that made it green; any mutation-style or coverage gap found; and any refactor after green. Use `Refactor: none` when no cleanup was needed.
 
 ## Principles
 

--- a/skills/testing-standards/agents/openai.yaml
+++ b/skills/testing-standards/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Testing Standards"
   short_description: "Design focused behavior tests"
-  default_prompt: "Use $testing-standards to design or review focused behavior tests for this change. MUST identify the dominant relevant existing test harness before editing; do not infer test language from implementation language, and MUST NOT add tests outside that harness unless the user explicitly asks or the behavior cannot be covered there. Stop and explain before any exception. For behavior changes, state the TDD/test-first decision before production edits, prefer public or documented entrypoints, run a mutation-style gap scan, verify coverage claims when practical, and report the red/green/refactor trace."
+  default_prompt: "Use $testing-standards to design or review focused behavior tests. MUST identify the dominant relevant existing test harness before editing, stop on unexpected green tests, treat human test-removal requests as coverage decisions, and report TDD decision, red, green, refactor, and validation."


### PR DESCRIPTION
## What

- Tighten shared agent workflow rules for reliability follow-ups, TDD reporting, test-removal decisions, unexpected green tests, and stale validation.
- Document the Codex/tool shell mismatch check so agents compare default command resolution with the initialized user shell before treating Make/Ruby failures as real.
- Extend the skill linter to validate skill frontmatter, agent metadata, prompt skill references, and the new policy markers.

## Why

- Makes process-critical skill guidance executable through lint checks so future edits do not drop the guardrails that prevent missed TDD, stale validation, command-environment, and reliability follow-up mistakes.

## Testing

- `make skills-lint` - passed
- `make scripts-lint` - passed
- `make lint` - passed
- `make dep` - passed
- `make sec` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
