### PR TITLE
feat(skills): tighten documentation gap workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ skill instead of one broad default:
 - `security-audit`: security reviews, vulnerability checks, unsafe shell/filesystem/network/auth inspection, and Go/Ruby/shell audit guidance.
 - `code-issues`: find confirmed code issues into `ISSUES.md`, then implement agreed fixes one code issue at a time.
 - `test-gaps`: find confirmed missing or weak tests into `ISSUES.md`, then implement agreed test fixes gap by gap.
-- `doc-gaps`: find confirmed missing, stale, or misleading docs/comments into `ISSUES.md`, then implement agreed doc fixes gap by gap.
+- `doc-gaps`: find and fix confirmed missing, stale, or misleading docs/comments in one pass, using `ISSUES.md` only for audit-only requests or unresolved gaps.
 - `reliability-standards`: SRE, NALSD, production-readiness, SLO, overload,
   observability, release-safety, recovery, and operability guidance.
 - `reliability-gaps`: find confirmed reliability gaps into `ISSUES.md`, then
@@ -124,10 +124,11 @@ Common composition:
 - `test-gaps` orchestrates a two-phase test-gap workflow: aggregate confirmed
   `project-workflow` context and missing or weak test coverage into
   `ISSUES.md`, then implement agreed test fixes gap by gap.
