### PR TITLE
feat(skills): add review-time documentation standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,9 @@ skill instead of one broad default:
 - `change-validation`: test, lint, CI, security, benchmark, and validation selection.
 - `testing-standards`: language-agnostic test design, coverage, fixtures,
   determinism, and test-layer guidance.
+- `docs-standards`: documentation quality standards for README files, docs,
+  examples, command/config docs, public API comments, docstrings, and stale-doc
+  review.
 - `naming-standards`: cross-language naming judgment for domain clarity,
   consistency, abstraction level, public terminology, and rename safety.
 - `code-review`: review findings, risk assessment, and missing coverage.
@@ -112,8 +115,9 @@ display name, short description, or default prompt became stale.
 Common composition:
 
 - `review-pr` orchestrates PR preparation with `project-workflow`,
-  `change-validation`, relevant language standards, `code-review`, summary
-  drafting, optional explicit `style-review`, and the review target.
+  `change-validation`, relevant language standards, `docs-standards`,
+  `code-review`, summary drafting, optional explicit `style-review`, and the
+  review target.
 - `code-issues` orchestrates a two-phase code-issue workflow: aggregate confirmed
   `project-workflow`, `code-review`, and `security-audit` findings into
   `ISSUES.md`, then implement agreed fixes one code issue at a time.
@@ -121,9 +125,9 @@ Common composition:
   `project-workflow` context and missing or weak test coverage into
   `ISSUES.md`, then implement agreed test fixes gap by gap.
 - `doc-gaps` orchestrates a two-phase doc-gap workflow: aggregate
-  confirmed `project-workflow` context and missing, stale, or misleading
-  README, docs, examples, comments, and docstrings into `ISSUES.md`, then
-  implement agreed doc fixes gap by gap.
+  confirmed `project-workflow` context and `$docs-standards` findings for
+  missing, stale, or misleading README, docs, examples, comments, and docstrings
+  into `ISSUES.md`, then implement agreed doc fixes gap by gap.
 - `reliability-gaps` orchestrates a two-phase reliability-gap workflow:
   aggregate confirmed `project-workflow` context and SRE, NALSD, operability,
   overload, observability, release-safety, recovery, or data-integrity gaps into
@@ -137,6 +141,9 @@ Common composition:
   `change-validation` for scanner, lint, or CI command selection.
 - `testing-standards` pairs with language standards for test idioms and
   `change-validation` for command selection.
+- `docs-standards` pairs with language standards for API comments and docstrings,
+  `naming-standards` for terminology, `change-safety` for documented contract
+  changes, and `change-validation` for docs-related validation.
 - `reliability-standards` pairs with `change-safety`, `security-audit`,
   `testing-standards`, and `change-validation` when changes affect production
   readiness, SLOs, overload, observability, release safety, recovery, or

--- a/skills/README.md
+++ b/skills/README.md
@@ -15,8 +15,9 @@ specific rule or local pattern, and ask for approval to deviate.
 ## Common Composition
 
 - `review-pr` orchestrates PR preparation with `project-workflow`,
-  `change-validation`, relevant language standards, `code-review`, summary
-  drafting, optional explicit `style-review`, and the review target.
+  `change-validation`, relevant language standards, `docs-standards`,
+  `code-review`, summary drafting, optional explicit `style-review`, and the
+  review target.
 - `code-issues` orchestrates a two-phase code-issue workflow: first aggregate confirmed
   `project-workflow`, `code-review`, and `security-audit` findings into
   `ISSUES.md`, then implement agreed fixes one code issue at a time.
@@ -24,9 +25,9 @@ specific rule or local pattern, and ask for approval to deviate.
   `project-workflow` context and confirmed missing or weak test coverage into
   `ISSUES.md`, then implement agreed test fixes one gap at a time.
 - `doc-gaps` orchestrates a two-phase doc-gap workflow: first
