### PR TITLE
feat(skills): bind workflows to active goals

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ example `Find $test-gaps in <folder>`. Active plans are per-session runtime
 state; durable findings continue to live in the scoped `ISSUES.md` files
 defined by the relevant skill.
 
+When the runtime supports goals, stateful workflow skills may also bind one
+active goal to the selected mode and scope. Goals are per-session runtime state
+for the user-visible outcome, waiting or blocked reason, and completion
+condition; they do not replace active plans or scoped `ISSUES.md` ledgers.
+
 ## Makefile includes (examples)
 
 ### Ruby-only project

--- a/skills/README.md
+++ b/skills/README.md
@@ -67,6 +67,23 @@ root. In downstream repositories that vendor this project as `./bin`, the
 consuming repository remains the execution context and `bin/skills/**` remains
 shared guidance.
 
+## Goal Binding
+
+When the runtime supports goals, stateful workflow skills should bind one active
+goal to the selected skill mode and requested scope. The goal states the
+user-visible outcome, current waiting or blocked reason, and completion
+condition. Goals are per-session runtime state, like active plans; do not write
+them into the repository unless the human explicitly asks for a durable goal
+artifact.
+
+Goals do not bypass skill steps, stop gates, permission gates, scoped
+`ISSUES.md` ledgers, human confirmation requirements, or validation freshness
+rules. The selected skill still owns the workflow plan; the goal only makes the
+intended outcome and current state explicit.
+When the runtime has stricter status-transition rules, follow those runtime
+rules and use the skill's goal rules to explain the waiting, blocked, or done
+reason.
+
 ## Format Rule
 
 When a skill is used as the final answer, use that skill's required output

--- a/skills/code-issues/SKILL.md
+++ b/skills/code-issues/SKILL.md
@@ -16,6 +16,9 @@ Before starting Find mode or Implement mode, read `references/plan.md` and use
 it to maintain the active execution plan. The active plan is runtime state; do
 not write it into the repository unless the human explicitly asks for a durable
 plan file.
+When the runtime supports goals, bind the selected mode and requested scope to
+one active goal and update that goal as ledger, proposal, approval, validation,
+or human-confirmation state changes.
 
 ## Operating Stance
 

--- a/skills/code-issues/agents/openai.yaml
+++ b/skills/code-issues/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Code Issues"
   short_description: "Find scoped code defects and risks"
-  default_prompt: "Use $code-issues with its active plan to delegate scoped code issue finding, store confirmed findings in that scope's ISSUES.md, or propose and implement explicitly agreed fixes one code issue at a time."
+  default_prompt: "Use $code-issues with its active goal and plan to delegate scoped code issue finding, store confirmed findings in that scope's ISSUES.md, or propose and implement explicitly agreed fixes one code issue at a time."

--- a/skills/code-issues/references/plan.md
+++ b/skills/code-issues/references/plan.md
@@ -17,6 +17,22 @@ repository root and keep `bin/` as shared guidance.
 - Record durable findings only in the scoped `ISSUES.md` ledger defined by the
   skill.
 
+## Goal State Rules
+
+- Bind the active goal to the selected mode and requested scope.
+- In Find mode, the goal is complete when no confirmed code issues are found and
+  reported, or when the scoped `ISSUES.md` ledger is written and presented.
+- In Implement mode, the goal is waiting while the human has not approved the
+  proposed issue solution, or after validation until the human confirms
+  `ISSUE-<number> is done`.
+- In Implement mode, the goal is complete for an issue only after the human
+  confirms it is done and the scoped ledger is updated accordingly.
+- Record a blocked reason when a required scope is missing, the scoped ledger
+  required by the mode is absent or already exists in a conflicting state,
+  required permission is denied, or the selected issue cannot be re-checked
+  without human input. Follow runtime rules for when that reason changes goal
+  status.
+
 ## Find Mode Plan
 
 1. Confirm the requested package or folder scope.

--- a/skills/doc-gaps/SKILL.md
+++ b/skills/doc-gaps/SKILL.md
@@ -16,6 +16,9 @@ Before starting Find mode or Implement mode, read `references/plan.md` and use
 it to maintain the active execution plan. The active plan is runtime state; do
 not write it into the repository unless the human explicitly asks for a durable
 plan file.
+When the runtime supports goals, bind the selected mode and requested scope to
+one active goal and update that goal as ledger, proposal, approval, validation,
+or human-confirmation state changes.
 
 ## Operating Stance
 

--- a/skills/doc-gaps/agents/openai.yaml
+++ b/skills/doc-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Doc Gaps"
   short_description: "Find scoped documentation gaps"
