### PR TITLE
feat(skills): add active workflow plan templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ matching skill for the task.
 Keeping only this pointer in downstream repos avoids repeating the shared skill
 list. Update `bin/AGENTS.md` when the shared skill set changes.
 
+Workflow skills may load `bin/skills/<name>/references/plan.md` as a canonical
+plan template, but downstream users should still invoke the skill itself, for
+example `Find $test-gaps in <folder>`. Active plans are per-session runtime
+state; durable findings continue to live in the scoped `ISSUES.md` files
+defined by the relevant skill.
+
 ## Makefile includes (examples)
 
 ### Ruby-only project

--- a/skills/README.md
+++ b/skills/README.md
@@ -57,6 +57,16 @@ specific rule or local pattern, and ask for approval to deviate.
   They pair with `naming-standards` when a change creates, reviews, or renames
   identifiers, commands, flags, files, tests, fixtures, or documentation terms.
 
+## Workflow Plan Templates
+
+Stateful workflow skills may include `references/plan.md`. These files are
+canonical plan templates for active runtime execution state, not durable task
+artifacts. Invoke the skill, for example `Find $test-gaps in <folder>`; the
+skill loads its plan template and instantiates it against the current repository
+root. In downstream repositories that vendor this project as `./bin`, the
+consuming repository remains the execution context and `bin/skills/**` remains
+shared guidance.
+
 ## Format Rule
 
 When a skill is used as the final answer, use that skill's required output

--- a/skills/code-issues/SKILL.md
+++ b/skills/code-issues/SKILL.md
@@ -12,6 +12,11 @@ Use this skill in two distinct modes:
 
 Do not combine the two modes in one pass.
 
+Before starting Find mode or Implement mode, read `references/plan.md` and use
+it to maintain the active execution plan. The active plan is runtime state; do
+not write it into the repository unless the human explicitly asks for a durable
+plan file.
+
 ## Operating Stance
 
 Operate as a strict issue triager and ledger owner: separate confirmed code
@@ -20,33 +25,30 @@ defects from test gaps, doc gaps, polish, and speculation; keep the scoped
 
 ## Find Mode
 
-1. Identify the requested package or folder scope. If no scope is provided, stop and ask for the package or folder.
-2. Use `ISSUES.md` in the requested package or folder as the review ledger, for example `<package/folder>/ISSUES.md`.
-3. If `ISSUES.md` already exists in the requested package or folder, stop. Tell the user the existing scoped ledger must be resolved first, or the human must delete that scoped `ISSUES.md` before a new find pass there.
-4. Use `$project-workflow` to discover repository entrypoints, CI expectations, and `./bin` wiring before planning review agents or validation.
-5. Treat `Find $code-issues in <package/folder>` or `Find code issues in <package/folder>` as the user's explicit request to delegate review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
-6. Use sub-agents for Find mode whenever the active runtime provides them and the runtime permits delegation for the request. Do not treat sub-agents as optional based on scope size, and do not perform the find review locally first.
-7. Do not claim that extra delegation wording is needed before launching review agents. The Find mode invocation is the explicit delegation request.
-8. If the runtime still requires an approval step before launching sub-agents, ask once with the concrete read-only agent plan. If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
-9. Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, or other non-read-only validation. Without that permission, agents should inspect code only and suggest validation.
-10. Exclude generated files and folders, vendored dependencies, caches, build output, and generated lockfile churn unless the requested scope is explicitly about them.
-11. Launch at least one sub-agent covering the requested root package/folder. Split agent assignments across:
-   - files directly under the requested root package/folder.
-   - each first-level subpackage/subfolder under the requested root.
-12. Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough and accurate `$code-review` and `$security-audit` for its assigned scope, using `$testing-standards` for concrete missing-coverage or weak-test analysis and `$change-validation` for likely validation commands.
-13. Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
-14. Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity.
-15. Wait for all agents to finish before aggregating results.
-16. Deduplicate overlapping findings and resolve conflicting agent conclusions by re-checking the code directly.
-17. Confirm each candidate finding against the code before recording it. Findings must be concrete bugs, security issues, compatibility breaks, or violated public contracts with user-visible impact.
-18. Do not record standalone missing, weak, flaky, misleading, or wrong-layer tests as code issues unless they are tied to a confirmed bug, security issue, compatibility break, or violated public contract. Use `$test-gaps` for standalone missing or weak test coverage passes.
-19. Do not record standalone missing, weak, stale, misleading, or wrong-location documentation, README, example, comment, or docstring gaps as code issues unless they reveal a confirmed bug, security issue, compatibility break, or violated public contract. Use `$doc-gaps` for standalone documentation review passes.
-20. Do not report optional regression tests, unused convenience aliases, API symmetry, or documentation polish as findings by themselves. List them only as testing gaps, doc gaps, or optional follow-up notes when relevant.
-21. If no confirmed code issues are found, report that no code issues were found and do not create `ISSUES.md`.
-22. If confirmed code issues are found, write all findings to the scoped `ISSUES.md` before making any fixes.
-23. Assign every finding a unique ID for the session in the form `ISSUE-<number>`.
-24. Present the scoped `ISSUES.md` and a proposed fix plan to the user.
-25. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
+Follow `references/plan.md#find-mode-plan`.
+
+These rules remain mandatory:
+
+- If no scope is provided, stop and ask for the package or folder.
+- Use `ISSUES.md` in the requested package or folder as the review ledger, for example `<package/folder>/ISSUES.md`.
+- If `ISSUES.md` already exists in the requested package or folder, stop. Tell the user the existing scoped ledger must be resolved first, or the human must delete that scoped `ISSUES.md` before a new find pass there.
+- Treat `Find $code-issues in <package/folder>` or `Find code issues in <package/folder>` as the user's explicit request to delegate review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
+- Use sub-agents for Find mode whenever the active runtime provides them and the runtime permits delegation for the request. Do not treat sub-agents as optional based on scope size, and do not perform the find review locally first.
+- Do not claim that extra delegation wording is needed before launching review agents. The Find mode invocation is the explicit delegation request.
+- If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
+- Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, or other non-read-only validation.
+- Exclude generated files and folders, vendored dependencies, caches, build output, and generated lockfile churn unless the requested scope is explicitly about them.
+- Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough and accurate `$code-review` and `$security-audit` for its assigned scope, using `$testing-standards` for concrete missing-coverage or weak-test analysis and `$change-validation` for likely validation commands.
+- Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
+- Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity.
+- Confirm each candidate finding against the code before recording it. Findings must be concrete bugs, security issues, compatibility breaks, or violated public contracts with user-visible impact.
+- Do not record standalone missing, weak, flaky, misleading, or wrong-layer tests as code issues unless they are tied to a confirmed bug, security issue, compatibility break, or violated public contract. Use `$test-gaps` for standalone missing or weak test coverage passes.
+- Do not record standalone missing, weak, stale, misleading, or wrong-location documentation, README, example, comment, or docstring gaps as code issues unless they reveal a confirmed bug, security issue, compatibility break, or violated public contract. Use `$doc-gaps` for standalone documentation review passes.
+- Do not report optional regression tests, unused convenience aliases, API symmetry, or documentation polish as findings by themselves. List them only as testing gaps, doc gaps, or optional follow-up notes when relevant.
+- If no confirmed code issues are found, report that no code issues were found and do not create `ISSUES.md`.
+- If confirmed code issues are found, write all findings to the scoped `ISSUES.md` before making any fixes.
+- Assign every finding a unique ID for the session in the form `ISSUE-<number>`.
+- Stop after presenting the ledger and plan. Do not fix findings in the same pass.
 
 ## `ISSUES.md` Format
 
@@ -75,31 +77,26 @@ Keep optional follow-up notes separate from findings:
 
 ## Implement Mode
 
-1. Identify the requested package or folder scope. If no scope is provided, stop and ask for the package or folder.
-2. Read `ISSUES.md` in the requested package or folder first and treat it as the working review ledger.
-   If scoped `ISSUES.md` does not exist, stop and ask whether to run Find mode first for that scope.
-3. Use `$project-workflow` before proposing or running validation so repository entrypoints, CI expectations, and `./bin` wiring are current.
-4. Work through code issues sequentially by ID unless the human explicitly names a different issue.
-5. For each issue, first present:
-   - the issue ID and current evidence.
-   - the proposed solution.
-   - compatibility or behavior tradeoffs.
-   - the intended validation.
-6. Stop after proposing the solution. Do not edit code, update `ISSUES.md`, or start validation until the human explicitly agrees to that issue's solution.
-7. Ask questions when behavior, compatibility, security, validation, or user intent is ambiguous. Treat silence or a broad "implement code issues" request as permission to start the proposal workflow, not as permission to code.
-8. After the human agrees and before editing, state the selected local code pattern, dominant relevant test harness, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
-9. Once the solution for the current issue is agreed and the local-pattern gate is satisfied, implement only that issue with the smallest safe change.
-10. Use `$testing-standards` when deciding whether to add or update regression tests for the fix, and prefer its test-first or scenario-first loop when a behavior-changing fix has a credible test or BDD layer.
-11. Validate the fix using checks appropriate to the changed code.
-12. Report the result for that issue and ask the human to verify and explicitly say `ISSUE-<number> is done`.
-13. Do not move to the next issue until the human says `ISSUE-<number> is done`.
-14. After the human confirms an issue is done, remove that issue from scoped `ISSUES.md`. If an issue is deemed invalid or not actually a code issue, remove it only after explaining why and getting human agreement.
-15. Then propose the solution for the next remaining issue and repeat the same agreement gate.
-16. Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
-17. Summarize what changed, which code issues were resolved or dismissed, and which validation steps were run or still need to be carried out by the human.
+Follow `references/plan.md#implement-mode-plan`.
+
+These rules remain mandatory:
+
+- If no scope is provided, stop and ask for the package or folder.
+- Read `ISSUES.md` in the requested package or folder first and treat it as the working review ledger.
+- If scoped `ISSUES.md` does not exist, stop and ask whether to run Find mode first for that scope.
+- Work through code issues sequentially by ID unless the human explicitly names a different issue.
+- Stop after proposing the solution. Do not edit code, update `ISSUES.md`, or start validation until the human explicitly agrees to that issue's solution.
+- Ask questions when behavior, compatibility, security, validation, or user intent is ambiguous. Treat silence or a broad "implement code issues" request as permission to start the proposal workflow, not as permission to code.
+- After the human agrees and before editing, state the selected local code pattern, dominant relevant test harness, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
+- Implement only the agreed issue with the smallest safe change.
+- Use `$testing-standards` when deciding whether to add or update regression tests for the fix, and prefer its test-first or scenario-first loop when a behavior-changing fix has a credible test or BDD layer.
+- Do not move to the next issue until the human says `ISSUE-<number> is done`.
+- After the human confirms an issue is done, remove that issue from scoped `ISSUES.md`. If an issue is deemed invalid or not actually a code issue, remove it only after explaining why and getting human agreement.
+- Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
 
 ## References
 