-- `doc-gaps` orchestrates a two-phase doc-gap workflow: aggregate
-  confirmed `project-workflow` context and `$doc-standards` findings for
-  missing, stale, or misleading README, docs, examples, comments, and docstrings
-  into `ISSUES.md`, then implement agreed doc fixes gap by gap.
+- `doc-gaps` orchestrates a one-pass doc-gap workflow: aggregate confirmed
+  `project-workflow` context and `$doc-standards` findings for missing, stale,
+  or misleading README, docs, examples, comments, and docstrings, implement
+  confirmed documentation fixes, validate them, and use `ISSUES.md` only for
+  audit-only requests or unresolved gaps.
 - `reliability-gaps` orchestrates a two-phase reliability-gap workflow:
   aggregate confirmed `project-workflow` context and SRE, NALSD, operability,
   overload, observability, release-safety, recovery, or data-integrity gaps into

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Projects that use the shared git workflow can include it separately:
 include bin/build/make/git.mak
 ```
 
+Consuming repositories choose which fragments to include and remain responsible
+for project-specific configuration such as service code, image names, release
+version files, and environment-specific settings.
+
 ## 🤖 Agent Skills
 
 This repository also ships shared agent guidance in `skills/`. Downstream

--- a/skills/README.md
+++ b/skills/README.md
@@ -24,10 +24,11 @@ specific rule or local pattern, and ask for approval to deviate.
 - `test-gaps` orchestrates a two-phase test-gap workflow: first aggregate
   `project-workflow` context and confirmed missing or weak test coverage into
   `ISSUES.md`, then implement agreed test fixes one gap at a time.
-- `doc-gaps` orchestrates a two-phase doc-gap workflow: first
-  aggregate `project-workflow` context and confirmed `$doc-standards` findings
-  for README, docs, examples, comments, and docstring gaps into `ISSUES.md`,
-  then implement agreed doc fixes one gap at a time.
+- `doc-gaps` orchestrates a one-pass doc-gap workflow: aggregate
+  `project-workflow` context and confirmed `$doc-standards` findings for
+  README, docs, examples, comments, and docstring gaps, implement confirmed
+  documentation fixes, validate them, and use `ISSUES.md` only for audit-only
+  requests or unresolved gaps.
 - `reliability-gaps` orchestrates a two-phase reliability-gap workflow: first
   aggregate `project-workflow` context and verified SRE, NALSD, operability,
   overload, observability, release-safety, recovery, or data-integrity gaps into

--- a/skills/doc-gaps/SKILL.md
+++ b/skills/doc-gaps/SKILL.md
@@ -1,69 +1,91 @@
 ---
 name: doc-gaps
-description: Finds concrete missing, weak, stale, or misleading documentation in a package or folder, including README files, user-facing docs, examples, and code comments/docstrings required by $doc-standards and relevant language standards, records confirmed gaps in that scope's ISSUES.md, and later proposes and implements explicitly agreed doc fixes gap by gap. Use when the user asks to find $doc-gaps in a package or folder, find doc gaps in a package or folder, implement $doc-gaps in a package or folder, or implement doc gaps in a package or folder.
+description: Finds and fixes concrete missing, weak, stale, or misleading documentation in a package or folder in one pass, including README files, user-facing docs, examples, command help, package docs, public API comments, code comments, and docstrings required by $doc-standards and relevant language standards. Uses parallel review agents when available, applies confirmed documentation fixes, validates the changes, and writes ISSUES.md only for audit-only requests or unresolved gaps. Use when the user asks to run $doc-gaps in a package or folder, find doc gaps in a package or folder, fix doc gaps in a package or folder, review docs for gaps, or audit-only doc gaps.
 ---
 
 # Doc Gaps
 
-Use this skill in two distinct modes:
+Use this skill in one-pass mode by default:
 
-- **Find mode**: `Find $doc-gaps in <package/folder>` or `Find doc gaps in <package/folder>`.
-- **Implement mode**: `Implement $doc-gaps in <package/folder>` or `Implement doc gaps in <package/folder>`.
+- **One-pass mode**: `Run $doc-gaps in <package/folder>`, `Find doc gaps in <package/folder>`, or `Fix doc gaps in <package/folder>`.
+- **Audit-only mode**: `Audit-only $doc-gaps in <package/folder>` or `Find doc gaps in <package/folder> without editing`.
 
-Do not combine the two modes in one pass.
-
-Before starting Find mode or Implement mode, read `references/plan.md` and use
-it to maintain the active execution plan. The active plan is runtime state; do
-not write it into the repository unless the human explicitly asks for a durable
-plan file.
+Before starting one-pass mode or audit-only mode, read `references/plan.md` and
+use it to maintain the active execution plan. The active plan is runtime state;
+do not write it into the repository unless the human explicitly asks for a
+durable plan file.
 When the runtime supports goals, bind the selected mode and requested scope to
-one active goal and update that goal as ledger, proposal, approval, validation,
-or human-confirmation state changes.
+one active goal and update that goal as delegation, edit, validation, summary,
+or unresolved-ledger state changes.
 
 ## Operating Stance
 
-Operate as a scoped documentation ledger manager: use `$doc-standards` for
-documentation quality judgment, and use this skill for scope control,
-delegation, `ISSUES.md` recording, and gap-by-gap implementation.
+Operate as a scoped documentation maintainer: use `$doc-standards` for
+documentation quality judgment, use this skill for scope control and
+delegation, and fix confirmed documentation gaps in the same pass unless a stop
+gate requires human input.
 
-## Find Mode
+## One-Pass Mode
 
-Follow `references/plan.md#find-mode-plan`.
+Follow `references/plan.md#one-pass-mode-plan`.
 
 These rules remain mandatory:
 
 - If no scope is provided, stop and ask for the package or folder.
-- Use `ISSUES.md` in the requested package or folder as the review ledger, for example `<package/folder>/ISSUES.md`.
-- If `ISSUES.md` already exists in the requested package or folder, stop. Tell the user the existing scoped ledger must be resolved first, or the human must delete that scoped `ISSUES.md` before a new find pass there.
-- Treat `Find $doc-gaps in <package/folder>` or `Find doc gaps in <package/folder>` as the user's explicit request to delegate documentation review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
-- Use sub-agents for Find mode whenever the active runtime provides them and the runtime permits delegation for the request. Do not treat sub-agents as optional based on scope size, and do not perform the doc-gap review locally first.
-- Do not claim that extra delegation wording is needed before launching review agents. The Find mode invocation is the explicit delegation request.
+- Treat `Run $doc-gaps in <package/folder>`, `Find doc gaps in <package/folder>`, or `Fix doc gaps in <package/folder>` as permission to delegate review, edit documentation in scope, run appropriate validation, and summarize the result in one pass.
+- Use audit-only mode only when the user explicitly asks not to edit or asks only for an audit or ledger. When a stop gate prevents a correct documentation fix during one-pass mode, record unresolved confirmed findings instead of switching modes.
+- If scoped `ISSUES.md` already exists, read it before reviewing. If it is a doc-gap ledger, include unresolved findings in the candidate set and update or delete the ledger after fixing them. If it is unrelated or ambiguous active work, stop and ask before editing it.
+- Use as many independent review agents as the runtime can safely run when the active runtime provides sub-agents and permits delegation for the request. Do not perform the doc-gap review locally first when delegation is available.
+- Treat the doc-gap invocation as the user's explicit request to delegate documentation review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
 - If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
 - Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, or other non-read-only validation.
 - Exclude generated files and folders, vendored dependencies, caches, build output, generated API docs, and generated lockfile churn unless the requested scope is explicitly about them.