-  aggregate `project-workflow` context and confirmed README, docs, examples,
-  comments, and docstring gaps into `ISSUES.md`, then implement agreed
-  doc fixes one gap at a time.
+  aggregate `project-workflow` context and confirmed `$docs-standards` findings
+  for README, docs, examples, comments, and docstring gaps into `ISSUES.md`,
+  then implement agreed doc fixes one gap at a time.
 - `reliability-gaps` orchestrates a two-phase reliability-gap workflow: first
   aggregate `project-workflow` context and verified SRE, NALSD, operability,
   overload, observability, release-safety, recovery, or data-integrity gaps into
@@ -41,6 +42,11 @@ specific rule or local pattern, and ask for approval to deviate.
 - `testing-standards` covers language-agnostic test design and coverage
   decisions; pair it with language standards for idioms and
   `change-validation` for command selection.
+- `docs-standards` covers README, docs, examples, command/config docs, public
+  API comments, docstrings, and stale-doc review; pair it with language
+  standards for API comments and docstrings, `naming-standards` for terminology,
+  `change-safety` for documented contract changes, and `change-validation` for
+  docs-related validation.
 - `reliability-standards` covers SRE, NALSD, production-readiness, SLO,
   overload, observability, release-safety, recovery, and operability judgment;
   pair it with `change-safety`, `security-audit`, `testing-standards`, and

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: Reviews changed code for bugs, regressions, risky assumptions, missing tests, compatibility breaks, missing documentation, and language-specific maintainability or idiom risks. Use when the user asks for a general code review, diff review, PR check, or pre-merge issue pass; delegate explicit security scope to $security-audit.
+description: Reviews changed code for bugs, regressions, risky assumptions, missing tests, compatibility breaks, missing or stale documentation, and language-specific maintainability or idiom risks. Use when the user asks for a general code review, diff review, PR check, or pre-merge issue pass; pair documentation judgment with $docs-standards and delegate explicit security scope to $security-audit.
 ---
 
 # Code Review
@@ -18,15 +18,17 @@ and credible user, compatibility, security, maintenance, or test impact.
 3. Inspect behavior, tests, compatibility, security, docs, and maintenance risk before style preferences.
 4. First identify high-risk review leads, especially deletions, cross-boundary drift, silent behavior changes, changed contracts, unhandled sibling cases, and error-path changes. Then verify concrete findings instead of reviewing every line uniformly.
 5. Prefer precision over recall. Do not report plausible concerns unless they survive attempts to disprove them and are grounded in changed code, concrete evidence, and credible user, compatibility, security, maintenance, or test risk.
-6. Pair with relevant language standards (`$go-standards`, `$ruby-standards`, `$shell-standards`) when reviewing language-specific code, APIs, docs, tests, or tooling behavior. Pair with `$naming-standards` when names create concrete ambiguity, misuse risk, public contract confusion, inconsistent vocabulary, or maintenance cost. Treat idiomatic style concerns as findings only when they create concrete readability, maintenance, correctness, compatibility, or public API risk; use `$style-review` instead for non-blocking polish when the user asks for style nits or a readability pass.
-7. Use `$testing-standards` when judging whether tests are missing, weak, overfit to internals, hard to read, or at the wrong layer.
-8. If the review scope includes security-sensitive code, configuration, dependencies, shell execution, filesystem writes/deletes, network/auth/TLS behavior, secrets/env handling, Docker helpers, or CI/security tooling, consult `$security-audit` and the smallest matching security reference; keep this skill's findings format.
-9. Verify claims against concrete file and line references whenever possible.
-10. When code review is the final response, use the exact structure in `references/findings-format.md`; do not add, remove, rename, or reorder sections.
-11. When another skill embeds this review, preserve findings, open questions, testing gaps, and summary facts in the caller's output format.
+6. Use `$docs-standards` when the review scope includes README files, user-facing docs, examples, command/config docs, public API comments, docstrings, or changed behavior that may make nearby existing documentation stale. Keep review scope to the current change and directly affected nearby docs unless the user explicitly asks for `$doc-gaps` or a broader documentation audit.
+7. Pair with relevant language standards (`$go-standards`, `$ruby-standards`, `$shell-standards`) when reviewing language-specific code, APIs, docs, tests, or tooling behavior. Pair with `$naming-standards` when names create concrete ambiguity, misuse risk, public contract confusion, inconsistent vocabulary, or maintenance cost. Treat idiomatic style concerns as findings only when they create concrete readability, maintenance, correctness, compatibility, or public API risk; use `$style-review` instead for non-blocking polish when the user asks for style nits or a readability pass.
+8. Use `$testing-standards` when judging whether tests are missing, weak, overfit to internals, hard to read, or at the wrong layer.
+9. If the review scope includes security-sensitive code, configuration, dependencies, shell execution, filesystem writes/deletes, network/auth/TLS behavior, secrets/env handling, Docker helpers, or CI/security tooling, consult `$security-audit` and the smallest matching security reference; keep this skill's findings format.
+10. Verify claims against concrete file and line references whenever possible.
+11. When code review is the final response, use the exact structure in `references/findings-format.md`; do not add, remove, rename, or reorder sections.
+12. When another skill embeds this review, preserve findings, open questions, testing gaps, and summary facts in the caller's output format.
 
 ## References
 
 - Read `references/findings-format.md` for review priorities, output format, and what to say when no issues are found.