+- Read `references/plan.md` before starting Find mode or Implement mode.
 - Use `../references/finding-severity.md` for confidence filtering and severity.
 - Use `$code-review` for review rigor and finding quality.
 - Use `$security-audit` for security-sensitive review scope.

--- a/skills/code-issues/agents/openai.yaml
+++ b/skills/code-issues/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Code Issues"
   short_description: "Find scoped code defects and risks"
-  default_prompt: "Use $code-issues to delegate code issue finding in a package or folder, store confirmed findings in that scope's ISSUES.md, or propose and implement explicitly agreed fixes from a scoped ISSUES.md one code issue at a time. Before editing an agreed fix, state the local code pattern, dominant test harness, and validation path."
+  default_prompt: "Use $code-issues with its active plan to delegate scoped code issue finding, store confirmed findings in that scope's ISSUES.md, or propose and implement explicitly agreed fixes one code issue at a time."

--- a/skills/code-issues/references/plan.md
+++ b/skills/code-issues/references/plan.md
@@ -1,0 +1,64 @@
+# Code Issues Plan
+
+Use this reference to instantiate the active execution plan for `$code-issues`.
+The active plan is runtime state. Do not write it into the repository unless the
+human explicitly asks for a durable plan file. In downstream repositories that
+vendor this project as `./bin`, instantiate the plan from the consuming
+repository root and keep `bin/` as shared guidance.
+
+## Plan State Rules
+
+- Keep exactly one active phase in progress at a time.
+- Preserve stop gates as plan boundaries; do not continue past a stop gate based
+  on silence or a broad request.
+- Update the active plan when scope, validation, delegation, or ledger state
+  changes.
+- Treat validation as stale when files change after a command ran.
+- Record durable findings only in the scoped `ISSUES.md` ledger defined by the
+  skill.
+
+## Find Mode Plan
+
+1. Confirm the requested package or folder scope.
+2. Check whether scoped `ISSUES.md` already exists and stop if it does.
+3. Run `$project-workflow` discovery for entrypoints, CI, and `./bin` wiring.
+4. Build the read-only review delegation plan from the requested root and its
+   first-level subfolders.
+5. Ask for required permission before any agent runs non-read-only, network,
+   auth, remote-write, or otherwise approval-gated commands.
+6. Launch the required review agents when available, or perform the local
+   fallback only when sub-agents are unavailable.
+7. Wait for all review work to finish.
+8. Deduplicate candidates and directly re-check conflicting or overlapping
+   conclusions.
+9. Confirm each finding is a concrete code issue, security issue,
+   compatibility break, or public contract violation.
+10. If no confirmed issues remain, report that result and do not create
+    `ISSUES.md`.
+11. If confirmed issues remain, write the scoped `ISSUES.md` with
+    `ISSUE-<number>` IDs.
+12. Present the scoped ledger and proposed fix plan.
+13. Stop before making fixes.
+
+## Implement Mode Plan
+
+1. Confirm the requested package or folder scope.
+2. Read scoped `ISSUES.md`, or stop and ask whether to run Find mode first.
+3. Run `$project-workflow` discovery for current entrypoints, CI, and `./bin`
+   wiring.
+4. Select the next issue by ID unless the human named a specific issue.
+5. Re-check the issue evidence against current code and tests.
+6. Present the issue evidence, proposed solution, compatibility or behavior
+   tradeoffs, and intended validation.
+7. Stop until the human explicitly agrees to that issue's solution.
+8. After agreement, state the local code pattern, dominant relevant test
+   harness, planned validation, and any needed deviation.
+9. If a deviation is needed, stop and ask before editing.
+10. Implement only the agreed issue with the smallest safe change.
+11. Use `$testing-standards` for regression coverage decisions.
+12. Validate the fix with commands appropriate to the changed files.
+13. Report the result and ask the human to verify with `ISSUE-<number> is done`.
+14. Stop until that confirmation arrives.
+15. After confirmation, remove or revise the issue in scoped `ISSUES.md`.
+16. Continue with the next issue, or delete scoped `ISSUES.md` after all issues
+    are confirmed resolved.

--- a/skills/doc-gaps/SKILL.md
+++ b/skills/doc-gaps/SKILL.md
@@ -12,6 +12,11 @@ Use this skill in two distinct modes:
 
 Do not combine the two modes in one pass.
 
+Before starting Find mode or Implement mode, read `references/plan.md` and use
+it to maintain the active execution plan. The active plan is runtime state; do
+not write it into the repository unless the human explicitly asks for a durable
+plan file.
+
 ## Operating Stance
 
 Operate as a documentation triager: protect users, operators, and maintainers
@@ -20,37 +25,30 @@ private-code commentary that do not reduce real use or maintenance risk.
 
 ## Find Mode
 
-1. Identify the requested package or folder scope. If no scope is provided, stop and ask for the package or folder.
-2. Use `ISSUES.md` in the requested package or folder as the review ledger, for example `<package/folder>/ISSUES.md`.
-3. If `ISSUES.md` already exists in the requested package or folder, stop. Tell the user the existing scoped ledger must be resolved first, or the human must delete that scoped `ISSUES.md` before a new find pass there.
-4. Use `$project-workflow` to discover repository entrypoints, CI expectations, documented commands, public APIs, examples, and `./bin` wiring before planning documentation review agents or validation.
-5. Treat `Find $doc-gaps in <package/folder>` or `Find doc gaps in <package/folder>` as the user's explicit request to delegate documentation review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
-6. Use sub-agents for Find mode whenever the active runtime provides them and the runtime permits delegation for the request. Do not treat sub-agents as optional based on scope size, and do not perform the doc-gap review locally first.
-7. Do not claim that extra delegation wording is needed before launching review agents. The Find mode invocation is the explicit delegation request.
-8. If the runtime still requires an approval step before launching sub-agents, ask once with the concrete read-only agent plan. If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
-9. Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, or other non-read-only validation. Without that permission, agents should inspect code and docs only and suggest validation.
-10. Exclude generated files and folders, vendored dependencies, caches, build output, generated API docs, and generated lockfile churn unless the requested scope is explicitly about them.
-11. Launch at least one sub-agent covering the requested root package/folder. Split agent assignments across:
-   - documentation files directly under the requested root package/folder.
-   - source files directly under the requested root package/folder whose comments or docstrings are in scope.
-   - each first-level subpackage/subfolder under the requested root.
-12. Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough documentation review for its assigned scope, pairing with:
-   - relevant language standards (`$go-standards`, `$ruby-standards`, `$shell-standards`) before recording language-specific comment, docstring, or API documentation findings.
-   - `$naming-standards` when documentation terminology, command/API names, examples, comments, or public vocabulary are unclear or inconsistent.
-   - `$change-validation` for likely validation commands.
-13. Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
-14. Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity.
-15. Wait for all agents to finish before aggregating results.
-16. Deduplicate overlapping findings and resolve conflicting agent conclusions by re-checking the code and docs directly.
-17. Confirm each candidate gap against the code, current docs, examples, and documented interfaces before recording it. Gaps must be concrete missing, weak, stale, misleading, or wrong-location documentation with credible risk to users, operators, maintainers, public APIs, documented command behavior, onboarding, setup, or contribution workflows.
-18. Do not record confirmed production bugs, security issues, compatibility breaks, or violated public contracts as doc gaps. If broken behavior is discovered during review, report it as out of scope for the doc-gap ledger and recommend `$code-issues`; use this skill when unclear, missing, stale, or misleading documentation is the finding.
-19. Do not record standalone missing, weak, flaky, misleading, or wrong-layer tests as doc gaps. Recommend `$test-gaps` when the unprotected behavior is the finding.
-20. Do not report arbitrary wording preferences, style nits, exhaustive private implementation comments, or optional documentation polish as findings by themselves. List them only as optional follow-up notes when relevant.
-21. If no confirmed doc gaps are found, report that no doc gaps were found and do not create `ISSUES.md`.
-22. If confirmed doc gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
-23. Assign every finding a unique ID for the session in the form `DOC-<number>`.
-24. Present the scoped `ISSUES.md` and a proposed doc-fix plan to the user.
-25. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
+Follow `references/plan.md#find-mode-plan`.
+
+These rules remain mandatory:
+
+- If no scope is provided, stop and ask for the package or folder.
+- Use `ISSUES.md` in the requested package or folder as the review ledger, for example `<package/folder>/ISSUES.md`.
+- If `ISSUES.md` already exists in the requested package or folder, stop. Tell the user the existing scoped ledger must be resolved first, or the human must delete that scoped `ISSUES.md` before a new find pass there.
+- Treat `Find $doc-gaps in <package/folder>` or `Find doc gaps in <package/folder>` as the user's explicit request to delegate documentation review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
+- Use sub-agents for Find mode whenever the active runtime provides them and the runtime permits delegation for the request. Do not treat sub-agents as optional based on scope size, and do not perform the doc-gap review locally first.
+- Do not claim that extra delegation wording is needed before launching review agents. The Find mode invocation is the explicit delegation request.
+- If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
+- Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, or other non-read-only validation.
+- Exclude generated files and folders, vendored dependencies, caches, build output, generated API docs, and generated lockfile churn unless the requested scope is explicitly about them.
+- Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough documentation review for its assigned scope, pairing with relevant language standards, `$naming-standards` when terminology is unclear or inconsistent, and `$change-validation` for likely validation commands.
+- Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
+- Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity.
+- Confirm each candidate gap against the code, current docs, examples, and documented interfaces before recording it. Gaps must be concrete missing, weak, stale, misleading, or wrong-location documentation with credible risk to users, operators, maintainers, public APIs, documented command behavior, onboarding, setup, or contribution workflows.
+- Do not record confirmed production bugs, security issues, compatibility breaks, or violated public contracts as doc gaps. If broken behavior is discovered during review, report it as out of scope for the doc-gap ledger and recommend `$code-issues`; use this skill when unclear, missing, stale, or misleading documentation is the finding.
+- Do not record standalone missing, weak, flaky, misleading, or wrong-layer tests as doc gaps. Recommend `$test-gaps` when the unprotected behavior is the finding.
+- Do not report arbitrary wording preferences, style nits, exhaustive private implementation comments, or optional documentation polish as findings by themselves. List them only as optional follow-up notes when relevant.
+- If no confirmed doc gaps are found, report that no doc gaps were found and do not create `ISSUES.md`.
+- If confirmed doc gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
+- Assign every finding a unique ID for the session in the form `DOC-<number>`.
+- Stop after presenting the ledger and plan. Do not fix findings in the same pass.
 
 ## Documentation Review Standards
 