-- Each subpackage/subfolder agent owns recursive review of the rest of that subtree. Each agent must perform a thorough documentation review for its assigned scope, pairing with `$doc-standards`, relevant language standards, `$naming-standards` when terminology is unclear or inconsistent, and `$change-validation` for likely validation commands.
-- Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
+- Assign review agents by root documentation surfaces and first-level subfolders when possible. Each subpackage/subfolder agent owns recursive review of the rest of that subtree.
+- Each agent must perform a thorough documentation review for its assigned scope, pairing with `$doc-standards`, relevant language standards, `$naming-standards` when terminology is unclear or inconsistent, and `$change-validation` for likely validation commands.
+- Each agent must audit the relevant documentation surfaces before returning candidates: README files, docs, examples, command help, package documentation, exported API comments, code comments, and docstrings. For each candidate, identify the intended audience, the user action or maintenance decision at risk, the existing documentation surface, the correct target surface, and any missing non-obvious contract required by `$doc-standards`.
+- Require each agent to return candidates in the candidate format below, without final IDs unless useful locally.
 - Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity.
-- Confirm each candidate gap against the code, current docs, examples, and documented interfaces before recording it, using `$doc-standards` as the finding threshold.
-- Do not record candidates that `$doc-standards` routes to `$code-review`, `$code-issues`, `$security-audit`, `$testing-standards`, or `$test-gaps`.
-- List optional documentation polish only as optional follow-up notes when relevant.
+- Confirm each candidate gap against the code, current docs, examples, and documented interfaces before fixing it, using `$doc-standards` as the finding threshold.
+- Before fixing or dismissing a candidate, route it to the correct documentation surface: README, docs, examples, command help, package documentation, exported API comment, code comment, docstring, or no change. Do not treat package GoDoc or code-comment improvements as sufficient when first-use, setup, configuration, operational behavior, security expectations, or service-author workflows would reasonably be expected in README files, user-facing docs, examples, or command help.
+- When dismissing a candidate because existing documentation is sufficient, identify the existing surface that covers the audience and action at risk in the final summary.
+- Do not fix candidates that `$doc-standards` routes to `$code-review`, `$code-issues`, `$security-audit`, `$testing-standards`, or `$test-gaps`. Report those as out of scope when relevant.
+- Before editing in one-pass mode, state the selected local documentation pattern, dominant relevant validation path, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
+- For unresolved-ledger fixes or any case where human approval is still required: After the human agrees and before editing, state the selected local documentation pattern, dominant relevant validation path, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
+- Implement confirmed doc gaps with the smallest clear documentation change using the established documentation location and style.
+- Stop and ask before editing when behavior, audience, documentation location, public-contract wording, examples, validation, or user intent is ambiguous enough that a correct documentation change cannot be inferred from local context.
+- Write unresolved confirmed findings to the scoped `ISSUES.md` only when they cannot be fixed in the same pass, the user requested audit-only mode, validation or permission is blocked, or the scope is too large to complete.
+- Validate documentation changes with commands appropriate to the changed files.
 - If no confirmed doc gaps are found, report that no doc gaps were found and do not create `ISSUES.md`.