+- Use `$docs-standards` for documentation quality, stale-doc, public API comment, README, example, command, and configuration documentation judgment.
 - Use relevant language standards for idiomatic code, API, docs, test, and tooling conventions.
 - Use `$style-review` for non-blocking style, readability, consistency, idiom, or cleanup suggestions that do not rise to code-review findings.

--- a/skills/code-review/agents/openai.yaml
+++ b/skills/code-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Code Review"
   short_description: "Review diffs for bugs and regressions"
-  default_prompt: "Use $code-review for a general bug, regression, missing-coverage, documentation, naming, and language-idiom risk review."
+  default_prompt: "Use $code-review for a general bug, regression, missing-coverage, documentation, naming, and language-idiom risk review; pair docs judgment with $docs-standards and security-sensitive scope with $security-audit."

--- a/skills/doc-gaps/SKILL.md
+++ b/skills/doc-gaps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doc-gaps
-description: Finds concrete missing, weak, stale, or misleading documentation in a package or folder, including README files, user-facing docs, examples, and code comments/docstrings required by relevant language standards, records confirmed gaps in that scope's ISSUES.md, and later proposes and implements explicitly agreed doc fixes gap by gap. Use when the user asks to find $doc-gaps in a package or folder, find doc gaps in a package or folder, implement $doc-gaps in a package or folder, or implement doc gaps in a package or folder.
+description: Finds concrete missing, weak, stale, or misleading documentation in a package or folder, including README files, user-facing docs, examples, and code comments/docstrings required by $docs-standards and relevant language standards, records confirmed gaps in that scope's ISSUES.md, and later proposes and implements explicitly agreed doc fixes gap by gap. Use when the user asks to find $doc-gaps in a package or folder, find doc gaps in a package or folder, implement $doc-gaps in a package or folder, or implement doc gaps in a package or folder.
 ---
 
 # Doc Gaps
@@ -22,9 +22,9 @@ or human-confirmation state changes.
 
 ## Operating Stance
 
-Operate as a documentation triager: protect users, operators, and maintainers
-from concrete misunderstanding, and reject wording preferences or exhaustive
-private-code commentary that do not reduce real use or maintenance risk.
+Operate as a scoped documentation ledger manager: use `$docs-standards` for
+documentation quality judgment, and use this skill for scope control,
+delegation, `ISSUES.md` recording, and gap-by-gap implementation.
 
 ## Find Mode
 
@@ -41,13 +41,12 @@ These rules remain mandatory:
 - If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
 - Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, or other non-read-only validation.
 - Exclude generated files and folders, vendored dependencies, caches, build output, generated API docs, and generated lockfile churn unless the requested scope is explicitly about them.
-- Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough documentation review for its assigned scope, pairing with relevant language standards, `$naming-standards` when terminology is unclear or inconsistent, and `$change-validation` for likely validation commands.
+- Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough documentation review for its assigned scope, pairing with `$docs-standards`, relevant language standards, `$naming-standards` when terminology is unclear or inconsistent, and `$change-validation` for likely validation commands.
 - Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
 - Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity.
-- Confirm each candidate gap against the code, current docs, examples, and documented interfaces before recording it. Gaps must be concrete missing, weak, stale, misleading, or wrong-location documentation with credible risk to users, operators, maintainers, public APIs, documented command behavior, onboarding, setup, or contribution workflows.
-- Do not record confirmed production bugs, security issues, compatibility breaks, or violated public contracts as doc gaps. If broken behavior is discovered during review, report it as out of scope for the doc-gap ledger and recommend `$code-issues`; use this skill when unclear, missing, stale, or misleading documentation is the finding.
-- Do not record standalone missing, weak, flaky, misleading, or wrong-layer tests as doc gaps. Recommend `$test-gaps` when the unprotected behavior is the finding.
-- Do not report arbitrary wording preferences, style nits, exhaustive private implementation comments, or optional documentation polish as findings by themselves. List them only as optional follow-up notes when relevant.
+- Confirm each candidate gap against the code, current docs, examples, and documented interfaces before recording it, using `$docs-standards` as the finding threshold.
+- Do not record candidates that `$docs-standards` routes to `$code-review`, `$code-issues`, `$security-audit`, `$testing-standards`, or `$test-gaps`.
+- List optional documentation polish only as optional follow-up notes when relevant.
 - If no confirmed doc gaps are found, report that no doc gaps were found and do not create `ISSUES.md`.
 - If confirmed doc gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
 - Assign every finding a unique ID for the session in the form `DOC-<number>`.
@@ -55,13 +54,12 @@ These rules remain mandatory:
 
 ## Documentation Review Standards
 
-Use these standards to decide whether a documentation concern is concrete enough to record:
-
-- **README and project docs**: README files should quickly explain what the project does, why it is useful, how users get started, where to get help, and who maintains or contributes to it. Prefer root, `.github/`, or `docs/` README placement when GitHub rendering matters. Keep startup docs concise, current, structured with headings, and linked to deeper docs instead of burying long manuals in the README.
-- **Examples and commands**: Installation, setup, usage, Make targets, CLI examples, environment variables, and API examples should be copy-paste-ready when practical and aligned with real entrypoints.
-- **Code comments**: Comments should explain non-obvious intent, tradeoffs, invariants, unidiomatic choices, bug-workaround context, copied-code sources, and helpful external references. Do not demand comments that merely restate obvious code. If a clear comment cannot be written because the code itself is confused, recommend `$code-issues`.
-- **Naming and terminology**: Use `$naming-standards` when documentation terminology, command/API names, examples, comments, or public vocabulary are unclear, inconsistent with code, or misleading.
-- **Language-specific docs**: Use the relevant standards skill for code comments, docstrings, public API docs, and language-specific examples before recording findings. Keep GoDoc details in `$go-standards`, RDoc details in `$ruby-standards`, and shell script/function comment rules in `$shell-standards`.
+Use `$docs-standards` to decide whether a documentation concern is concrete
+enough to record. Use the relevant language standards for code comments,
+docstrings, public API docs, and language-specific examples before recording
+findings. Keep GoDoc details in `$go-standards`, RDoc details in
+`$ruby-standards`, and shell script/function comment rules in
+`$shell-standards`.
 
 ## `ISSUES.md` Format
 
@@ -103,7 +101,7 @@ These rules remain mandatory:
 - Ask questions when behavior, audience, documentation location, public-contract wording, examples, validation, or user intent is ambiguous. Treat silence or a broad "implement doc gaps" request as permission to start the proposal workflow, not as permission to edit.
 - After the human agrees and before editing, state the selected local documentation pattern, dominant relevant validation path, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
 - Implement only the agreed finding with the smallest clear documentation change.