@@ -90,31 +88,26 @@ Keep optional follow-up notes separate from findings:
 
 ## Implement Mode
 
-1. Identify the requested package or folder scope. If no scope is provided, stop and ask for the package or folder.
-2. Read `ISSUES.md` in the requested package or folder first and treat it as the working doc-gap ledger.
-   If scoped `ISSUES.md` does not exist, stop and ask whether to run Find mode first for that scope.
-3. Use `$project-workflow` before proposing or running validation so repository entrypoints, CI expectations, documented commands, public APIs, examples, and `./bin` wiring are current.
-4. Work through findings sequentially by ID unless the human explicitly names a different finding.
-5. For each finding, first present:
-   - the issue ID and current evidence.
-   - the proposed documentation solution.
-   - documentation-location, public-contract, example accuracy, compatibility, or maintenance tradeoffs.
-   - the intended validation.
-6. Stop after proposing the solution. Do not edit files, update `ISSUES.md`, or start validation until the human explicitly agrees to that finding's solution.
-7. Ask questions when behavior, audience, documentation location, public-contract wording, examples, validation, or user intent is ambiguous. Treat silence or a broad "implement doc gaps" request as permission to start the proposal workflow, not as permission to edit.
-8. After the human agrees and before editing, state the selected local documentation pattern, dominant relevant validation path, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
-9. Once the solution for the current finding is agreed and the local-pattern gate is satisfied, implement only that finding with the smallest clear documentation change.
-10. Use relevant language standards for code comments and API docs. Use `$change-safety` when documentation changes public API, command, migration, or compatibility expectations.
-11. Validate the documentation change using checks appropriate to the changed files, such as markdown linting if present, generated documentation checks if present, relevant language linting, examples, or documented command smoke checks.
-12. Report the result for that finding and ask the human to verify and explicitly say `DOC-<number> is done`.
-13. Do not move to the next finding until the human says `DOC-<number> is done`.
-14. After the human confirms a finding is done, remove that finding from scoped `ISSUES.md`. If a finding is deemed invalid or not actually a doc gap, remove it only after explaining why and getting human agreement.
-15. Then propose the solution for the next remaining finding and repeat the same agreement gate.
-16. Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
-17. Summarize what changed, which doc gaps were resolved or dismissed, and which validation steps were run or still need to be carried out by the human.
+Follow `references/plan.md#implement-mode-plan`.
+
+These rules remain mandatory:
+
+- If no scope is provided, stop and ask for the package or folder.
+- Read `ISSUES.md` in the requested package or folder first and treat it as the working doc-gap ledger.
+- If scoped `ISSUES.md` does not exist, stop and ask whether to run Find mode first for that scope.
+- Work through findings sequentially by ID unless the human explicitly names a different finding.
+- Stop after proposing the solution. Do not edit files, update `ISSUES.md`, or start validation until the human explicitly agrees to that finding's solution.
+- Ask questions when behavior, audience, documentation location, public-contract wording, examples, validation, or user intent is ambiguous. Treat silence or a broad "implement doc gaps" request as permission to start the proposal workflow, not as permission to edit.
+- After the human agrees and before editing, state the selected local documentation pattern, dominant relevant validation path, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
+- Implement only the agreed finding with the smallest clear documentation change.
+- Use relevant language standards for code comments and API docs. Use `$change-safety` when documentation changes public API, command, migration, or compatibility expectations.
+- Do not move to the next finding until the human says `DOC-<number> is done`.
+- After the human confirms a finding is done, remove that finding from scoped `ISSUES.md`. If a finding is deemed invalid or not actually a doc gap, remove it only after explaining why and getting human agreement.
+- Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
 
 ## References
 
+- Read `references/plan.md` before starting Find mode or Implement mode.
 - Use `../references/finding-severity.md` for confidence filtering and severity.
 - Use `$project-workflow` for repository command discovery, documented entrypoints, CI expectations, examples, and `./bin` wiring before review planning or validation.
 - Use relevant language standards for code comments, public API docs, and examples.

--- a/skills/doc-gaps/agents/openai.yaml
+++ b/skills/doc-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Doc Gaps"
   short_description: "Find scoped documentation gaps"
-  default_prompt: "Use $doc-gaps to find scoped missing, weak, stale, misleading, or terminology-confusing docs and comments, store confirmed gaps in that scope's ISSUES.md, or propose and implement agreed doc fixes one gap at a time. Before editing, state the local documentation pattern and validation path."
+  default_prompt: "Use $doc-gaps with its active plan to find scoped missing, weak, stale, misleading, or terminology-confusing docs and comments, store confirmed gaps in ISSUES.md, or implement agreed doc fixes one gap at a time."

--- a/skills/doc-gaps/references/plan.md
+++ b/skills/doc-gaps/references/plan.md
@@ -1,0 +1,73 @@
+# Doc Gaps Plan
+
+Use this reference to instantiate the active execution plan for `$doc-gaps`.
+The active plan is runtime state. Do not write it into the repository unless the
+human explicitly asks for a durable plan file. In downstream repositories that
+vendor this project as `./bin`, instantiate the plan from the consuming
+repository root and keep `bin/` as shared guidance.
+
+## Plan State Rules
+
+- Keep exactly one active phase in progress at a time.
+- Preserve stop gates as plan boundaries; do not continue past a stop gate based
+  on silence or a broad request.
+- Update the active plan when scope, documentation location, validation,
+  delegation, or ledger state changes.
+- Treat validation as stale when files change after a command ran.
+- Record durable findings only in the scoped `ISSUES.md` ledger defined by the
+  skill.
+
+## Find Mode Plan
+
+1. Confirm the requested package or folder scope.
+2. Check whether scoped `ISSUES.md` already exists and stop if it does.
+3. Run `$project-workflow` discovery for entrypoints, CI, documented commands,
+   public APIs, examples, and `./bin` wiring.
+4. Identify existing documentation locations, examples, comments, docstrings,
+   and language-specific documentation standards for the requested scope.
+5. Build the read-only documentation review delegation plan from the requested
+   root and its first-level subfolders.
+6. Ask for required permission before any agent runs non-read-only, network,
+   auth, remote-write, or otherwise approval-gated commands.
+7. Launch the required review agents when available, or perform the local
+   fallback only when sub-agents are unavailable.
+8. Wait for all review work to finish.
+9. Deduplicate candidates and directly re-check conflicting or overlapping
+   conclusions against code, docs, examples, and public interfaces.
+10. Confirm each finding is a concrete missing, weak, stale, misleading, or
+    wrong-location documentation gap with real user, operator, or maintainer
+    risk.
+11. If no confirmed gaps remain, report that result and do not create
+    `ISSUES.md`.
+12. If confirmed gaps remain, write the scoped `ISSUES.md` with `DOC-<number>`
+    IDs.
+13. Present the scoped ledger and proposed doc-fix plan.
+14. Stop before making fixes.
+
+## Implement Mode Plan
+
+1. Confirm the requested package or folder scope.
+2. Read scoped `ISSUES.md`, or stop and ask whether to run Find mode first.
+3. Run `$project-workflow` discovery for current entrypoints, CI, documented
+   commands, public APIs, examples, and `./bin` wiring.
+4. Select the next finding by ID unless the human named a specific finding.
+5. Re-check the finding against current code, docs, examples, and public
+   interfaces.
+6. Present the finding evidence, proposed documentation solution, location,
+   public-contract, example accuracy, compatibility, maintenance tradeoffs, and
+   intended validation.
+7. Stop until the human explicitly agrees to that finding's solution.
+8. After agreement, state the local documentation pattern, dominant relevant
+   validation path, planned validation, and any needed deviation.
+9. If a deviation is needed, stop and ask before editing.
+10. Implement only the agreed doc gap with the smallest clear documentation
+    change.
+11. Use relevant language standards for comments, docstrings, and public API
+    docs.
+12. Validate the documentation change with commands appropriate to the changed
+    files.
+13. Report the result and ask the human to verify with `DOC-<number> is done`.
+14. Stop until that confirmation arrives.
+15. After confirmation, remove or revise the finding in scoped `ISSUES.md`.
+16. Continue with the next finding, or delete scoped `ISSUES.md` after all gaps
+    are confirmed resolved.