-  default_prompt: "Use $doc-gaps with its active plan to find scoped missing, weak, stale, misleading, or terminology-confusing docs and comments, store confirmed gaps in ISSUES.md, or implement agreed doc fixes one gap at a time."
+  default_prompt: "Use $doc-gaps with its active goal and plan to find scoped missing, weak, stale, misleading, or terminology-confusing docs and comments, store confirmed gaps in ISSUES.md, or implement agreed doc fixes one gap at a time."

--- a/skills/doc-gaps/references/plan.md
+++ b/skills/doc-gaps/references/plan.md
@@ -17,6 +17,22 @@ repository root and keep `bin/` as shared guidance.
 - Record durable findings only in the scoped `ISSUES.md` ledger defined by the
   skill.
 
+## Goal State Rules
+
+- Bind the active goal to the selected mode and requested scope.
+- In Find mode, the goal is complete when no confirmed doc gaps are found and
+  reported, or when the scoped `ISSUES.md` ledger is written and presented.
+- In Implement mode, the goal is waiting while the human has not approved the
+  proposed doc-gap solution, or after validation until the human confirms
+  `DOC-<number> is done`.
+- In Implement mode, the goal is complete for a finding only after the human
+  confirms it is done and the scoped ledger is updated accordingly.
+- Record a blocked reason when a required scope is missing, the scoped ledger
+  required by the mode is absent or already exists in a conflicting state,
+  required permission is denied, or the selected finding cannot be re-checked
+  without human input. Follow runtime rules for when that reason changes goal
+  status.
+
 ## Find Mode Plan
 
 1. Confirm the requested package or folder scope.

--- a/skills/reliability-gaps/SKILL.md
+++ b/skills/reliability-gaps/SKILL.md
@@ -16,6 +16,9 @@ Before starting Find mode or Implement mode, read `references/plan.md` and use
 it to maintain the active execution plan. The active plan is runtime state; do
 not write it into the repository unless the human explicitly asks for a durable
 plan file.
+When the runtime supports goals, bind the selected mode and requested scope to
+one active goal and update that goal as ledger, proposal, approval, validation,
+or human-confirmation state changes.
 
 ## Operating Stance
 

--- a/skills/reliability-gaps/agents/openai.yaml
+++ b/skills/reliability-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Reliability Gaps"
   short_description: "Find scoped SRE readiness gaps"
-  default_prompt: "Use $reliability-gaps with its active plan to find scoped reliability gaps, answer REL-N follow-ups, and implement each agreed fix with explicit TDD, red, green, refactor, and validation reporting."
+  default_prompt: "Use $reliability-gaps with its active goal and plan to find scoped reliability gaps, answer REL-N follow-ups, and implement each agreed fix with explicit TDD, red, green, refactor, and validation reporting."

--- a/skills/reliability-gaps/references/plan.md
+++ b/skills/reliability-gaps/references/plan.md
@@ -17,6 +17,23 @@ plan from the consuming repository root and keep `bin/` as shared guidance.
 - Record durable findings only in the scoped `ISSUES.md` ledger defined by the
   skill.
 
+## Goal State Rules
+
+- Bind the active goal to the selected mode and requested scope.
+- In Find mode, the goal is complete when no confirmed reliability gaps are
+  found and reported, or when the scoped `ISSUES.md` ledger is written and
+  presented.
+- In Implement mode, the goal is waiting while the human has not approved the
+  proposed reliability-gap solution, or after validation until the human
+  confirms `REL-<number> is done`.
+- In Implement mode, the goal is complete for a finding only after the human
+  confirms it is done and the scoped ledger is updated accordingly.
+- Record a blocked reason when a required scope is missing, the scoped ledger
+  required by the mode is absent or already exists in a conflicting state,
+  required permission is denied, or the selected finding cannot be re-checked
+  without human input. Follow runtime rules for when that reason changes goal
+  status.
+
 ## Find Mode Plan
 
 1. Confirm the requested package or folder scope.

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -8,6 +8,9 @@ description: Reviews, validates, commits, force-pushes, and opens a draft pull r
 Before executing this workflow, read `references/plan.md` and use it to maintain
 the active execution plan. The active plan is runtime state; do not write it
 into the repository unless the human explicitly asks for a durable plan file.
+When the runtime supports goals, bind this workflow to one active goal for the
+review PR outcome and update that goal as permission, validation, review, PR
+drafting, or remote-write state changes.
 
 ## Steps
 