-- If confirmed doc gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
-- Assign every finding a unique ID for the session in the form `DOC-<number>`.
-- Stop after presenting the ledger and plan. Do not fix findings in the same pass.
+- If all confirmed doc gaps are fixed, do not leave a new `ISSUES.md` behind. If an existing doc-gap ledger is fully resolved, delete it.
+- Final output must summarize fixed gaps, dismissed or out-of-scope candidates when relevant, unresolved findings written to `ISSUES.md` if any, and validation results.
+
+## Audit-Only Mode
+
+Follow `references/plan.md#audit-only-mode-plan`.
+
+These rules remain mandatory:
+
+- If no scope is provided, stop and ask for the package or folder.
+- Use `ISSUES.md` in the requested package or folder as the audit ledger, for example `<package/folder>/ISSUES.md`.
+- If `ISSUES.md` already exists in the requested package or folder, stop unless the human explicitly asked to refresh or overwrite that scoped ledger.
+- Use the same delegation, surface-routing, candidate confirmation, severity, and out-of-scope rules as one-pass mode.
+- If no confirmed doc gaps are found, report that no doc gaps were found and do not create `ISSUES.md`.
+- If confirmed doc gaps are found, write all findings to the scoped `ISSUES.md` with `DOC-<number>` IDs.
+- Stop after presenting the audit ledger. Do not make fixes in audit-only mode.
 
 ## Documentation Review Standards
 
 Use `$doc-standards` to decide whether a documentation concern is concrete
-enough to record. Use the relevant language standards for code comments,
-docstrings, public API docs, and language-specific examples before recording
-findings. Keep GoDoc details in `$go-standards`, RDoc details in
+enough to fix or record. Use the relevant language standards for code comments,
+docstrings, public API docs, and language-specific examples before fixing or
+recording findings. Keep GoDoc details in `$go-standards`, RDoc details in
 `$ruby-standards`, and shell script/function comment rules in
 `$shell-standards`.
 
-## `ISSUES.md` Format
+## Candidate And `ISSUES.md` Format
 
-Use this structure:
+Use this structure for review candidates and unresolved or audit-only ledger
+entries:
 
 ```markdown
 # Issues
@@ -73,6 +95,11 @@ Use this structure:
 - Type: Doc Gap
 - Severity: Critical|High|Medium|Low
 - Scope: path/to/file-or-folder
+- Audience: Service author|Operator|Package consumer|Maintainer
+- User action at risk: Concrete action or decision the reader cannot safely complete from current docs.
+- Current surface: Existing README/docs/examples/command help/package docs/API comments/code comments coverage, or "missing".
+- Target surface: README|docs|example|command help|package docs|API comment|code comment|docstring.
+- Missing contract: Behavior/purpose|error/panic/nil/empty/zero-value|side effect/lifecycle/cleanup|concurrency/cache/retry/timeout/cancellation/idempotency|config default/limit/validation/fallback|security/operations/compatibility/data-loss|alias/wrapper/re-export/dependency boundary|none.
 - Impact: Risk created by the missing, weak, stale, misleading, or wrong-location documentation.
 - Evidence: Concrete file and line references, command/API behavior, existing docs, examples, or comment/docstring gap.
 - Proposed fix: Brief documentation direction using the established documentation location and style.
@@ -87,28 +114,9 @@ Keep optional follow-up notes separate from findings:
 - Optional or non-blocking note.
 ```
 
-## Implement Mode
-
-Follow `references/plan.md#implement-mode-plan`.
-
-These rules remain mandatory:
-
-- If no scope is provided, stop and ask for the package or folder.
-- Read `ISSUES.md` in the requested package or folder first and treat it as the working doc-gap ledger.
-- If scoped `ISSUES.md` does not exist, stop and ask whether to run Find mode first for that scope.
-- Work through findings sequentially by ID unless the human explicitly names a different finding.
-- Stop after proposing the solution. Do not edit files, update `ISSUES.md`, or start validation until the human explicitly agrees to that finding's solution.
-- Ask questions when behavior, audience, documentation location, public-contract wording, examples, validation, or user intent is ambiguous. Treat silence or a broad "implement doc gaps" request as permission to start the proposal workflow, not as permission to edit.
-- After the human agrees and before editing, state the selected local documentation pattern, dominant relevant validation path, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
-- Implement only the agreed finding with the smallest clear documentation change.
-- Use `$doc-standards` and relevant language standards for code comments and API docs. Use `$change-safety` when documentation changes public API, command, migration, or compatibility expectations.
-- Do not move to the next finding until the human says `DOC-<number> is done`.
-- After the human confirms a finding is done, remove that finding from scoped `ISSUES.md`. If a finding is deemed invalid or not actually a doc gap, remove it only after explaining why and getting human agreement.
-- Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
-
 ## References
 