--- a/skills/reliability-gaps/SKILL.md
+++ b/skills/reliability-gaps/SKILL.md
@@ -12,6 +12,11 @@ Use this skill in two distinct modes:
 
 Do not combine the two modes in one pass.
 
+Before starting Find mode or Implement mode, read `references/plan.md` and use
+it to maintain the active execution plan. The active plan is runtime state; do
+not write it into the repository unless the human explicitly asks for a durable
+plan file.
+
 ## Operating Stance
 
 Operate as a production-readiness triager: record only verified reliability gaps
@@ -23,30 +28,24 @@ preferences, and findings that depend on undocumented future requirements.
 
 ## Find Mode
 
-1. Identify the requested package or folder scope. If no scope is provided, stop and ask for the package or folder.
-2. Use `ISSUES.md` in the requested package or folder as the review ledger, for example `<package/folder>/ISSUES.md`.
-3. If `ISSUES.md` already exists in the requested package or folder, stop. Tell the user the existing scoped ledger must be resolved first, or the human must delete that scoped `ISSUES.md` before a new find pass there.
-4. Use `$project-workflow` to discover repository entrypoints, CI expectations, documented commands, operational docs, release/config surfaces, and `./bin` wiring before planning reliability review agents or validation.
-5. Treat `Find $reliability-gaps in <package/folder>` or `Find reliability gaps in <package/folder>` as the user's explicit request to delegate reliability review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
-6. Use sub-agents for Find mode whenever the active runtime provides them and the runtime permits delegation for the request. Do not treat sub-agents as optional based on scope size, and do not perform the reliability-gap review locally first.
-7. Do not claim that extra delegation wording is needed before launching review agents. The Find mode invocation is the explicit delegation request.
-8. If the runtime still requires an approval step before launching sub-agents, ask once with the concrete read-only agent plan. If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
-9. Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, destructive operations, or non-read-only validation. Without that permission, agents should inspect code, config, tests, docs, and CI only and suggest validation.
-10. Exclude generated files and folders, vendored dependencies, caches, build output, generated API docs, and generated lockfile churn unless the requested scope is explicitly about them.
-11. Launch at least one sub-agent covering the requested root package/folder. Split agent assignments across:
-   - files directly under the requested root package/folder.
-   - operational docs, config, deployment, CI, scripts, or Make targets directly under the requested root package/folder.
-   - each first-level subpackage/subfolder under the requested root.
-12. Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough `$reliability-standards` review for its assigned scope, pairing with:
-   - `$change-safety` for public APIs, commands, flags, env vars, file formats, migrations, config, deployment, or documented operator behavior.
-   - `$security-audit` for auth, secrets, privilege, attacker-driven failure, DoS, logging privacy, supply chain, or incident containment.
-   - `$testing-standards` and `$change-validation` for likely failure-path tests and validation commands.
-13. Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
-14. Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity.
-15. Wait for all agents to finish before aggregating results.
-16. Deduplicate overlapping findings and resolve conflicting agent conclusions by re-checking the code, config, tests, docs, and CI directly.
-17. Confirm each candidate gap against current evidence before recording it. Try to disprove the candidate by tracing the current code path, reading the documented workflow, checking the relevant config, inspecting existing tests, or running an allowed local command. A gap must name the affected reliability promise or operational expectation, the trigger condition, the failure mode, the missing or weak control, and the likely user or operator impact.
-18. Record reliability gaps only when they involve repository-owned behavior or documented/implicit operational contracts, such as:
+Follow `references/plan.md#find-mode-plan`.
+
+These rules remain mandatory:
+
+- If no scope is provided, stop and ask for the package or folder.
+- Use `ISSUES.md` in the requested package or folder as the review ledger, for example `<package/folder>/ISSUES.md`.
+- If `ISSUES.md` already exists in the requested package or folder, stop. Tell the user the existing scoped ledger must be resolved first, or the human must delete that scoped `ISSUES.md` before a new find pass there.
+- Treat `Find $reliability-gaps in <package/folder>` or `Find reliability gaps in <package/folder>` as the user's explicit request to delegate reliability review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
+- Use sub-agents for Find mode whenever the active runtime provides them and the runtime permits delegation for the request. Do not treat sub-agents as optional based on scope size, and do not perform the reliability-gap review locally first.
+- Do not claim that extra delegation wording is needed before launching review agents. The Find mode invocation is the explicit delegation request.
+- If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
+- Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, destructive operations, or non-read-only validation.
+- Exclude generated files and folders, vendored dependencies, caches, build output, generated API docs, and generated lockfile churn unless the requested scope is explicitly about them.
+- Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough `$reliability-standards` review for its assigned scope, pairing with `$change-safety`, `$security-audit`, `$testing-standards`, and `$change-validation` as the surface requires.
+- Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
+- Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity.
+- Confirm each candidate gap against current evidence before recording it. Try to disprove the candidate by tracing the current code path, reading the documented workflow, checking the relevant config, inspecting existing tests, or running an allowed local command. A gap must name the affected reliability promise or operational expectation, the trigger condition, the failure mode, the missing or weak control, and the likely user or operator impact.
+- Record reliability gaps only when they involve repository-owned behavior or documented/implicit operational contracts, such as:
    - missing or weak SLO, SLI, alertability, dashboard, runbook, or operator diagnostic coverage for behavior the repository claims or owns.
    - unbounded or unsafe timeouts, retries, backoff, jitter, concurrency, queues, subprocesses, files, disk, memory, network, or worker resources.
    - missing backpressure, load shedding, graceful degradation, or fallback for a meaningful dependency or overload failure mode.
@@ -54,19 +53,18 @@ preferences, and findings that depend on undocumented future requirements.
    - missing idempotency, replay, deduplication, ordering, reconciliation, backup, restore, or data-integrity controls for stateful behavior.
    - missing health/readiness/shutdown/drain behavior for long-running services or workers.
    - missing concrete NALSD assumptions, capacity estimates, bottleneck analysis, or failure-domain reasoning where the code or docs already make scale or availability claims.
-19. Do not record generic advice to add monitoring, runbooks, autoscaling, retries, queues, circuit breakers, chaos testing, load tests, Kubernetes probes, or dashboards unless a concrete current failure mode and repository-owned fix are identified.
-20. Do not record findings whose evidence is only a repository preference, transport choice, hosting choice, cloud architecture preference, or environment setup assumption. For example, an SSH Git remote or submodule URL is not a reliability gap unless a documented repository-owned workflow currently fails for intended operators and the repository owns the fix.
-21. For release or supply-chain findings involving Docker/image scans, first trace the exact artifacts through CI, Make targets, scripts, Dockerfiles, tags, build arguments, and push commands. Do not record a pre-publish scan or release-gate gap merely because CI scans a test image or runs scan jobs on non-release branches. Record the gap only when the scanned artifact and published artifact can materially differ, the release build bypasses a repository-owned required scan, or a documented release contract is violated.
-22. Do not record reliability gaps whose only support is an undocumented future scale target, hypothetical product direction, architecture preference, or a conclusion reached from briefly noticing a pattern without verifying a concrete failure path.
-23. Do not record confirmed production bugs, security issues, compatibility breaks, or violated public contracts as reliability gaps. If broken behavior is discovered during review, report it as out of scope for the reliability-gap ledger and recommend `$code-issues`, `$security-audit`, or `$change-safety` as appropriate.
-24. Do not record standalone missing, weak, flaky, misleading, or wrong-layer tests as reliability gaps. Use `$test-gaps` when missing failure-path coverage is the finding.
-25. Do not record standalone missing, weak, stale, misleading, or wrong-location operational docs as reliability gaps. Use `$doc-gaps` when documentation itself is the finding.
-26. Do not report optional maturity improvements, cloud-architecture preferences, private implementation preferences, or "best practice" checkboxes as findings by themselves. List them only as optional follow-up notes when relevant.
-27. If no confirmed reliability gaps are found, report that no reliability gaps were found and do not create `ISSUES.md`.
-28. If confirmed reliability gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
-29. Assign every finding a unique ID for the session in the form `REL-<number>`.
-30. Present the scoped `ISSUES.md` and a proposed reliability-fix plan to the user.
-31. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
+- Do not record generic advice to add monitoring, runbooks, autoscaling, retries, queues, circuit breakers, chaos testing, load tests, Kubernetes probes, or dashboards unless a concrete current failure mode and repository-owned fix are identified.
+- Do not record findings whose evidence is only a repository preference, transport choice, hosting choice, cloud architecture preference, or environment setup assumption. For example, an SSH Git remote or submodule URL is not a reliability gap unless a documented repository-owned workflow currently fails for intended operators and the repository owns the fix.
+- For release or supply-chain findings involving Docker/image scans, first trace the exact artifacts through CI, Make targets, scripts, Dockerfiles, tags, build arguments, and push commands. Do not record a pre-publish scan or release-gate gap merely because CI scans a test image or runs scan jobs on non-release branches. Record the gap only when the scanned artifact and published artifact can materially differ, the release build bypasses a repository-owned required scan, or a documented release contract is violated.
+- Do not record reliability gaps whose only support is an undocumented future scale target, hypothetical product direction, architecture preference, or a conclusion reached from briefly noticing a pattern without verifying a concrete failure path.
+- Do not record confirmed production bugs, security issues, compatibility breaks, or violated public contracts as reliability gaps. If broken behavior is discovered during review, report it as out of scope for the reliability-gap ledger and recommend `$code-issues`, `$security-audit`, or `$change-safety` as appropriate.
+- Do not record standalone missing, weak, flaky, misleading, or wrong-layer tests as reliability gaps. Use `$test-gaps` when missing failure-path coverage is the finding.
+- Do not record standalone missing, weak, stale, misleading, or wrong-location operational docs as reliability gaps. Use `$doc-gaps` when documentation itself is the finding.
+- Do not report optional maturity improvements, cloud-architecture preferences, private implementation preferences, or "best practice" checkboxes as findings by themselves. List them only as optional follow-up notes when relevant.
+- If no confirmed reliability gaps are found, report that no reliability gaps were found and do not create `ISSUES.md`.
+- If confirmed reliability gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
+- Assign every finding a unique ID for the session in the form `REL-<number>`.
+- Stop after presenting the ledger and plan. Do not fix findings in the same pass.
 
 ## `ISSUES.md` Format
 
