### PR TITLE
feat(go): scope specs by package

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ After repeating the same build/lint/test/CI glue across projects, it’s useful 
 |-----------------|------------------------------------------------------------------------------------|
 | `build/make/`   | Makefile include fragments (Go, Ruby, git workflow, buf/proto, project templates). |
 | `build/git/`    | Git workflow helper scripts used by `build/make/git.mak`.                          |
-| `build/go/`     | Go-related helper scripts (`lint`, `clean`, `fa`).                                 |
+| `build/go/`     | Go-related helper scripts (`lint`, `clean`, `fa`, `test`).                         |
 | `build/docker/` | Docker helpers and `build/docker/go/Dockerfile`.                                   |
 | `build/sec/`    | Security scanning helpers (Trivy).                                                 |
 | `quality/`      | Quality/test helpers (Go coverage processing, cucumber wrappers).                  |
@@ -96,7 +96,7 @@ This gives you targets like:
 
 - `make dep` (download/tidy/vendor)
 - `make lint` / `make fix-lint` / `make format`
-- `make specs` (gotestsum + race + coverage written under `test/reports/`)
+- `make specs` (gotestsum + race + coverage written under `test/reports/`; set `package=<path>` to test one package)
 - `make coverage` (HTML + func coverage from `test/reports/final.cov`)
 - `make sec` (govulncheck + Trivy repo scan)
 

--- a/build/go/test
+++ b/build/go/test
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091
+# Run Go tests with gotestsum, optionally limited to package.
+
+set -eo pipefail
+
+cover_packages="$1"
+shift
+
+packages=("$@")
+
+if [[ -n ${package:-} ]]; then
+  export package
+
+  source "$(dirname "$0")/../../lib/validate.sh"
+  validate_package
+
+  packages=("$(go list "./$package")")
+  cover_packages="${packages[0]}"
+fi
+
+gotestsum --format testdox --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg="$cover_packages" -coverprofile=test/reports/profile.cov "${packages[@]}"

--- a/build/make/_service.mak
+++ b/build/make/_service.mak
@@ -106,8 +106,9 @@ benchmarks: build
 	@make -C test benchmarks
 
 # Run Go tests with gotestsum (race + coverage) and write reports under test/reports/.
+# Set package=<path> to test one package.
 specs:
-	@gotestsum --format testdox --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
+	@$(BIN_ROOT)/build/go/test "$(if $(package),,$(COVER_PACKAGES))" $(if $(package),,$(PACKAGES))
 
 # Fetch a Go module (set module=<path>).
 go-get:

--- a/build/make/go.mak
+++ b/build/make/go.mak
@@ -77,8 +77,9 @@ format:
 	@go fmt ./...
 
 # Run tests with gotestsum (race + coverage) and write reports under test/reports/.
+# Set package=<path> to test one package.
 specs:
-	@gotestsum --format testdox --junitfile test/reports/specs.xml -- -vet=off -race -mod vendor -covermode=atomic -coverpkg=$(COVER_PACKAGES) -coverprofile=test/reports/profile.cov $(PACKAGES)
+	@$(BIN_ROOT)/build/go/test "$(if $(package),,$(COVER_PACKAGES))" $(if $(package),,$(PACKAGES))
 
 # Run benchmarks for package=$(package), or the module root when unset.
 # Set benchtime=<duration-or-count> to pass -benchtime to go test.


### PR DESCRIPTION
## What

- Let `make specs package=<path>` run only the requested Go package while keeping the default unfiltered `make specs` behavior.
- Route the Go and service Make fragments through a shared `build/go/test` helper that preserves the existing gotestsum, race, vendor, JUnit, and coverage report options.
- Document the package-scoped specs option in the README alongside the existing Go project target list.

## Why

- Downstream projects can run fast package-level specs without paying the cost of the full package list when iterating on a focused change.
- Keeping the unfiltered path intact preserves existing CI and local workflows while giving maintainers a narrower opt-in command.

## Testing

- `make dep` - passed
- `make scripts-lint` - passed
- `make skills-lint` - passed
- `make docker-lint` - passed
- `make lint` - passed
- `make sec` - passed
- `git diff --check` - passed
- `make -f /Users/alejandro/code/bin/build/make/go.mak specs package=errors` in `/Users/alejandro/code/go-service` - passed
- `make -f /Users/alejandro/code/bin/build/make/go.mak specs package=health/checker` in `/Users/alejandro/code/go-service` - passed
- `make -f /Users/alejandro/code/bin/build/make/go.mak specs` in `/Users/alejandro/code/go-service` - passed, 1933 tests