-- Read `references/plan.md` before starting Find mode or Implement mode.
+- Read `references/plan.md` before starting one-pass mode or audit-only mode.
 - Use `$doc-standards` as the documentation quality bar and routing threshold.
 - Use `../references/finding-severity.md` for confidence filtering and severity.
 - Use `$project-workflow` for repository command discovery, documented entrypoints, CI expectations, examples, and `./bin` wiring before review planning or validation.

--- a/skills/doc-gaps/agents/openai.yaml
+++ b/skills/doc-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Doc Gaps"
-  short_description: "Find scoped documentation gaps"
-  default_prompt: "Use $doc-gaps with its active goal and plan plus $doc-standards to find scoped missing, weak, stale, misleading, or terminology-confusing docs and comments, store confirmed gaps in ISSUES.md, or implement agreed doc fixes one gap at a time."
+  short_description: "Find and fix scoped documentation gaps"
+  default_prompt: "Use $doc-gaps with its active goal and plan plus $doc-standards to run a one-pass scoped documentation gap workflow: delegate review broadly, route each gap to the right documentation surface, identify missing non-obvious contracts, apply confirmed doc fixes, validate, and write ISSUES.md only for audit-only requests or unresolved gaps."

--- a/skills/doc-gaps/references/plan.md
+++ b/skills/doc-gaps/references/plan.md
@@ -12,79 +12,82 @@ repository root and keep `bin/` as shared guidance.
 - Preserve stop gates as plan boundaries; do not continue past a stop gate based
   on silence or a broad request.
 - Update the active plan when scope, documentation location, validation,
-  delegation, or ledger state changes.
+  delegation, edits, summary, or unresolved ledger state changes.
 - Treat validation as stale when files change after a command ran.
-- Record durable findings only in the scoped `ISSUES.md` ledger defined by the
-  skill.
+- Use a scoped `ISSUES.md` ledger only for audit-only mode, unresolved confirmed
+  gaps, or an existing doc-gap ledger being completed.
 
 ## Goal State Rules
 
 - Bind the active goal to the selected mode and requested scope.
-- In Find mode, the goal is complete when no confirmed doc gaps are found and
-  reported, or when the scoped `ISSUES.md` ledger is written and presented.
-- In Implement mode, the goal is waiting while the human has not approved the
-  proposed doc-gap solution, or after validation until the human confirms
-  `DOC-<number> is done`.
-- In Implement mode, the goal is complete for a finding only after the human
-  confirms it is done and the scoped ledger is updated accordingly.
-- Record a blocked reason when a required scope is missing, the scoped ledger
-  required by the mode is absent or already exists in a conflicting state,
-  required permission is denied, or the selected finding cannot be re-checked
-  without human input. Follow runtime rules for when that reason changes goal
-  status.
+- In one-pass mode, the goal is complete when confirmed gaps are fixed and
+  validated, no confirmed gaps are found and reported, or unresolved findings
+  are recorded because a stop gate prevents a correct fix.
+- In audit-only mode, the goal is complete when no confirmed doc gaps are found
+  and reported, or when the scoped `ISSUES.md` ledger is written and presented.
+- Record a blocked reason when a required scope is missing, required permission
+  is denied, an existing scoped ledger is unrelated or ambiguous, or a selected
+  finding cannot be fixed or recorded without human input. Follow runtime rules
+  for when that reason changes goal status.
 
-## Find Mode Plan
+## One-Pass Mode Plan
 
 1. Confirm the requested package or folder scope.
-2. Check whether scoped `ISSUES.md` already exists and stop if it does.
+2. If scoped `ISSUES.md` exists, read it. Incorporate doc-gap ledger findings,
+   or stop if the file is unrelated or ambiguous active work.
 3. Run `$project-workflow` discovery for entrypoints, CI, documented commands,
    public APIs, examples, and `./bin` wiring.