@@ -96,40 +94,35 @@ Keep optional follow-up notes separate from findings:
 
 ## Implement Mode
 
-1. Identify the requested package or folder scope. If no scope is provided, stop and ask for the package or folder.
-2. Read `ISSUES.md` in the requested package or folder first and treat it as the working reliability-gap ledger.
-   If scoped `ISSUES.md` does not exist, stop and ask whether to run Find mode first for that scope.
-3. Use `$project-workflow` before proposing or running validation so repository entrypoints, CI expectations, documented commands, operational docs, release/config surfaces, and `./bin` wiring are current.
-4. Work through findings sequentially by ID unless the human explicitly names a different finding.
-5. Before proposing a fix for each finding, re-check the current code, config, tests, docs, and CI. Treat the ledger as something that can go stale: dismiss or revise findings that are already addressed, no longer have a concrete failure mode, duplicate another issue, or belong in `$code-issues`, `$security-audit`, `$test-gaps`, or `$doc-gaps`.
-6. For each finding, first present:
-   - the issue ID and current evidence.
-   - the affected reliability promise or operational expectation.
-   - the proposed reliability solution.
-   - code, config, docs, test-layer, validation, compatibility, rollout, rollback, and operator tradeoffs.
-   - the intended validation.
-7. Stop after proposing the solution. Do not edit files, update `ISSUES.md`, or start validation until the human explicitly agrees to that finding's solution.
-8. Ask questions when SLOs, expected failure behavior, operator workflow, compatibility, rollout, validation, or user intent is ambiguous. Treat silence or a broad "implement reliability gaps" request as permission to start the proposal workflow, not as permission to edit.
-9. After the human agrees and before editing, state the selected local code/config/docs pattern, dominant relevant test harness, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
-10. For behavior-changing fixes, state the reliability execution checklist before editing:
+Follow `references/plan.md#implement-mode-plan`.
+
+These rules remain mandatory:
+
+- If no scope is provided, stop and ask for the package or folder.
+- Read `ISSUES.md` in the requested package or folder first and treat it as the working reliability-gap ledger.
+- If scoped `ISSUES.md` does not exist, stop and ask whether to run Find mode first for that scope.
+- Work through findings sequentially by ID unless the human explicitly names a different finding.
+- Before proposing a fix for each finding, re-check the current code, config, tests, docs, and CI. Treat the ledger as something that can go stale: dismiss or revise findings that are already addressed, no longer have a concrete failure mode, duplicate another issue, or belong in `$code-issues`, `$security-audit`, `$test-gaps`, or `$doc-gaps`.
+- Stop after proposing the solution. Do not edit files, update `ISSUES.md`, or start validation until the human explicitly agrees to that finding's solution.
+- Ask questions when SLOs, expected failure behavior, operator workflow, compatibility, rollout, validation, or user intent is ambiguous. Treat silence or a broad "implement reliability gaps" request as permission to start the proposal workflow, not as permission to edit.
+- After the human agrees and before editing, state the selected local code/config/docs pattern, dominant relevant test harness, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
+- For behavior-changing fixes, state the reliability execution checklist before editing:
    - `TDD decision`: yes/no, with the concrete reason if no.
    - `First test/scenario`: the narrowest test, table, fixture, or scenario to add or update first.
    - `Expected red`: the command and failure expected before production edits.
    - `Intended green change`: the smallest code/config/docs change expected to pass.
    - `Refactor checkpoint`: the cleanup pass planned after green, or `none`.
    - `Validation`: the focused and expanded commands intended after refactor.
-11. Once the solution for the current finding is agreed and the local-pattern gate is satisfied, implement only that finding with the smallest clear reliability change.
-12. Use `$reliability-standards` for reliability design, `$change-safety` for public or operational compatibility, `$testing-standards` for failure-path tests, and `$change-validation` for checks. Pair with `$security-audit` when the fix touches auth, secrets, privilege, DoS, logs, supply chain, or incident containment.
-13. Validate the reliability change using checks appropriate to the changed behavior. Prefer repository Make targets and documented entrypoints.
-14. Report the result for that finding with `Red`, `Green`, `Refactor`, and `Validation` entries. Use `Refactor: none` when no cleanup was needed after green. Then ask the human to verify and explicitly say `REL-<number> is done`.
-15. Do not move to the next finding until the human says `REL-<number> is done`.
-16. After the human confirms a finding is done, remove that finding from scoped `ISSUES.md`. If a finding is deemed invalid or not actually a reliability gap, remove it only after explaining why and getting human agreement.
-17. Then propose the solution for the next remaining finding and repeat the same agreement gate.
-18. Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
-19. Summarize what changed, which reliability gaps were resolved or dismissed, and which validation steps were run or still need to be carried out by the human.
+- Implement only the agreed finding with the smallest clear reliability change.
+- Use `$reliability-standards` for reliability design, `$change-safety` for public or operational compatibility, `$testing-standards` for failure-path tests, and `$change-validation` for checks. Pair with `$security-audit` when the fix touches auth, secrets, privilege, DoS, logs, supply chain, or incident containment.
+- Report the result for that finding with `Red`, `Green`, `Refactor`, and `Validation` entries. Use `Refactor: none` when no cleanup was needed after green. Then ask the human to verify and explicitly say `REL-<number> is done`.
+- Do not move to the next finding until the human says `REL-<number> is done`.
+- After the human confirms a finding is done, remove that finding from scoped `ISSUES.md`. If a finding is deemed invalid or not actually a reliability gap, remove it only after explaining why and getting human agreement.
+- Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
 
 ## References
 
+- Read `references/plan.md` before starting Find mode or Implement mode.
 - Use `../references/finding-severity.md` for confidence filtering and severity.
 - Use `$reliability-standards` for SRE, NALSD, resilience, recovery, overload, observability, release-safety, and production-readiness judgment.
 - Use `$project-workflow` for repository command discovery, CI expectations, documented entrypoints, operational docs, and `./bin` wiring before review planning or validation.

--- a/skills/reliability-gaps/agents/openai.yaml
+++ b/skills/reliability-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Reliability Gaps"
   short_description: "Find scoped SRE readiness gaps"
-  default_prompt: "Use $reliability-gaps to find scoped reliability gaps, answer REL-N follow-ups, propose agreed fixes one at a time, and implement each fix with explicit TDD decision, red, green, refactor, and validation reporting before waiting for REL-N is done."
+  default_prompt: "Use $reliability-gaps with its active plan to find scoped reliability gaps, answer REL-N follow-ups, and implement each agreed fix with explicit TDD, red, green, refactor, and validation reporting."

