### PR TITLE
feat(git): stabilize guarded sync pushes

### DIFF
--- a/build/git/push
+++ b/build/git/push
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Force-push the current branch to origin when it still matches the fetched ref.
+
+set -eo pipefail
+
+readonly branch="${BRANCH:-$(git branch --show-current)}"
+readonly remote_branch="refs/remotes/origin/$branch"
+
+if git show-ref --verify --quiet "$remote_branch"; then
+  git push --force-with-lease="refs/heads/$branch:$remote_branch" origin "$branch"
+else
+  git push --force-with-lease="refs/heads/$branch:" origin "$branch"
+fi

--- a/build/git/sync
+++ b/build/git/sync
@@ -5,12 +5,10 @@ set -eo pipefail
 
 readonly branch="${BRANCH:-$(git branch --show-current)}"
 
-# The push target uses --force-with-lease --force-if-includes, so after fetch Git
-# rejects a forced update if origin/$branch moved and this checkout has not
-# integrated that remote tip. Rebase onto origin/$branch first so remote branch
-# updates are included in the history we rewrite, then rebase that combined
-# history onto origin/master.
-if [[ -n $branch ]] && git show-ref --verify --quiet "refs/remotes/origin/$branch"; then
+# The push target leases against the fetched origin/$branch ref. Rebase onto
+# origin/$branch first so remote branch updates are included in the history we
+# rewrite, then rebase that combined history onto origin/master.
+if [[ -n $branch && $branch != "master" ]] && git show-ref --verify --quiet "refs/remotes/origin/$branch"; then
   git rebase "origin/$branch"
 fi
 

--- a/build/make/git.mak
+++ b/build/make/git.mak
@@ -109,11 +109,11 @@ edit-amend: add
 commit: add
 	@$(BIN_ROOT)/build/git/commit
 
-# Force-push the current branch to origin with a lease and inclusion check.
+# Force-push the current branch to origin when it still matches the fetched ref.
 push:
-	@git push --force-with-lease --force-if-includes origin "$$BRANCH"
+	@$(BIN_ROOT)/build/git/push
 
-# Amend the last commit and force-push with a lease and inclusion check.
+# Amend the last commit and force-push with a lease.
 force: amend push
 
 # Create a draft PR for the current branch (gh pr create --draft).
@@ -128,10 +128,10 @@ pr:
 merge:
 	@gh pr merge --auto --squash
 
-# Commit, force-push with a lease and inclusion check, and open a draft PR.
+# Commit, force-push with a lease, and open a draft PR.
 review: commit push draft
 
-# Commit, force-push with a lease and inclusion check, open PR, and enable auto-merge.
+# Commit, force-push with a lease, open PR, and enable auto-merge.
 ready: commit push pr merge
 
 # Checkout master, pull, and update submodules.


### PR DESCRIPTION
## What

- Move guarded force-push behavior from the Make recipe into a dedicated `build/git/push` helper.
- Lease pushes against the fetched remote branch ref, with a first-push path that fails if the branch already exists remotely.
- Skip the same-branch rebase on `master` while preserving non-master branch integration before rebasing onto `origin/master`.

## Why

- Fixes CI sync pushes that can fail with `remote ref updated since checkout` after the branch is rebased onto latest `origin/master`.
- Keeps the remote-update safety check explicit: pushes still reject when the remote branch moves after the last fetch.

## Testing

- `zsh -lic 'make dep'` - passed
- `zsh -lic 'make clean-dep'` - passed
- `zsh -lic 'make scripts-lint'` - passed
- `zsh -lic 'make skills-lint'` - passed
- `zsh -lic 'make docker-lint'` - passed
- `zsh -lic 'make lint'` - passed
- `zsh -lic 'make sec'` - passed with Trivy cache access outside the sandbox
- Temporary repository repro of the old guarded push failure - reproduced
- Temporary repository check using `build/git/sync` and `build/git/push` after `origin/master` moved - passed
- Temporary repository stale-remote check - rejected as expected