-4. Identify existing documentation locations, examples, comments, docstrings,
-   `$doc-standards`, and language-specific documentation standards for the
-   requested scope.
-5. Build the read-only documentation review delegation plan from the requested
-   root and its first-level subfolders.
+4. Identify existing documentation locations, examples, command help, package
+   documentation, comments, docstrings, `$doc-standards`, and
+   language-specific documentation standards for the requested scope.
+5. Build the read-only documentation review delegation plan from root docs,
+   README files, and first-level subfolders; use as many independent review
+   agents as the runtime can safely run.
 6. Ask for required permission before any agent runs non-read-only, network,
    auth, remote-write, or otherwise approval-gated commands.
 7. Launch the required review agents when available, or perform the local
    fallback only when sub-agents are unavailable.
 8. Wait for all review work to finish.
 9. Deduplicate candidates and directly re-check conflicting or overlapping
-   conclusions against code, docs, examples, and public interfaces.
-10. Confirm each finding is a concrete missing, weak, stale, misleading, or
-    wrong-location documentation gap with real user, operator, or maintainer
-    risk.
-11. If no confirmed gaps remain, report that result and do not create
+   conclusions against code, docs, examples, command help, package docs, and
+   public interfaces.
+10. Route each candidate to the correct documentation surface by identifying
+    the intended audience, user action or maintenance decision at risk, current
+    documentation surface, target surface, and any missing non-obvious contract
+    required by `$doc-standards`.
+11. Confirm each finding is a concrete missing, weak, stale, misleading, or
+    wrong-location documentation gap with real user, operator, package
+    consumer, or maintainer risk.
+12. Dismiss candidates already covered by the correct surface, candidates below
+    the finding threshold, and candidates that belong to code, security, test,
+    or reliability workflows.
+13. If no confirmed gaps remain, report that result and do not create
     `ISSUES.md`.
-12. If confirmed gaps remain, write the scoped `ISSUES.md` with `DOC-<number>`
-    IDs.
-13. Present the scoped ledger and proposed doc-fix plan.
-14. Stop before making fixes.
+14. Implement confirmed doc gaps with the smallest clear documentation changes.
+15. If a confirmed gap cannot be fixed correctly in this pass, write or update
+    the scoped `ISSUES.md` with `DOC-<number>` entries for unresolved gaps.
+16. If an existing doc-gap ledger is fully resolved, delete it.
+17. Validate the documentation change with commands appropriate to the changed
+    files.
+18. Present fixed gaps, dismissed or out-of-scope candidates when relevant,
+    unresolved ledger entries if any, and validation results.
 
-## Implement Mode Plan
+## Audit-Only Mode Plan
 
 1. Confirm the requested package or folder scope.
-2. Read scoped `ISSUES.md`, or stop and ask whether to run Find mode first.
-3. Run `$project-workflow` discovery for current entrypoints, CI, documented
-   commands, public APIs, examples, and `./bin` wiring.
-4. Select the next finding by ID unless the human named a specific finding.
-5. Re-check the finding against current code, docs, examples, and public
-   interfaces.
-6. Present the finding evidence, proposed documentation solution, location,
-   public-contract, example accuracy, compatibility, maintenance tradeoffs, and
-   intended validation.
-7. Stop until the human explicitly agrees to that finding's solution.
-8. After agreement, state the local documentation pattern, dominant relevant
-   validation path, planned validation, and any needed deviation.
-9. If a deviation is needed, stop and ask before editing.
-10. Implement only the agreed doc gap with the smallest clear documentation
-    change.
-11. Use `$doc-standards` and relevant language standards for comments,
-    docstrings, and public API docs.
-12. Validate the documentation change with commands appropriate to the changed
-    files.
-13. Report the result and ask the human to verify with `DOC-<number> is done`.
-14. Stop until that confirmation arrives.
-15. After confirmation, remove or revise the finding in scoped `ISSUES.md`.
-16. Continue with the next finding, or delete scoped `ISSUES.md` after all gaps
-    are confirmed resolved.
+2. Check whether scoped `ISSUES.md` already exists and stop unless the human
+   explicitly asked to refresh or overwrite that ledger.
+3. Run `$project-workflow` discovery for entrypoints, CI, documented commands,
+   public APIs, examples, and `./bin` wiring.
+4. Identify existing documentation locations, examples, command help, package
+   documentation, comments, docstrings, `$doc-standards`, and
+   language-specific documentation standards for the requested scope.
+5. Build and launch the same documentation review delegation plan as one-pass
+   mode.
+6. Deduplicate, route, and confirm candidates against code, docs, examples,
+   command help, package docs, and public interfaces.
+7. If no confirmed gaps remain, report that result and do not create
+   `ISSUES.md`.
+8. If confirmed gaps remain, write the scoped `ISSUES.md` with `DOC-<number>`
+   IDs.
+9. Present the scoped audit ledger and stop before making fixes.