--- a/skills/reliability-gaps/references/plan.md
+++ b/skills/reliability-gaps/references/plan.md
@@ -1,0 +1,79 @@
+# Reliability Gaps Plan
+
+Use this reference to instantiate the active execution plan for
+`$reliability-gaps`. The active plan is runtime state. Do not write it into the
+repository unless the human explicitly asks for a durable plan file. In
+downstream repositories that vendor this project as `./bin`, instantiate the
+plan from the consuming repository root and keep `bin/` as shared guidance.
+
+## Plan State Rules
+
+- Keep exactly one active phase in progress at a time.
+- Preserve stop gates as plan boundaries; do not continue past a stop gate based
+  on silence or a broad request.
+- Update the active plan when scope, reliability surface, validation,
+  delegation, or ledger state changes.
+- Treat validation as stale when files change after a command ran.
+- Record durable findings only in the scoped `ISSUES.md` ledger defined by the
+  skill.
+
+## Find Mode Plan
+
+1. Confirm the requested package or folder scope.
+2. Check whether scoped `ISSUES.md` already exists and stop if it does.
+3. Run `$project-workflow` discovery for entrypoints, CI, documented commands,
+   operational docs, release/config surfaces, and `./bin` wiring.
+4. Identify the reliability surface in scope, including services, APIs, CLIs,
+   jobs, scripts, deployment/config, observability, release, recovery, and
+   operability evidence.
+5. Build the read-only reliability review delegation plan from the requested
+   root and its first-level subfolders.
+6. Ask for required permission before any agent runs non-read-only, network,
+   auth, remote-write, destructive, or otherwise approval-gated commands.
+7. Launch the required review agents when available, or perform the local
+   fallback only when sub-agents are unavailable.
+8. Wait for all review work to finish.
+9. Deduplicate candidates and directly re-check conflicting or overlapping
+   conclusions against code, config, tests, docs, and CI.
+10. Confirm each gap names a current reliability promise or operational
+    expectation, trigger, failure mode, missing or weak control, and user or
+    operator impact.
+11. Reject generic maturity advice, future-scale assumptions, private
+    preferences, and findings that belong in code, security, test, or doc
+    ledgers.
+12. If no confirmed gaps remain, report that result and do not create
+    `ISSUES.md`.
+13. If confirmed gaps remain, write the scoped `ISSUES.md` with `REL-<number>`
+    IDs.
+14. Present the scoped ledger and proposed reliability-fix plan.
+15. Stop before making fixes.
+
+## Implement Mode Plan
+
+1. Confirm the requested package or folder scope.
+2. Read scoped `ISSUES.md`, or stop and ask whether to run Find mode first.
+3. Run `$project-workflow` discovery for current entrypoints, CI, documented
+   commands, operational docs, release/config surfaces, and `./bin` wiring.
+4. Select the next finding by ID unless the human named a specific finding.
+5. Re-check the finding against current code, config, tests, docs, and CI.
+6. Present the finding evidence, affected reliability promise or operational
+   expectation, proposed solution, tradeoffs, and intended validation.
+7. Stop until the human explicitly agrees to that finding's solution.
+8. After agreement, state the local code/config/docs pattern, dominant relevant
+   test harness, planned validation, and any needed deviation.
+9. If a deviation is needed, stop and ask before editing.
+10. For behavior-changing fixes, state the reliability execution checklist:
+    TDD decision, first test/scenario, expected red, intended green change,
+    refactor checkpoint, and validation.
+11. Implement only the agreed reliability gap with the smallest clear change.
+12. Use `$reliability-standards`, `$change-safety`, `$testing-standards`,
+    `$change-validation`, and `$security-audit` as required by the touched
+    surface.
+13. Validate the reliability change through repository Make targets or
+    documented entrypoints.
+14. Report `Red`, `Green`, `Refactor`, and `Validation`, then ask the human to
+    verify with `REL-<number> is done`.
+15. Stop until that confirmation arrives.
+16. After confirmation, remove or revise the finding in scoped `ISSUES.md`.
+17. Continue with the next finding, or delete scoped `ISSUES.md` after all gaps
+    are confirmed resolved.

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -5,43 +5,47 @@ description: Reviews, validates, commits, force-pushes, and opens a draft pull r
 
 # Review PR
 
+Before executing this workflow, read `references/plan.md` and use it to maintain
+the active execution plan. The active plan is runtime state; do not write it
+into the repository unless the human explicitly asks for a durable plan file.
+
 ## Steps
 
-1. Inspect the changed paths from the working tree first; if the working tree is clean, inspect the latest commit.
-2. Confirm the user explicitly asked in the current request to commit, push, update, or open a review PR. If not, do not run `make review`, `make push`, or any equivalent push/PR update command.
-3. If new changes would make an existing PR description, review comment, or previously drafted summary obsolete, flag that and ask whether the user wants the PR updated before pushing anything.
-4. Use `$project-workflow` before validation or `make review` so repository entrypoints, CI expectations, and `./bin` wiring are discovered first.
-5. Make the remote-write behavior of `make review` explicit before running it: the target commits, force-pushes, and opens a draft PR.
-6. Use `$change-validation` to select and run credible validation for the full change before `make review`; language-specific standards may refine that validation.
-7. If the changed paths include Go code, Go tests, Go modules, Go docs, or Go tooling behavior, also use `$go-standards`.
-8. If the changed paths include Ruby code, Ruby tests/features, Gemfiles, RuboCop config, Ruby docs, or Ruby tooling behavior, also use `$ruby-standards`.
-9. If the changed paths include shell scripts, Bash helpers, ShellCheck config/directives, shell docs, or script behavior, also use `$shell-standards`.
-10. If the changed paths include tests, test helpers, fixtures, or changes that raise test coverage or test-design questions, also use `$testing-standards`.
-11. Use `$code-review` to inspect the current change before drafting PR text.
-12. If the user explicitly asks for style nits, polish, readability review, or non-blocking cleanup comments before the PR, also use `$style-review` after the code-review pass.
-13. Resolve any blocking review findings before continuing. Do not run `make review` while blocking findings remain unless the human explicitly says to open a draft PR with those findings unresolved; in that case, call them out in the PR summary.
-14. If `$code-review` reports security findings or security validation gaps, resolve them or document them in the PR summary before `make review`.
-15. Treat `$style-review` notes as non-blocking unless the user explicitly asks to resolve them before opening the PR.
-16. Read `references/summary-format.md`, then draft a lowercase, unprefixed `msg` and multiline Markdown `desc` from the current working tree.
-17. Follow the commit-subject rules: `make review` adds the branch-derived `type(scope):` prefix, so treat branch words as routing metadata rather than message source material and do not repeat the type or scope in `msg`.
-18. Keep `desc` in the summary format, including honest testing details.
-19. When attribution is appropriate or requested, append this footer to the summary instead of a `Co-authored-by:` trailer:
+Follow `references/plan.md#execution-plan`.
+
+These rules remain mandatory:
+
+- Confirm the user explicitly asked in the current request to commit, push, update, or open a review PR. If not, do not run `make review`, `make push`, or any equivalent push/PR update command.
+- If new changes would make an existing PR description, review comment, or previously drafted summary obsolete, flag that and ask whether the user wants the PR updated before pushing anything.
+- Make the remote-write behavior of `make review` explicit before running it: the target commits, force-pushes, and opens a draft PR.
+- Use `$change-validation` to select and run credible validation for the full change before `make review`; language-specific standards may refine that validation.
+- Use the relevant language standards for changed Go, Ruby, shell, and test paths.
+- Use `$code-review` to inspect the current change before drafting PR text.
+- If the user explicitly asks for style nits, polish, readability review, or non-blocking cleanup comments before the PR, also use `$style-review` after the code-review pass.
+- Resolve any blocking review findings before continuing. Do not run `make review` while blocking findings remain unless the human explicitly says to open a draft PR with those findings unresolved; in that case, call them out in the PR summary.
+- If `$code-review` reports security findings or security validation gaps, resolve them or document them in the PR summary before `make review`.
+- Treat `$style-review` notes as non-blocking unless the user explicitly asks to resolve them before opening the PR.
+- Read `references/summary-format.md`, then draft a lowercase, unprefixed `msg` and multiline Markdown `desc` from the current working tree.
+- Follow the commit-subject rules: `make review` adds the branch-derived `type(scope):` prefix, so treat branch words as routing metadata rather than message source material and do not repeat the type or scope in `msg`.
+- Keep `desc` in the summary format, including honest testing details.
+- When attribution is appropriate or requested, append this footer to the summary instead of a `Co-authored-by:` trailer:
 
 ```text
 AI-assisted-by: [Codex](https://openai.com/codex/)
 ```
 
-20. Write the multiline Markdown `desc` to a temporary file with `mktemp`, then run the review target with the drafted subject and file path:
+- Write the multiline Markdown `desc` to a temporary file with `mktemp`, then run the review target with the drafted subject and file path:
 
 ```bash
 make msg="unprefixed subject" desc_file="$desc_file" review
 ```
 
-21. Pass `desc_file` as the path to the multiline Markdown summary; do not flatten the summary into a single line or pass Markdown through a quoted shell argument.
-22. Read `references/output-format.md`, then report the result using that exact structure; do not add, remove, rename, or reorder sections.
+- Pass `desc_file` as the path to the multiline Markdown summary; do not flatten the summary into a single line or pass Markdown through a quoted shell argument.
+- Read `references/output-format.md`, then report the result using that exact structure; do not add, remove, rename, or reorder sections.
 
 ## References
 
+- Read `references/plan.md` before executing the review PR workflow.
 - Read `references/summary-format.md` before drafting the `msg` value and PR summary content.
 - Read `references/output-format.md` before producing the final review PR report.
 - Use `$project-workflow` for repository command discovery, CI expectations, and `./bin` wiring before validation and `make review`.

--- a/skills/review-pr/agents/openai.yaml
+++ b/skills/review-pr/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Review PR"
   short_description: "Prepare an approved review PR flow"
-  default_prompt: "Use $review-pr when I explicitly ask to commit, push, and open or update a review PR."
+  default_prompt: "Use $review-pr with its active plan when I explicitly ask to commit, push, and open or update a review PR."

--- a/skills/review-pr/references/plan.md
+++ b/skills/review-pr/references/plan.md
@@ -1,0 +1,43 @@
+# Review PR Plan
+
+Use this reference to instantiate the active execution plan for `$review-pr`.
+The active plan is runtime state. Do not write it into the repository unless the
+human explicitly asks for a durable plan file. In downstream repositories that
+vendor this project as `./bin`, instantiate the plan from the consuming
+repository root and keep `bin/` as shared guidance.
+
+## Plan State Rules
+
+- Keep exactly one active phase in progress at a time.
+- Preserve permission gates as plan boundaries.
+- Update the active plan when changed files, validation, review findings,
+  drafted summary, or remote-write permission changes.
+- Treat validation as stale when files change after a command ran.
+- Do not run `make review`, `make push`, or any equivalent remote-write command
+  unless the current request explicitly asked for that PR flow.
+
+## Execution Plan
+
+1. Inspect changed paths from the working tree, or the latest commit if the
+   working tree is clean.
+2. Confirm the current user request explicitly asks to commit, push, update, or
+   open a review PR.
+3. If existing PR text may become obsolete, ask whether to update it before
+   pushing.
+4. Run `$project-workflow` discovery for entrypoints, CI, and `./bin` wiring.
+5. Make the remote-write behavior explicit: the review target commits,
+   force-pushes, and opens a draft PR.
+6. Select and run credible validation for the full change with
+   `$change-validation`.
+7. Apply relevant language and test standards for the changed paths.
+8. Run `$code-review` on the current change.
+9. Run `$style-review` only when the human explicitly asked for non-blocking
+   polish.
+10. Resolve blocking review findings or get explicit approval to open the draft
+    PR with unresolved findings documented.
+11. Read `references/summary-format.md`.
+12. Draft the lowercase, unprefixed `msg` and multiline Markdown `desc`.
+13. Write `desc` to a temporary file.
+14. Run `make msg="..." desc_file="$desc_file" review`.
+15. Read `references/output-format.md`.
+16. Report the result in the required output format.

