### PR TITLE
feat(go): target lint runs by package

### DIFF
--- a/build/go/lint
+++ b/build/go/lint
@@ -1,8 +1,22 @@
 #!/usr/bin/env bash
-# Run golangci-lint only when it is installed in PATH.
+# shellcheck disable=SC1091
+# Run golangci-lint only when it is installed in PATH, optionally limited to package.
 
 set -eo pipefail
 
-if command -v golangci-lint >/dev/null 2>&1; then
-  golangci-lint "$@"
+if ! command -v golangci-lint >/dev/null 2>&1; then
+  exit 0
 fi
+
+args=("$@")
+
+if [[ ${args[0]:-} == "run" && -n ${package:-} ]]; then
+  export package
+
+  source "$(dirname "$0")/../../lib/validate.sh"
+  validate_package
+
+  args+=("./$package")
+fi
+
+golangci-lint "${args[@]}"

--- a/build/make/_service.mak
+++ b/build/make/_service.mak
@@ -32,9 +32,11 @@ field-alignment:
 fix-field-alignment:
 	@$(BIN_ROOT)/build/go/fa -fix
 
+# Run golangci-lint with build-tags=features. Set package=<path> to lint one package.
 golangci-lint:
 	@$(BIN_ROOT)/build/go/lint run --build-tags features  --timeout 5m
 
+# Auto-fix golangci-lint issues with build-tags=features. Set package=<path> to lint one package.
 fix-golangci-lint:
 	@$(BIN_ROOT)/build/go/lint run --build-tags features --timeout 5m --fix
 

--- a/build/make/go.mak
+++ b/build/make/go.mak
@@ -60,9 +60,11 @@ field-alignment:
 fix-field-alignment:
 	@$(BIN_ROOT)/build/go/fa -fix
 
+# Run golangci-lint. Set package=<path> to lint one package.
 golangci-lint:
 	@$(BIN_ROOT)/build/go/lint run --timeout 5m
 
+# Auto-fix golangci-lint issues. Set package=<path> to lint one package.
 fix-golangci-lint:
 	@$(BIN_ROOT)/build/go/lint run --timeout 5m --fix
 


### PR DESCRIPTION
## What

- Let `build/go/lint` append a validated `./$package` argument for `golangci-lint run`.
- Keep other golangci-lint subcommands, including cache cleanup, unchanged when `package` is set.
- Document `package=<path>` on standalone and service golangci-lint make targets.

## Why

- Downstream repositories can run faster targeted package lint checks while preserving existing full-repo behavior when `package` is unset.
- Reusing the existing package validator keeps the lint command aligned with other package-scoped tooling.

## Testing

- `make dep` - passed
- `make scripts-lint` - passed
- `make lint` - passed
- `make sec` - passed
- `make skills-lint` - passed
- `make docker-lint` - passed
- `bash -n build/go/lint` - passed
- `git diff --check` - passed
- `zsh -lic 'BIN_ROOT=/Users/alejandro/code/bin make package=env golangci-lint'` - passed
- No validation gaps identified.

AI-assisted-by: [Codex](https://openai.com/codex/)