--- a/skills/doc-standards/SKILL.md
+++ b/skills/doc-standards/SKILL.md
@@ -23,9 +23,9 @@ real use or maintenance risk.
    documentation directly affected by the current change. Do not perform a
    package-wide documentation audit unless the user explicitly asks for
    `$doc-gaps` or a broader docs pass.
-4. For `$doc-gaps`, use these standards as the quality bar for recording
-   confirmed missing, weak, stale, misleading, or wrong-location documentation
-   in the scoped `ISSUES.md` ledger.
+4. For `$doc-gaps`, use these standards as the quality bar for fixing or
+   recording confirmed missing, weak, stale, misleading, or wrong-location
+   documentation.
 5. Pair with relevant language standards for language-specific public API
    comments and docstrings. Pair with `$naming-standards` when terminology,
    command/API names, examples, or public vocabulary are unclear or
@@ -85,6 +85,25 @@ Apply these rules strictly for code comments, public API comments, docstrings,
 RDoc, GoDoc, shell function comments, and any language-specific documentation
 near code.
 
+For package docs and exported API comments, do not only check whether a comment
+exists or starts with the identifier. Audit whether it documents the
+repository-owned contract that a caller cannot safely infer from the signature.
+For each exported package, type, function, method, variable, or constant in
+scope, check whether the comment needs to cover:
+
+- behavior and purpose;
+- error, panic, nil, empty, or zero-value behavior;
+- side effects, lifecycle, cleanup, global registration, or process behavior;
+- concurrency, caching, retry, timeout, cancellation, or idempotency behavior;
+- configuration defaults, limits, validation, and fallback behavior;
+- security, operational, compatibility, or data-loss risks; and
+- alias, wrapper, re-export, or dependency ownership boundaries.
+
+Do not require every comment to mention every category. Require the relevant
+non-obvious contract to be documented. If none of these categories apply and the
+comment only restates the name or signature, remove or keep it minimal according
+to the language lint requirement.
+
 These rules follow the rule set from Stack Overflow's "Best practices for
 writing code comments":
 https://stackoverflow.blog/2021/12/23/best-practices-for-writing-code-comments/
@@ -128,11 +147,23 @@ how to exercise its public surface.
 
 README headings should use a short, relevant emoji prefix to make the document
 easier to scan and add visual colour. Use one emoji per heading, keep the
-heading text clear without relying on the emoji for meaning, and preserve a
-stronger local heading convention when one already exists.
+heading text clear without relying on the emoji for meaning, and preserve local
+heading names and order only when they keep the canonical README
+responsibilities easy to find.
 
-Use this default README shape unless the repository already has a stronger
-local convention:
+Use this default README shape as the canonical README audit model. A repository
+may keep different heading names, order, or grouping only when the README
+clearly covers the same responsibilities: project identity, why or boundary,
+install or bootstrap, usage, configuration, operations when applicable, and
+references.
+
+Do not dismiss README structure gaps merely because the current README is large,
+locally consistent, or has an established heading style. Treat missing,
+hard-to-find, stale, or wrong-location coverage for these responsibilities as a
+documentation gap.
+
+Do not rename or reorder headings only for cosmetic template conformity when the
+equivalent responsibility is already clear.
 
 ```markdown
 # 📦 <Project Name>
@@ -172,6 +203,23 @@ the project has no operator-facing behavior.>
 <Links to generated API docs, protobuf contracts, examples, changelog, package
 docs, or deeper design notes.>
 ```