--- a/skills/test-gaps/SKILL.md
+++ b/skills/test-gaps/SKILL.md
@@ -12,6 +12,11 @@ Use this skill in two distinct modes:
 
 Do not combine the two modes in one pass.
 
+Before starting Find mode or Implement mode, read `references/plan.md` and use
+it to maintain the active execution plan. The active plan is runtime state; do
+not write it into the repository unless the human explicitly asks for a durable
+plan file.
+
 ## Operating Stance
 
 Operate as a coverage triager: protect repository-owned behavior through the
@@ -20,38 +25,35 @@ dependency semantics, private implementation detail, or coverage vanity.
 
 ## Find Mode
 
-1. Identify the requested package or folder scope. If no scope is provided, stop and ask for the package or folder.
-2. Use `ISSUES.md` in the requested package or folder as the review ledger, for example `<package/folder>/ISSUES.md`.
-3. If `ISSUES.md` already exists in the requested package or folder, stop. Tell the user the existing scoped ledger must be resolved first, or the human must delete that scoped `ISSUES.md` before a new find pass there.
-4. Use `$project-workflow` to discover repository entrypoints, CI expectations, and `./bin` wiring before planning review agents or validation.
-5. Treat `Find $test-gaps in <package/folder>` or `Find test gaps in <package/folder>` as the user's explicit request to delegate test-gap review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
-6. Use sub-agents for Find mode whenever the active runtime provides them and the runtime permits delegation for the request. Do not treat sub-agents as optional based on scope size, and do not perform the test-gap review locally first.
-7. Do not claim that extra delegation wording is needed before launching review agents. The Find mode invocation is the explicit delegation request.
-8. If the runtime still requires an approval step before launching sub-agents, ask once with the concrete read-only agent plan. If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
-9. Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, or other non-read-only validation. Without that permission, agents should inspect code and tests only and suggest validation.
-10. Exclude generated files and folders, vendored dependencies, caches, build output, and generated lockfile churn unless the requested scope is explicitly about them.
-11. Launch at least one sub-agent covering the requested root package/folder. Split agent assignments across:
-   - files directly under the requested root package/folder.
-   - each first-level subpackage/subfolder under the requested root.
-12. Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough and accurate `$testing-standards` review for its assigned scope, pairing with relevant language standards and `$change-validation` for likely validation commands.
-13. Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally. Each finding must name the repository-owned behavior being protected; reject findings that only test dependency semantics, aliases, or pass-through wrappers.
-14. Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity.
-15. Wait for all agents to finish before aggregating results.
-16. Deduplicate overlapping findings and resolve conflicting agent conclusions by re-checking the code and tests directly.
-17. Confirm each candidate gap against the code and existing tests before recording it. Gaps must be concrete missing, weak, misleading, flaky, or wrong-layer coverage with credible risk to changed behavior, public contracts, compatibility, release-sensitive workflows, or documented command/API behavior.
-18. For each candidate, explicitly identify the nearby existing test shape and why extending existing tests, fixtures, tables, helpers, or assertions does not already cover the behavior. Do not record a gap when the proposed fix would duplicate coverage already provided by that local shape.
-19. Do not record gaps whose only meaningful test would assert pass-through behavior to an upstream library, standard library, or framework. This includes aliases, type aliases, thin wrappers, direct option forwarding, direct global setter/getter calls, dependency injection container behavior, validator tag behavior, encoder/parser behavior, and constructors where the repository adds no branching, validation, transformation, error handling, lifecycle behavior, compatibility policy, or composition contract of its own.
-20. Only record a gap around third-party integration when the untested behavior is repository-owned. Examples include local validation/normalization before calling the dependency, local input/output mapping, local error wrapping/classification/recovery, lifecycle ordering or cleanup owned by the repository, documented compatibility behavior promised across dependency versions, or end-to-end behavior through a supported public repo entrypoint where multiple repo-owned pieces are composed.
-21. When a candidate gap touches a wrapper around a dependency, explicitly ask: "Would the proposed test fail because repository code changed, or only because the dependency's behavior/shape changed?" Record it only when repository code owns the failing behavior.
-22. Do not record gaps that require build tags, architecture-specific execution, optional services, integration environments, or other validation modes the repository does not normally run, unless the finding is explicitly that CI or the documented validation path must add that mode.
-23. Do not record confirmed production bugs, security issues, compatibility breaks, or violated public contracts as test gaps. If such broken behavior is discovered during review, report it as out of scope for the test-gap ledger and recommend `$code-issues`; use this skill when the unprotected or poorly protected behavior is the finding.
-24. Do not record standalone missing, weak, stale, misleading, or wrong-location documentation, README, example, comment, or docstring gaps as test gaps. Use `$doc-gaps` when documentation itself is the finding.
-25. Do not report optional nice-to-have tests, private implementation coverage, arbitrary coverage percentage improvements, style preferences, or docs-only validation as findings by themselves. List them only as doc gaps or optional follow-up notes when relevant.
-26. If no confirmed test gaps are found, report that no test gaps were found and do not create `ISSUES.md`.
-27. If confirmed test gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
-28. Assign every finding a unique ID for the session in the form `TEST-<number>`.
-29. Present the scoped `ISSUES.md` and a proposed test-fix plan to the user.
-30. Stop after presenting the ledger and plan. Do not fix findings in the same pass.
+Follow `references/plan.md#find-mode-plan`.
+
+These rules remain mandatory:
+
+- If no scope is provided, stop and ask for the package or folder.
+- Use `ISSUES.md` in the requested package or folder as the review ledger, for example `<package/folder>/ISSUES.md`.
+- If `ISSUES.md` already exists in the requested package or folder, stop. Tell the user the existing scoped ledger must be resolved first, or the human must delete that scoped `ISSUES.md` before a new find pass there.
+- Treat `Find $test-gaps in <package/folder>` or `Find test gaps in <package/folder>` as the user's explicit request to delegate test-gap review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
+- Use sub-agents for Find mode whenever the active runtime provides them and the runtime permits delegation for the request. Do not treat sub-agents as optional based on scope size, and do not perform the test-gap review locally first.
+- Do not claim that extra delegation wording is needed before launching review agents. The Find mode invocation is the explicit delegation request.
+- If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
+- Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, or other non-read-only validation.
+- Exclude generated files and folders, vendored dependencies, caches, build output, and generated lockfile churn unless the requested scope is explicitly about them.
+- Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough and accurate `$testing-standards` review for its assigned scope, pairing with relevant language standards and `$change-validation` for likely validation commands.
+- Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally. Each finding must name the repository-owned behavior being protected; reject findings that only test dependency semantics, aliases, or pass-through wrappers.
+- Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity.
+- Confirm each candidate gap against the code and existing tests before recording it. Gaps must be concrete missing, weak, misleading, flaky, or wrong-layer coverage with credible risk to changed behavior, public contracts, compatibility, release-sensitive workflows, or documented command/API behavior.
+- For each candidate, explicitly identify the nearby existing test shape and why extending existing tests, fixtures, tables, helpers, or assertions does not already cover the behavior. Do not record a gap when the proposed fix would duplicate coverage already provided by that local shape.
+- Do not record gaps whose only meaningful test would assert pass-through behavior to an upstream library, standard library, or framework. This includes aliases, type aliases, thin wrappers, direct option forwarding, direct global setter/getter calls, dependency injection container behavior, validator tag behavior, encoder/parser behavior, and constructors where the repository adds no branching, validation, transformation, error handling, lifecycle behavior, compatibility policy, or composition contract of its own.
+- Only record a gap around third-party integration when the untested behavior is repository-owned. Examples include local validation/normalization before calling the dependency, local input/output mapping, local error wrapping/classification/recovery, lifecycle ordering or cleanup owned by the repository, documented compatibility behavior promised across dependency versions, or end-to-end behavior through a supported public repo entrypoint where multiple repo-owned pieces are composed.
+- When a candidate gap touches a wrapper around a dependency, explicitly ask: "Would the proposed test fail because repository code changed, or only because the dependency's behavior/shape changed?" Record it only when repository code owns the failing behavior.
+- Do not record gaps that require build tags, architecture-specific execution, optional services, integration environments, or other validation modes the repository does not normally run, unless the finding is explicitly that CI or the documented validation path must add that mode.
+- Do not record confirmed production bugs, security issues, compatibility breaks, or violated public contracts as test gaps. If such broken behavior is discovered during review, report it as out of scope for the test-gap ledger and recommend `$code-issues`; use this skill when the unprotected or poorly protected behavior is the finding.
+- Do not record standalone missing, weak, stale, misleading, or wrong-location documentation, README, example, comment, or docstring gaps as test gaps. Use `$doc-gaps` when documentation itself is the finding.
+- Do not report optional nice-to-have tests, private implementation coverage, arbitrary coverage percentage improvements, style preferences, or docs-only validation as findings by themselves. List them only as doc gaps or optional follow-up notes when relevant.
+- If no confirmed test gaps are found, report that no test gaps were found and do not create `ISSUES.md`.
+- If confirmed test gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
+- Assign every finding a unique ID for the session in the form `TEST-<number>`.
+- Stop after presenting the ledger and plan. Do not fix findings in the same pass.
 
 ## `ISSUES.md` Format
 