-- Use relevant language standards for code comments and API docs. Use `$change-safety` when documentation changes public API, command, migration, or compatibility expectations.
+- Use `$docs-standards` and relevant language standards for code comments and API docs. Use `$change-safety` when documentation changes public API, command, migration, or compatibility expectations.
 - Do not move to the next finding until the human says `DOC-<number> is done`.
 - After the human confirms a finding is done, remove that finding from scoped `ISSUES.md`. If a finding is deemed invalid or not actually a doc gap, remove it only after explaining why and getting human agreement.
 - Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
@@ -111,11 +109,7 @@ These rules remain mandatory:
 ## References
 
 - Read `references/plan.md` before starting Find mode or Implement mode.
+- Use `$docs-standards` as the documentation quality bar and routing threshold.
 - Use `../references/finding-severity.md` for confidence filtering and severity.
 - Use `$project-workflow` for repository command discovery, documented entrypoints, CI expectations, examples, and `./bin` wiring before review planning or validation.
-- Use relevant language standards for code comments, public API docs, and examples.
-- Use `$naming-standards` when documentation terminology, command/API names, examples, comments, or public vocabulary are unclear, inconsistent, or misleading.
-- Use `$change-safety` when documentation affects public contracts, compatibility, migrations, security expectations, or documented operational behavior.
-- Use `$change-validation` when selecting validation commands for implemented doc fixes.
-- Use `$code-issues` when the confirmed problem is broken behavior, a security issue, a compatibility break, or a violated public contract.
-- Use `$test-gaps` when the confirmed problem is missing or weak test coverage rather than documentation.
+- Use the paired language, naming, safety, and validation skills through `$docs-standards`.

--- a/skills/doc-gaps/agents/openai.yaml
+++ b/skills/doc-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Doc Gaps"
   short_description: "Find scoped documentation gaps"
-  default_prompt: "Use $doc-gaps with its active goal and plan to find scoped missing, weak, stale, misleading, or terminology-confusing docs and comments, store confirmed gaps in ISSUES.md, or implement agreed doc fixes one gap at a time."
+  default_prompt: "Use $doc-gaps with its active goal and plan plus $docs-standards to find scoped missing, weak, stale, misleading, or terminology-confusing docs and comments, store confirmed gaps in ISSUES.md, or implement agreed doc fixes one gap at a time."

--- a/skills/doc-gaps/references/plan.md
+++ b/skills/doc-gaps/references/plan.md
@@ -40,7 +40,8 @@ repository root and keep `bin/` as shared guidance.
 3. Run `$project-workflow` discovery for entrypoints, CI, documented commands,
    public APIs, examples, and `./bin` wiring.
 4. Identify existing documentation locations, examples, comments, docstrings,
-   and language-specific documentation standards for the requested scope.
+   `$docs-standards`, and language-specific documentation standards for the
+   requested scope.
 5. Build the read-only documentation review delegation plan from the requested
    root and its first-level subfolders.
 6. Ask for required permission before any agent runs non-read-only, network,
@@ -78,8 +79,8 @@ repository root and keep `bin/` as shared guidance.
 9. If a deviation is needed, stop and ask before editing.
 10. Implement only the agreed doc gap with the smallest clear documentation
     change.
-11. Use relevant language standards for comments, docstrings, and public API
-    docs.
+11. Use `$docs-standards` and relevant language standards for comments,
+    docstrings, and public API docs.
 12. Validate the documentation change with commands appropriate to the changed
     files.
 13. Report the result and ask the human to verify with `DOC-<number> is done`.