+
+When reviewing a README, explicitly check whether it covers:
+
+- Identity: project name, module/package/service purpose, and intended
+  audience.
+- Boundary: what the project owns, what it does not own, and when to use it.
+- Bootstrap: first commands or setup required before useful work.
+- Usage: minimal copy-paste-ready example through the main public surface.
+- Configuration: required config shape, examples, defaults, and links to
+  schemas or authoritative config docs.
+- Operations: security, deployment, health, compatibility, migration,
+  observability, data-loss, or lifecycle notes when applicable.
+- References: generated docs, API contracts, examples, changelog, templates, or
+  deeper design docs.
+
+A README may group or rename sections, but missing or hard-to-find coverage for
+an applicable responsibility is a documentation gap.
 
 Keep, add, remove, or rename sections based on the project type:
 
@@ -249,7 +297,7 @@ gap. When the confirmed problem is missing or weak test coverage, use
 - `$code-review` and `$review-pr`: changed docs plus directly affected nearby
   docs.
 - `$doc-gaps`: the requested package or folder, recursively, using that skill's
-  ledger and delegation rules.
+  one-pass, audit-only, and delegation rules.
 - Direct user request: the scope the user named. If no scope is clear and the
   decision affects edit size or review cost, ask for the intended documentation
   surface before auditing broadly.

--- a/skills/doc-standards/agents/openai.yaml
+++ b/skills/doc-standards/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Doc Standards"
-  short_description: "Review concise docs and emoji README headings"
-  default_prompt: "Use $doc-standards when reviewing changed docs, examples, README content, public API comments, code comments, docstrings, or behavior changes that may make documentation stale; keep READMEs concise with emoji-prefixed headings, avoid duplicating command catalogs or CI config, and reject comments that merely repeat the code."
+  short_description: "Review docs and canonical README coverage"
+  default_prompt: "Use $doc-standards when reviewing changed docs, examples, README content, public API comments, code comments, docstrings, or behavior changes that may make documentation stale; audit READMEs against the canonical coverage model, audit exported comments for non-obvious repository-owned contracts, avoid duplicating command catalogs or CI config, and reject comments that merely repeat the code."

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -53,7 +53,7 @@ make msg="unprefixed subject" desc_file="$desc_file" review
 - Read `references/summary-format.md` before drafting the `msg` value and PR summary content.
 - Read `references/output-format.md` before producing the final review PR report.
 - Use `$project-workflow` for repository command discovery, CI expectations, and `./bin` wiring before validation and `make review`.
-- Use `$doc-standards` for review-time documentation judgment; use `$doc-gaps` only when the user explicitly asks for a scoped documentation audit.
+- Use `$doc-standards` for review-time documentation judgment; use `$doc-gaps` only when the user explicitly asks for a scoped documentation gap pass.
 - Use `$style-review` only when the user explicitly asks for non-blocking polish before the PR.
 
 ## Notes


### PR DESCRIPTION
## What

- Convert `$doc-gaps` from a default two-stage ledger workflow into a one-pass review, fix, and validate workflow.
- Keep `ISSUES.md` for audit-only requests, unresolved confirmed gaps, or existing doc-gap ledgers that still need completion.
- Tighten `$doc-standards` so README review uses a canonical coverage model and exported comments document non-obvious repository-owned contracts.
- Update shared skill metadata, composition docs, and README guidance so downstream agents see the new documentation workflow consistently.

## Why

- Reduces friction when documentation gaps can be found and fixed safely in one review pass.
- Preserves an audit ledger only when it helps review, blocked work, or explicit no-edit requests.
- Makes README and code-comment reviews stricter where consistency affects service authors, operators, package consumers, and maintainers.

## Testing

- `make dep` - passed
- `make clean-dep` - passed
- `make lint` - passed
- `make sec` - passed
- `make skills-lint` - passed
- `make scripts-lint` - passed
- `make docker-lint` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