--- a/skills/review-pr/agents/openai.yaml
+++ b/skills/review-pr/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Review PR"
   short_description: "Prepare an approved review PR flow"
-  default_prompt: "Use $review-pr with its active plan when I explicitly ask to commit, push, and open or update a review PR."
+  default_prompt: "Use $review-pr with its active goal and plan when I explicitly ask to commit, push, and open or update a review PR."

--- a/skills/review-pr/references/plan.md
+++ b/skills/review-pr/references/plan.md
@@ -16,6 +16,20 @@ repository root and keep `bin/` as shared guidance.
 - Do not run `make review`, `make push`, or any equivalent remote-write command
   unless the current request explicitly asked for that PR flow.
 
+## Goal State Rules
+
+- Bind the active goal to opening or updating the review PR for the current
+  change.
+- Record a waiting reason when explicit PR-flow permission, obsolete PR text
+  direction, remote-write permission, or unresolved-finding approval is needed.
+- Record a blocked reason only when a required permission is denied, validation
+  cannot be run or interpreted, or blocking findings cannot be resolved without
+  human input. Follow runtime rules for when that reason changes goal status.
+- Treat the goal as complete only after the review target confirms the commit,
+  push, and draft PR result and the required output format has been reported.
+- Do not treat a prepared summary, clean validation, or finished review as goal
+  completion before the remote-write flow succeeds.
+
 ## Execution Plan
 
 1. Inspect changed paths from the working tree, or the latest commit if the

--- a/skills/test-gaps/SKILL.md
+++ b/skills/test-gaps/SKILL.md
@@ -16,6 +16,9 @@ Before starting Find mode or Implement mode, read `references/plan.md` and use
 it to maintain the active execution plan. The active plan is runtime state; do
 not write it into the repository unless the human explicitly asks for a durable
 plan file.
+When the runtime supports goals, bind the selected mode and requested scope to
+one active goal and update that goal as ledger, proposal, approval, validation,
+or human-confirmation state changes.
 
 ## Operating Stance
 

--- a/skills/test-gaps/agents/openai.yaml
+++ b/skills/test-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Test Gaps"
   short_description: "Find scoped weak, flaky, or wrong-layer tests"
-  default_prompt: "Use $test-gaps with its active plan to find scoped missing, weak, misleading, flaky, or wrong-layer test coverage, store confirmed gaps in ISSUES.md, or implement agreed test fixes one gap at a time."
+  default_prompt: "Use $test-gaps with its active goal and plan to find scoped missing, weak, misleading, flaky, or wrong-layer test coverage, store confirmed gaps in ISSUES.md, or implement agreed test fixes one gap at a time."

--- a/skills/test-gaps/references/plan.md
+++ b/skills/test-gaps/references/plan.md
@@ -17,6 +17,22 @@ repository root and keep `bin/` as shared guidance.
 - Record durable findings only in the scoped `ISSUES.md` ledger defined by the
   skill.
 
+## Goal State Rules
+
+- Bind the active goal to the selected mode and requested scope.
+- In Find mode, the goal is complete when no confirmed test gaps are found and
+  reported, or when the scoped `ISSUES.md` ledger is written and presented.
+- In Implement mode, the goal is waiting while the human has not approved the
+  proposed test-gap solution, or after validation until the human confirms
+  `TEST-<number> is done`.
+- In Implement mode, the goal is complete for a finding only after the human
+  confirms it is done and the scoped ledger is updated accordingly.
+- Record a blocked reason when a required scope is missing, the scoped ledger
+  required by the mode is absent or already exists in a conflicting state,
+  required permission is denied, or the selected finding cannot be re-checked
+  without human input. Follow runtime rules for when that reason changes goal
+  status.
+
 ## Find Mode Plan
 
 1. Confirm the requested package or folder scope.


### PR DESCRIPTION
## What

- Adds shared goal-binding guidance for stateful workflow skills as per-session runtime state.
- Defines goal state rules for review PR, code issue, test gap, doc gap, and reliability gap workflow plans.
- Updates downstream README guidance and skill metadata prompts so active goals sit beside active plans without replacing scoped `ISSUES.md` ledgers.

## Why

- Multi-turn workflows now have a clearer user-visible outcome, waiting or blocked reason, and completion condition.
- The change preserves existing stop gates, permission gates, validation freshness, and ledger ownership while making resumable workflow state easier to reason about.

## Testing

- `make dep` - passed
- `make skills-lint` - passed
- `make lint` - passed
- `make sec` - passed
- `make scripts-lint` - passed
- `make docker-lint` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