--- a/skills/docs-standards/SKILL.md
+++ b/skills/docs-standards/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: docs-standards
+description: Applies documentation quality standards for README files, user-facing docs, examples, command/config docs, public API comments, docstrings, and behavior changes that may make existing documentation stale. Use when writing, reviewing, or updating documentation; when changed code affects documented behavior; when $code-review or $review-pr needs documentation judgment; and when $doc-gaps needs criteria for scoped documentation triage.
+---
+
+# Docs Standards
+
+## Operating Stance
+
+Operate as a documentation reviewer: protect users, operators, and
+maintainers from concrete misunderstanding while rejecting wording preferences,
+exhaustive private-code commentary, and optional polish that does not reduce
+real use or maintenance risk.
+
+## Steps
+
+1. Identify the documentation surface in scope: README files, docs, examples,
+   command help, setup instructions, configuration docs, public API comments,
+   code comments, docstrings, changelogs, migration notes, or generated docs.
+2. Compare documentation against the changed behavior, requested scope, tests,
+   examples, command output, configuration schema, and public interfaces.
+3. For `$code-review` and `$review-pr`, inspect changed documentation and nearby
+   documentation directly affected by the current change. Do not perform a
+   package-wide documentation audit unless the user explicitly asks for
+   `$doc-gaps` or a broader docs pass.
+4. For `$doc-gaps`, use these standards as the quality bar for recording
+   confirmed missing, weak, stale, misleading, or wrong-location documentation
+   in the scoped `ISSUES.md` ledger.
+5. Pair with relevant language standards for language-specific public API
+   comments and docstrings. Pair with `$naming-standards` when terminology,
+   command/API names, examples, or public vocabulary are unclear or
+   inconsistent.
+6. Pair with `$change-safety` when documentation changes public contracts,
+   compatibility expectations, migrations, security guidance, operational
+   behavior, or documented support boundaries.
+7. Pair with `$change-validation` when selecting validation for documentation
+   changes, such as docs lint, generated-doc checks, example tests, command
+   snapshots, or the repository's normal review target.
+
+## Documentation Standards
+
+- **Correctness**: Documentation must describe the current repository-owned
+  behavior, command syntax, configuration shape, examples, defaults, limits,
+  errors, compatibility expectations, and operational constraints accurately.
+- **Completeness**: Public entrypoints, exported APIs, commands, configuration
+  keys, setup paths, migrations, and examples need enough documentation for the
+  intended user to use or maintain them without reading private implementation
+  code first.
+- **Location**: Put documentation where the target audience will look: public
+  API comments near exported identifiers, command behavior in help or README
+  docs, setup and operator guidance in project docs, and examples near the
+  documented entrypoint.
+- **Examples**: Examples and commands should be copy-paste-ready when practical,
+  aligned with real entrypoints, and kept current with flags, config keys,
+  package names, imports, outputs, and validation constraints.
+- **Public API comments and docstrings**: Explain exported behavior, contracts,
+  nil or error behavior, compatibility constraints, side effects, deprecations,
+  and security or operational requirements when those are not obvious from the
+  signature. Do not demand comments that merely restate obvious code.
+- **Code comments**: Explain non-obvious intent, invariants, tradeoffs,
+  bug-workaround context, copied-code sources, or surprising behavior. If a
+  clear comment cannot be written because the code itself is confused, recommend
+  `$code-issues`.
+- **Terminology**: Use the same names for concepts, commands, config keys, API
+  fields, and roles across docs, code, examples, and tests. Use
+  `$naming-standards` when unclear terminology creates misuse or maintenance
+  risk.
+- **Audience**: Keep startup docs concise, current, and structured with headings
+  and links to deeper docs. Do not bury critical setup, security, migration, or
+  operational instructions in unrelated comments or long prose.
+
+## Finding Threshold
+
+Treat a documentation concern as a finding only when it creates credible risk
+to users, operators, maintainers, public API consumers, documented command
+behavior, onboarding, setup, contribution workflows, security expectations, or
+compatibility. Do not report arbitrary wording preferences, style nits,
+exhaustive private implementation comments, or optional documentation polish as
+findings.
+
+When the confirmed problem is broken behavior, a security issue, a compatibility
+break, or a violated public contract, report it through `$code-review`,
+`$code-issues`, or `$security-audit` instead of treating it as a documentation
+gap. When the confirmed problem is missing or weak test coverage, use
+`$testing-standards` or `$test-gaps`.
+
+## Review Scope
+
+- `$code-review` and `$review-pr`: changed docs plus directly affected nearby
+  docs.
+- `$doc-gaps`: the requested package or folder, recursively, using that skill's
+  ledger and delegation rules.
+- Direct user request: the scope the user named. If no scope is clear and the
+  decision affects edit size or review cost, ask for the intended documentation
+  surface before auditing broadly.

