### PR TITLE
feat(skills): add emoji readme heading guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 [![CircleCI](https://circleci.com/gh/alexfalkowski/bin.svg?style=shield)](https://circleci.com/gh/alexfalkowski/bin)
 [![Stability: Active](https://masterminds.github.io/stability/active.svg)](https://masterminds.github.io/stability/active.html)
 
-# bin
+# 🧰 bin
 
 Shared executables, Makefile includes, and agent skills for projects that use
 this repository as a Git submodule at `./bin`.
 
-## Why This Exists
+## 🎯 Why This Exists
 
 The projects that use this repository share the same build, lint, test,
 security, Docker, release, and agent-workflow glue. Keeping that glue here makes
 the consuming repositories smaller while giving them one supported integration
 path.
 
-## Install Or Bootstrap
+## 🚀 Install Or Bootstrap
 
 Add this repository as the downstream project's `bin` submodule:
 
@@ -30,7 +30,7 @@ git submodule update --init
 git submodule update --init
 ```
 
-## Usage
+## 💻 Usage
 
 Include only the Make fragments your project needs. The fragments derive helper
 paths from their own location, so downstream includes work when this repository
@@ -58,7 +58,7 @@ Projects that use the shared git workflow can include it separately:
 include bin/build/make/git.mak
 ```
 
-## Agent Skills
+## 🤖 Agent Skills
 
 This repository also ships shared agent guidance in `skills/`. Downstream
 repositories should point agents at the shared instructions instead of copying
@@ -75,7 +75,7 @@ matching skill for the task.
 Update `AGENTS.md` when the shared skill set, composition rules, or repository
 workflow guidance changes.
 
-## Operations
+## 🛠️ Operations
 
 This repository is shared tooling. Changes can affect every downstream project
 that vendors it, so prefer small compatible changes and validate through the
@@ -87,7 +87,7 @@ version files; security helpers assume Trivy is available; shell and Dockerfile
 lint targets depend on `shellcheck` and `hadolint`; `build/docker/env` needs SSH
 access to clone or update the sibling `../docker` repository when it is missing.
 
-## References
+## 🔗 References
 
 - `make` or `make help`: current command catalog for this repository.
 - `build/make/*.mak`: reusable Makefile fragments for downstream projects.

--- a/skills/doc-standards/SKILL.md
+++ b/skills/doc-standards/SKILL.md
@@ -126,43 +126,48 @@ inventory of the repository. Prefer content that helps a new user, service
 owner, operator, or contributor decide what the project is, when to use it, and
 how to exercise its public surface.
 
+README headings should use a short, relevant emoji prefix to make the document
+easier to scan and add visual colour. Use one emoji per heading, keep the
+heading text clear without relying on the emoji for meaning, and preserve a
+stronger local heading convention when one already exists.
+
 Use this default README shape unless the repository already has a stronger
 local convention:
 
 ```markdown
-# <Project Name>
+# 📦 <Project Name>
 
 <One or two sentences explaining what this project does and who should use it.>
 
-## Why This Exists
+## 🎯 Why This Exists
 
 <The problem it solves, the boundary it owns, and the tradeoff or design choice
 that helps users decide whether it fits.>
 
-## Install Or Bootstrap
+## 🚀 Install Or Bootstrap
 
 <Only the commands required before the first useful command can run, such as
 package installation, submodule initialization, dependency setup, or required
 runtime assets.>
 
-## Usage
+## 💻 Usage
 
 <A minimal, copy-paste-ready example through the main public API, CLI, service
 endpoint, package import, or configuration path.>
 
-## Configuration
+## 🔧 Configuration
 
 <Only the configuration users must understand to run or integrate the project.
 Link to schema, examples, generated docs, or sample config when exhaustive
 field documentation belongs there.>
 
-## Operations
+## 🛠️ Operations
 
 <Security, deployment, compatibility, data freshness, health, migration,
 shutdown, or observability notes that affect real use. Omit this section when
 the project has no operator-facing behavior.>
 
-## References
+## 🔗 References
 
 <Links to generated API docs, protobuf contracts, examples, changelog, package
 docs, or deeper design notes.>

--- a/skills/doc-standards/agents/openai.yaml
+++ b/skills/doc-standards/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Doc Standards"
-  short_description: "Review concise docs and useful comments"
-  default_prompt: "Use $doc-standards when reviewing changed docs, examples, README content, public API comments, code comments, docstrings, or behavior changes that may make documentation stale; keep READMEs concise, avoid duplicating command catalogs or CI config, and reject comments that merely repeat the code."
+  short_description: "Review concise docs and emoji README headings"
+  default_prompt: "Use $doc-standards when reviewing changed docs, examples, README content, public API comments, code comments, docstrings, or behavior changes that may make documentation stale; keep READMEs concise with emoji-prefixed headings, avoid duplicating command catalogs or CI config, and reject comments that merely repeat the code."


### PR DESCRIPTION
## What

- Add README heading guidance to `$doc-standards` requiring a short relevant emoji prefix while preserving stronger local conventions.
- Update the default README template and OpenAI skill metadata so agents see the new heading expectation.
- Apply the guidance to the root README headings without expanding the repository command catalog.

## Why

- Makes the shared documentation standard and this repository README align on scannable, more visually distinct README structure.
- Keeps downstream guidance concise and avoids copy/paste drift between the skill rule, template, and root README.

## Testing

- `make dep` - passed
- `make skills-lint` - passed
- `make lint` - passed
- `make scripts-lint` - passed
- `make docker-lint` - passed
- `make sec` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