@@ -81,33 +83,27 @@ Keep optional follow-up notes separate from findings:
 
 ## Implement Mode
 
-1. Identify the requested package or folder scope. If no scope is provided, stop and ask for the package or folder.
-2. Read `ISSUES.md` in the requested package or folder first and treat it as the working test-gap ledger.
-   If scoped `ISSUES.md` does not exist, stop and ask whether to run Find mode first for that scope.
-3. Use `$project-workflow` before proposing or running validation so repository entrypoints, CI expectations, and `./bin` wiring are current.
-4. Work through findings sequentially by ID unless the human explicitly names a different finding.
-5. Before proposing a fix for each finding, re-check the current code and nearby tests. Treat the ledger as something that can go stale: dismiss or revise findings that are already covered, would duplicate the local test shape, test only underlying libraries/frameworks, or require validation modes the repository does not run.
-6. For each finding, first present:
-   - the issue ID and current evidence.
-   - the proposed test solution.
-   - why the behavior is repository-owned and not already covered by existing tests.
-   - test-layer, fixture, determinism, compatibility, or maintenance tradeoffs.
-   - the intended validation.
-7. Stop after proposing the solution. Do not edit code, update `ISSUES.md`, or start validation until the human explicitly agrees to that finding's solution.
-8. Ask questions when behavior, compatibility, test layer, fixture strategy, validation, or user intent is ambiguous. Treat silence or a broad "implement test gaps" request as permission to start the proposal workflow, not as permission to code.
-9. After the human agrees and before editing, state the selected local test pattern, dominant relevant test harness, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
-10. Once the solution for the current finding is agreed and the local-pattern gate is satisfied, implement only that finding with the smallest clear test change, preferring the existing local test shape over new standalone structure.
-11. Use `$testing-standards` for test design and pair with the relevant language standard for local idioms. If implementing the test gap requires production behavior to change, prefer the test-first or scenario-first loop from `$testing-standards`.
-12. Validate the test change using checks appropriate to the changed tests.
-13. Report the result for that finding and ask the human to verify and explicitly say `TEST-<number> is done`.
-14. Do not move to the next finding until the human says `TEST-<number> is done`.
-15. After the human confirms a finding is done, remove that finding from scoped `ISSUES.md`. If a finding is deemed invalid or not actually a test gap, remove it only after explaining why and getting human agreement.
-16. Then propose the solution for the next remaining finding and repeat the same agreement gate.
-17. Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
-18. Summarize what changed, which test gaps were resolved or dismissed, and which validation steps were run or still need to be carried out by the human.
+Follow `references/plan.md#implement-mode-plan`.
+
+These rules remain mandatory:
+
+- If no scope is provided, stop and ask for the package or folder.
+- Read `ISSUES.md` in the requested package or folder first and treat it as the working test-gap ledger.
+- If scoped `ISSUES.md` does not exist, stop and ask whether to run Find mode first for that scope.
+- Work through findings sequentially by ID unless the human explicitly names a different finding.
+- Before proposing a fix for each finding, re-check the current code and nearby tests. Treat the ledger as something that can go stale: dismiss or revise findings that are already covered, would duplicate the local test shape, test only underlying libraries/frameworks, or require validation modes the repository does not run.
+- Stop after proposing the solution. Do not edit code, update `ISSUES.md`, or start validation until the human explicitly agrees to that finding's solution.
+- Ask questions when behavior, compatibility, test layer, fixture strategy, validation, or user intent is ambiguous. Treat silence or a broad "implement test gaps" request as permission to start the proposal workflow, not as permission to code.
+- After the human agrees and before editing, state the selected local test pattern, dominant relevant test harness, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
+- Implement only the agreed finding with the smallest clear test change, preferring the existing local test shape over new standalone structure.
+- Use `$testing-standards` for test design and pair with the relevant language standard for local idioms. If implementing the test gap requires production behavior to change, prefer the test-first or scenario-first loop from `$testing-standards`.
+- Do not move to the next finding until the human says `TEST-<number> is done`.
+- After the human confirms a finding is done, remove that finding from scoped `ISSUES.md`. If a finding is deemed invalid or not actually a test gap, remove it only after explaining why and getting human agreement.
+- Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
 
 ## References
 
+- Read `references/plan.md` before starting Find mode or Implement mode.
 - Use `../references/finding-severity.md` for confidence filtering and severity.
 - Use `$testing-standards` for cross-language test quality, coverage, fixtures, determinism, and test-layer decisions.
 - Use relevant language standards for local test idioms.

--- a/skills/test-gaps/agents/openai.yaml
+++ b/skills/test-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Test Gaps"
   short_description: "Find scoped weak, flaky, or wrong-layer tests"
-  default_prompt: "Use $test-gaps to find scoped missing, weak, misleading, flaky, or wrong-layer test coverage, store confirmed gaps in that scope's ISSUES.md, or propose and implement agreed test fixes one gap at a time. Before editing, preserve the dominant relevant test harness and state the validation path."
+  default_prompt: "Use $test-gaps with its active plan to find scoped missing, weak, misleading, flaky, or wrong-layer test coverage, store confirmed gaps in ISSUES.md, or implement agreed test fixes one gap at a time."

--- a/skills/test-gaps/references/plan.md
+++ b/skills/test-gaps/references/plan.md
@@ -1,0 +1,66 @@
+# Test Gaps Plan
+
+Use this reference to instantiate the active execution plan for `$test-gaps`.
+The active plan is runtime state. Do not write it into the repository unless the
+human explicitly asks for a durable plan file. In downstream repositories that
+vendor this project as `./bin`, instantiate the plan from the consuming
+repository root and keep `bin/` as shared guidance.
+
+## Plan State Rules
+
+- Keep exactly one active phase in progress at a time.
+- Preserve stop gates as plan boundaries; do not continue past a stop gate based
+  on silence or a broad request.
+- Update the active plan when scope, dominant test harness, validation,
+  delegation, or ledger state changes.
+- Treat validation as stale when files change after a command ran.
+- Record durable findings only in the scoped `ISSUES.md` ledger defined by the
+  skill.
+
+## Find Mode Plan
+
+1. Confirm the requested package or folder scope.
+2. Check whether scoped `ISSUES.md` already exists and stop if it does.
+3. Run `$project-workflow` discovery for entrypoints, CI, and `./bin` wiring.
+4. Identify the existing tests, fixtures, helpers, and dominant relevant harness
+   for the requested scope.
+5. Build the read-only test-gap delegation plan from the requested root and its
+   first-level subfolders.
+6. Ask for required permission before any agent runs non-read-only, network,
+   auth, remote-write, or otherwise approval-gated commands.
+7. Launch the required review agents when available, or perform the local
+   fallback only when sub-agents are unavailable.
+8. Wait for all review work to finish.
+9. Deduplicate candidates and directly re-check conflicting or overlapping
+   conclusions against code and tests.
+10. Confirm each gap protects repository-owned behavior and is not duplicate,
+    private-only, dependency-only, optional, or better handled by another skill.
+11. If no confirmed gaps remain, report that result and do not create
+    `ISSUES.md`.
+12. If confirmed gaps remain, write the scoped `ISSUES.md` with `TEST-<number>`
+    IDs.
+13. Present the scoped ledger and proposed test-fix plan.
+14. Stop before making fixes.
+
+## Implement Mode Plan
+
+1. Confirm the requested package or folder scope.
+2. Read scoped `ISSUES.md`, or stop and ask whether to run Find mode first.
+3. Run `$project-workflow` discovery for current entrypoints, CI, and `./bin`
+   wiring.
+4. Select the next finding by ID unless the human named a specific finding.
+5. Re-check the finding against current code, tests, fixtures, and harnesses.
+6. Present the finding evidence, proposed test solution, repository-owned
+   behavior, existing coverage gap, tradeoffs, and intended validation.
+7. Stop until the human explicitly agrees to that finding's solution.
+8. After agreement, state the local test pattern, dominant relevant test
+   harness, planned validation, and any needed deviation.
+9. If a deviation is needed, stop and ask before editing.
+10. Implement only the agreed test gap with the smallest clear test change.
+11. Use `$testing-standards` and the relevant language standard for test design.
+12. Validate the test change with commands appropriate to the changed tests.
+13. Report the result and ask the human to verify with `TEST-<number> is done`.
+14. Stop until that confirmation arrives.
+15. After confirmation, remove or revise the finding in scoped `ISSUES.md`.
+16. Continue with the next finding, or delete scoped `ISSUES.md` after all gaps
+    are confirmed resolved.


### PR DESCRIPTION
## What

- Add canonical `references/plan.md` templates for `code-issues`, `test-gaps`, `doc-gaps`, `reliability-gaps`, and `review-pr`.
- Require each stateful workflow skill to load its plan template before execution while keeping active plans as runtime state instead of durable repository artifacts.
- Update skill UI prompts and shared docs so downstream repositories still invoke the skill itself while `bin/skills/**` supplies the shared plan guidance.

## Why

- Makes long-running skill workflows easier to audit, resume, and enforce without changing the durable `ISSUES.md` ledger contract.
- Gives downstream repositories a consistent execution shape from the shared submodule while preserving the consuming repository as the command, validation, and local-pattern authority.

## Testing

- `zsh -lic 'make dep'` - passed
- `zsh -lic 'make clean-dep'` - passed
- `zsh -lic 'make skills-lint'` - passed
- `zsh -lic 'make lint'` - passed
- `zsh -lic 'make scripts-lint'` - passed
- `zsh -lic 'make docker-lint'` - passed
- `zsh -lic 'make sec'` - passed
- `git diff --cached --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