--- a/skills/docs-standards/agents/openai.yaml
+++ b/skills/docs-standards/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Docs Standards"
+  short_description: "Review documentation quality"
+  default_prompt: "Use $docs-standards when reviewing changed docs, examples, README content, public API comments, or behavior changes that may make documentation stale."

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -23,6 +23,7 @@ These rules remain mandatory:
 - Make the remote-write behavior of `make review` explicit before running it: the target commits, force-pushes, and opens a draft PR.
 - Use `$change-validation` to select and run credible validation for the full change before `make review`; language-specific standards may refine that validation.
 - Use the relevant language standards for changed Go, Ruby, shell, and test paths.
+- Use `$docs-standards` for changed README files, user-facing docs, examples, command/config docs, public API comments, docstrings, or behavior changes that may make nearby existing documentation stale.
 - Use `$code-review` to inspect the current change before drafting PR text.
 - If the user explicitly asks for style nits, polish, readability review, or non-blocking cleanup comments before the PR, also use `$style-review` after the code-review pass.
 - Resolve any blocking review findings before continuing. Do not run `make review` while blocking findings remain unless the human explicitly says to open a draft PR with those findings unresolved; in that case, call them out in the PR summary.
@@ -52,6 +53,7 @@ make msg="unprefixed subject" desc_file="$desc_file" review
 - Read `references/summary-format.md` before drafting the `msg` value and PR summary content.
 - Read `references/output-format.md` before producing the final review PR report.
 - Use `$project-workflow` for repository command discovery, CI expectations, and `./bin` wiring before validation and `make review`.
+- Use `$docs-standards` for review-time documentation judgment; use `$doc-gaps` only when the user explicitly asks for a scoped documentation audit.
 - Use `$style-review` only when the user explicitly asks for non-blocking polish before the PR.
 
 ## Notes

--- a/skills/review-pr/agents/openai.yaml
+++ b/skills/review-pr/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Review PR"
   short_description: "Prepare an approved review PR flow"
-  default_prompt: "Use $review-pr with its active goal and plan when I explicitly ask to commit, push, and open or update a review PR."
+  default_prompt: "Use $review-pr with its active goal and plan when I explicitly ask to commit, push, and open or update a review PR; include review-time documentation judgment through $docs-standards."

--- a/skills/review-pr/references/plan.md
+++ b/skills/review-pr/references/plan.md
@@ -43,7 +43,8 @@ repository root and keep `bin/` as shared guidance.
    force-pushes, and opens a draft PR.
 6. Select and run credible validation for the full change with
    `$change-validation`.
-7. Apply relevant language and test standards for the changed paths.
+7. Apply relevant language, test, and documentation standards for the changed
+   paths.
 8. Run `$code-review` on the current change.
 9. Run `$style-review` only when the human explicitly asked for non-blocking
    polish.


### PR DESCRIPTION
## What

- Added `$docs-standards` as a lightweight documentation-review standard for README files, docs, examples, command/config docs, public API comments, docstrings, and stale-doc checks.
- Wired `$code-review` and `$review-pr` to use `$docs-standards` for current-change documentation judgment while keeping `$doc-gaps` as the scoped `ISSUES.md` ledger workflow.
- Updated shared skill indexes, plan references, and OpenAI skill metadata so the new composition is discoverable.

## Why

- Helps PR review catch documentation made stale by a change without automatically invoking a package-wide `$doc-gaps` audit.
- Keeps full documentation gap discovery explicit, scoped, and reusable through `$doc-gaps`.

## Testing

- `zsh -lic 'make skills-lint'` - passed
- `git diff --check` - passed
- `ruby -e 'require "yaml"; ...'` - passed
- Validation gap: `quick_validate.py` could not run because this local Python environment is missing PyYAML; the repository skill lint and Ruby YAML/frontmatter parse passed.
