### PR TITLE
feat(skills): summarize repository delivery health

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,9 @@ skill instead of one broad default:
   observability, release-safety, recovery, and operability guidance.
 - `reliability-gaps`: find confirmed reliability gaps into `ISSUES.md`, then
   implement agreed reliability fixes gap by gap.
+- `productivity-summary`: daily or weekly repository delivery, CI quality,
+  release/deploy, and service reliability summaries using GitHub, CircleCI,
+  Kubernetes/DigitalOcean, and UptimeRobot evidence.
 - `review-pr`: create a commit, force-push, and open a draft PR with a generated summary.
 - `shell-standards`: Bash scripting, ShellCheck, text processing, directory
   scope, and function documentation conventions.
@@ -133,6 +136,10 @@ Common composition:
   aggregate confirmed `project-workflow` context and SRE, NALSD, operability,
   overload, observability, release-safety, recovery, or data-integrity gaps into
   `ISSUES.md`, then implement agreed reliability fixes gap by gap.
+- `productivity-summary` orchestrates delivery, quality, release/deploy, and
+  service-reliability reporting; pair it with `project-workflow` for repository
+  discovery and `change-validation` only when the summary process changes files
+  or validation commands need to be selected.
 - `code-review` conditionally consults `security-audit` for security-sensitive
   review scope while keeping the review findings format.
 - `style-review` performs an optional non-blocking polish pass when explicitly

--- a/skills/README.md
+++ b/skills/README.md
@@ -33,6 +33,11 @@ specific rule or local pattern, and ask for approval to deviate.
   aggregate `project-workflow` context and verified SRE, NALSD, operability,
   overload, observability, release-safety, recovery, or data-integrity gaps into
   `ISSUES.md`, then implement agreed reliability fixes one gap at a time.
+- `productivity-summary` orchestrates daily or weekly repository health
+  reporting across delivery flow, CI quality, release/deploy activity, and
+  service reliability. It should use `project-workflow` for repository
+  discovery and source boundaries, and keep missing GitHub, CircleCI,
+  Kubernetes/DigitalOcean, or UptimeRobot data explicit.
 - `code-review` performs the review pass and conditionally consults
   `security-audit` for security-sensitive scope.
 - `style-review` performs an optional non-blocking polish pass when explicitly

--- a/skills/productivity-summary/SKILL.md
+++ b/skills/productivity-summary/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: productivity-summary
+description: Produces daily or weekly repository productivity summaries across delivery flow, CI quality, release/deploy activity, and service reliability. Use when the user asks for a productivity summary, delivery health report, weekly or daily engineering metrics, repo health comparison, service health summary, library maintenance summary, or period-over-period view for a specific GitHub repository using local git, GitHub, CircleCI, Kubernetes/DigitalOcean, and UptimeRobot evidence.
+---
+
+# Productivity Summary
+
+Use this skill to turn repository activity and operational evidence into a
+concise daily or weekly engineering-health report. Report what changed, whether
+delivery was smooth, and whether the repo or service looks healthier than the
+comparison period.
+
+## Workflow
+
+1. Identify the requested repository, period, comparison period, and summary
+   mode.
+   - Default to the current working repository when the user does not name one.
+   - Default to weekly summary for the last complete 7 days when no period is
+     provided.
+   - Use the local timezone unless the user specifies another timezone.
+   - Compare weekly summaries with the preceding 7 days; compare daily summaries
+     with the preceding 24 hours or preceding calendar day, matching the
+     requested window.
+2. Classify the repo as `library`, `service`, or `unknown`.
+   - Treat a `.cd` file as a service signal: the repo is deployed, uses
+     DigitalOcean, and has UptimeRobot monitoring.
+   - Treat deploy manifests, Docker release targets, Kubernetes objects, service
+     monitors, or UptimeRobot evidence as service signals.
+   - Treat packages, reusable modules, CLIs, or shared Make/tooling repos with no
+     deployment evidence as library signals.
+   - If classification affects the requested answer and evidence is ambiguous,
+     ask one concise question before collecting service-only metrics.
+3. Read `references/sources.md` before collecting data.
+4. Read `references/metrics.md` before calculating or naming metrics.
+5. Read `references/output.md` before writing the final summary.
+6. Prefer `scripts/collect.rb` for collection when Ruby is available. It
+   performs the local, GitHub, CircleCI, DigitalOcean/Kubernetes, and
+   UptimeRobot read-only collection in one command and returns JSON.
+7. If the script cannot cover the requested scope, collect the narrowest
+   credible evidence manually. Prefer local repository facts first, then
+   authenticated source APIs or CLIs when available.
+8. Keep missing data explicit. Use `n/a` only when the source is unavailable,
+   not when the metric is inconvenient to compute.
+9. Keep collection read-only. API calls, `gh`, `curl`, `git log`, and
+   repository searches are acceptable; do not modify remote systems, clusters,
+   monitors, branches, PRs, or releases while producing the summary.
+10. Produce the summary in Markdown tables with a short narrative. Do not create
+   files unless the user asks for a durable report.
+
+## Reporting Rules
+
+- Do not rank individual developers, infer effort from lines of code, or call a
+  person productive/unproductive from activity metrics.
+- Do not collapse delivery, quality, and reliability into a single productivity
+  score.
+- Do not fabricate missing GitHub, CircleCI, Kubernetes, DigitalOcean, or
+  UptimeRobot values. State the missing source, credential, command, or mapping.
+- Do not expose tokens, API keys, private URLs, or raw incident payloads in the
+  final report.
+- Prefer medians over averages for age, lead-time, duration, and recovery-time
+  metrics.
+- Prefer period-over-period deltas over standalone counts.
+- Include exact window boundaries in the final report.
+- Call out interpretation separately from measured facts.
+
+## Summary Modes
+
+- **Weekly**: Best for management rhythm, maintenance review, and service
+  health. Include delivery flow, CI quality, release/deploy activity, service
+  reliability when applicable, notable changes, and risks.
+- **Daily**: Best for operational check-ins. Emphasize yesterday/today flow,
+  failed checks, deploys, incidents, open review bottlenecks, and follow-up
+  actions.
+- **Library**: Omit service reliability unless monitors or deploys exist.
+  Emphasize maintenance throughput, release readiness, CI, dependency/security
+  signals when available, and downstream-impact notes visible in the repo.
+- **Service**: Include deployment, uptime, incident, response-time, Kubernetes,
+  and monitor-health evidence when available.
+
+## References
+
+- Run `scripts/collect.rb --repo <path>` to collect summary evidence in JSON.
+- Read `references/sources.md` for source priority, credential names, and
+  collection boundaries.
+- Read `references/metrics.md` for metric definitions, comparison logic, and
+  anti-metrics.
+- Read `references/output.md` for the required final report shape.

--- a/skills/productivity-summary/agents/openai.yaml
+++ b/skills/productivity-summary/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Productivity Summary"
+  short_description: "Summarize repo delivery and health"
+  default_prompt: "Use $productivity-summary to produce a weekly delivery, quality, and reliability summary for this repository."

--- a/skills/productivity-summary/references/metrics.md
+++ b/skills/productivity-summary/references/metrics.md
@@ -1,0 +1,110 @@
+# Metrics
+
+Use this reference for metric names and calculations. Prefer a few trustworthy
+metrics over a large table of weak proxies.
+
+## Window Logic
+
+- `current period`: the requested daily or weekly window.
+- `comparison period`: the immediately preceding window of the same length.
+- `delta`: current period minus comparison period.
+- `direction`: `better`, `worse`, `up`, `down`, `flat`, or `n/a`.
+
+Use exact timestamps in the local timezone in the final report.
+For GitHub search date ranges, use inclusive date syntax for the calendar dates
+that correspond to the requested window, then filter timestamps precisely when
+the API returns full timestamps.
+
+## Delivery Flow
+
+| Metric | Definition |
+| --- | --- |
+| Commits | Non-merge commits authored or committed in the period, depending on the available source. State which timestamp is used. |
+| PRs opened | Pull requests created in the period. |
+| PRs merged | Pull requests merged in the period. |
+| PRs closed unmerged | Pull requests closed without merge in the period. |
+| Open PRs | Pull requests open at the end of the current period. |
+| Stale PRs | Open PRs with no commits, comments, review, or status update for at least 7 days unless the repo has another documented threshold. |
+| Median PR age | Median time from PR creation to merge for PRs merged in the period. |
+| Median review latency | Median time from PR creation to first human review or review comment when available. |
+
+Interpretation:
+
+- More merged PRs is not automatically better; compare it with CI failures,
+  incident rate, and PR age.
+- Rising open or stale PR counts are bottleneck signals.
+- Very small sample sizes should be labeled as low confidence.
+- If all sampled PRs lack review records, report review latency as `n/a`.
+
+## CI Quality
+
+| Metric | Definition |
+| --- | --- |
+| Workflow success rate | Successful workflows divided by completed workflows in the period. |
+| Failed workflows | Failed, errored, canceled, or timed-out workflows in the period. State the source categories when available. |
+| Median workflow duration | Median duration of completed workflows. |
+| p95 workflow duration | 95th percentile duration when enough runs exist. |
+| Flaky tests | Tests identified by CircleCI or the dominant test harness as flaky in the period. |
+
+Interpretation:
+
+- Success-rate improvement is meaningful only when workflow volume is similar or
+  the sample size is stated.
+- Faster workflows are useful when success rate and coverage are not degrading.
+- Flaky tests are a quality and trust signal; report the workflow or test names
+  when available.
+- CircleCI's flaky-test endpoint can report a total count that is higher than
+  the number of returned example rows. Use the total count as the metric and
+  list returned rows as examples.
+
+## Release And Deployment
+
+| Metric | Definition |
+| --- | --- |
+| Releases | GitHub releases, version tags, or documented release artifacts created in the period. |
+| Deploys | Production or environment deployments completed in the period. State the environment if known. |
+| Deploy frequency | Deploy count divided by period length. |
+| Lead time to deploy | Median time from merge to deployment for merged PRs that can be matched to deploys. |
+| Rollbacks | Reverts, rollback deploys, or documented rollback events in the period. |
+
+For libraries, treat releases as the deployment analogue. For services, prefer
+actual deploy events over inferred tag or image activity.
+When CI has explicit deploy jobs, report successful deploy jobs and failed
+deploy jobs separately from releases/tags.
+
+## Service Reliability
+
+| Metric | Definition |
+| --- | --- |
+| Uptime | Percentage of time monitors were up during the period. |
+| Downtime | Total monitor downtime in the period. |
+| Incidents | Distinct downtime or degraded-service windows in the period. |
+| MTTR | Median time from incident start to recovery when incident windows are available. |
+| Average response time | Average external monitor response time in the period. |
+| Pod readiness | Ready replicas divided by desired replicas at collection time. |
+| Restarts | Pod/container restarts during the period or current restart count when period data is unavailable. |
+| Runtime image | Deployed image tag at collection time. |
+
+Interpretation:
+
+- External uptime is the user-visible reliability signal; Kubernetes readiness
+  is supporting evidence.
+- Do not infer customer impact from internal Kubernetes events alone.
+- Correlate failed deploys, incidents, and rollbacks only when timestamps
+  overlap credibly.
+- Treat Kubernetes readiness, restart count, and runtime image as
+  collection-time values unless historical metrics are available.
+
+## Anti-Metrics
+
+Do not use these as productivity claims:
+
+- lines added or deleted;
+- number of comments by person;
+- commit count by person;
+- PR size as a standalone good/bad score;
+- individual rankings;
+- a single productivity score.
+
+These may be mentioned only as context when the user explicitly asks and the
+limitations are stated.

--- a/skills/productivity-summary/references/output.md
+++ b/skills/productivity-summary/references/output.md
@@ -1,0 +1,99 @@
+# Output
+
+Use this final report shape unless the user asks for a different format.
+
+## Required Shape
+
+Start with the repository and exact window:
+
+```markdown
+**Repository:** owner/repo
+**Window:** 2026-06-08 00:00 to 2026-06-15 00:00 Europe/Berlin
+**Mode:** service weekly summary
+```
+
+Then include these sections:
+
+1. `**Summary**`
+2. `**Delivery Flow**`
+3. `**CI Quality**`
+4. `**Release And Deploy**`
+5. `**Service Reliability**` for services only
+6. `**Notable Work**`
+7. `**Risks And Follow-Ups**`
+8. `**Data Sources**`
+
+Omit `Service Reliability` for libraries unless service evidence exists.
+
+## Summary
+
+Use 2-5 bullets. Separate measured facts from interpretation.
+
+Good examples:
+
+- `Delivery improved: 12 PRs merged versus 8 in the prior week, while median PR age fell from 2.1d to 1.3d.`
+- `CI is the main weak spot: success rate dropped to 84% and the deploy workflow accounts for most failures.`
+- `Service health was steady: uptime stayed at 99.99% with no visible incidents.`
+
+## Metric Tables
+
+Use compact Markdown tables:
+
+```markdown
+| Metric | Current | Previous | Delta | Signal |
+| --- | ---: | ---: | ---: | --- |
+| PRs merged | 12 | 8 | +4 | better |
+| Median PR age | 1.3d | 2.1d | -0.8d | better |
+```
+
+Use `n/a` for unavailable values. In `Signal`, use:
+
+- `better`
+- `worse`
+- `up`
+- `down`
+- `flat`
+- `n/a`
+
+Use `better` or `worse` only when direction clearly maps to health. Use `up` or
+`down` for neutral volume changes.
+
+## Notable Work
+
+List up to 5 concrete items visible from commits, merged PRs, releases, or
+deploys. Prefer merged PR titles and release names over commit noise.
+
+```markdown
+- Merged #123, "Add retry budget to webhook delivery".
+- Released v1.8.0.
+```
+
+## Risks And Follow-Ups
+
+List only actionable risks supported by evidence:
+
+```markdown
+- Deploy workflow failed 3 times; inspect the failed `deploy` jobs before the next release.
+- 4 PRs are stale for more than 7 days; decide whether to close or revive them.
+```
+
+If there are no evidence-backed risks, write `- None from the available data.`
+If a metric is collection-time only, stale, or based on partial samples, call
+that out here rather than hiding it in the data-source table.
+If CircleCI has `max_auto_reruns`, mention the rerun context when discussing
+workflow failure counts.
+
+## Data Sources
+
+End with source coverage and gaps:
+
+```markdown
+| Source | Status | Notes |
+| --- | --- | --- |
+| Local git | used | Commit and tag history. |
+| GitHub | used | PRs, releases, checks. |
+| CircleCI | unavailable | `CIRCLE_TOKEN` is not set. |
+| UptimeRobot | skipped | Library repo; no service monitor mapping found. |
+```
+
+Do not include secrets, full API payloads, or private incident URLs.

--- a/skills/productivity-summary/references/sources.md
+++ b/skills/productivity-summary/references/sources.md
@@ -1,0 +1,243 @@
+# Sources
+
+Use this reference to choose evidence sources and report missing data clearly.
+
+## Source Priority
+
+1. Use local git and repository files for repository identity, current branch,
+   recent commits, release files, deployment manifests, CI config, and service
+   hints.
+2. Use authenticated GitHub sources for PRs, issues, releases, checks, review
+   activity, and exact timestamps when available.
+3. Use CircleCI Insights for workflow health, duration, success rate, credits,
+   flaky tests, and recent workflow runs when the repo uses CircleCI.
+4. Use Kubernetes, DigitalOcean, or deployment tooling only for service repos or
+   when the user asks for operational state.
+5. Use UptimeRobot public status pages or API data for externally visible
+   uptime, incidents, monitor status, and response time.
+
+## Local Evidence
+
+Prefer the bundled collector when available:
+
+```bash
+ruby <skill-dir>/scripts/collect.rb --repo <repo-path>
+```
+
+Useful local commands include:
+
+```bash
+git remote get-url origin
+git rev-parse --show-toplevel
+git branch --show-current
+git log --since=<start> --until=<end> --format=%H%x09%aI%x09%an%x09%s
+git tag --sort=-creatordate
+```
+
+Search the repository for service and release hints with `rg` before using
+cloud tools:
+
+```bash
+rg --files -g '!.git/**' -g '!vendor/**'
+rg 'CircleCI|circleci|deploy|kubernetes|k8s|uptime|UptimeRobot|doctl|kubectl|Dockerfile'
+```
+
+If `.cd` exists at the repository root, classify the repo as a deployed service.
+For these repos, use DigitalOcean/Kubernetes and UptimeRobot when credentials
+and monitor mappings are available.
+
+## GitHub
+
+Prefer `gh` when it is authenticated and installed. Use the REST or GraphQL API
+when `gh` is unavailable but a token exists.
+
+Common environment variables:
+
+- `GITHUB_TOKEN`
+- `GH_TOKEN`
+
+Useful data:
+
+- pull requests created, merged, closed, open, and stale;
+- median PR age and review latency;
+- commits in the requested period;
+- releases and tags;
+- check runs or commit statuses when CircleCI data is unavailable;
+- issues opened and closed when the user asks for planning or support signals.
+
+For unauthenticated public repos, local git can provide commits but not reliable
+PR, review, or private CI data.
+
+Useful `gh` patterns:
+
+```bash
+gh pr list --repo <owner>/<repo> --state all \
+  --search "created:<start-date>..<end-date>" \
+  --json number
+
+gh pr list --repo <owner>/<repo> --state merged \
+  --search "merged:<start-date>..<end-date>" \
+  --limit 100 \
+  --json number,title,createdAt,mergedAt,url,reviews
+
+gh pr list --repo <owner>/<repo> --state closed \
+  --search "closed:<start-date>..<end-date> -merged:<start-date>..<end-date>" \
+  --json number
+
+gh pr list --repo <owner>/<repo> --state open \
+  --json number,title,updatedAt,createdAt
+
+gh release list --repo <owner>/<repo> \
+  --limit 100 \
+  --json tagName,createdAt,publishedAt,isDraft,isPrerelease
+```
+
+When PR review records are empty, report review latency as `n/a` instead of
+inferring it from merge time.
+
+## CircleCI
+
+Use CircleCI only when `.circleci/config.yml` exists or project metadata points
+to CircleCI.
+Read `.circleci/config.yml` before interpreting CircleCI metrics. Record
+workflow-level settings that affect counts, especially `max_auto_reruns`, branch
+filters, serialized jobs, and required release/deploy jobs.
+
+Common environment variables:
+
+- `CIRCLE_TOKEN`
+- `CIRCLECI_TOKEN`
+
+If neither environment variable is set, check the CircleCI CLI config at
+`${CIRCLECI_CLI_CONFIG:-$HOME/.circleci/cli.yml}` and use its `token` field
+when present. Do not print the token.
+
+The common project slug shape is `gh/<owner>/<repo>`. If the slug is ambiguous,
+derive it from the GitHub remote and state the assumption.
+
+Useful data:
+
+- workflow success rate;
+- median and p95 workflow duration;
+- failed workflow count;
+- recent failed workflows;
+- flaky tests;
+- credit usage when useful for cost or throughput context.
+
+CircleCI Insights can have retention and reporting-window limits. If the
+requested window is outside the available range, state the truncation.
+
+Useful read-only API pattern:
+
+1. List project pipelines for `gh/<owner>/<repo>` and the relevant branch:
+   `/api/v2/project/gh/<owner>/<repo>/pipeline?branch=<branch>`.
+2. Page backward until the oldest collected pipeline is before the comparison
+   period start.
+3. For each pipeline, list workflows with `/api/v2/pipeline/<pipeline-id>/workflow`.
+4. Bucket workflows by `created_at`; count completed workflows, successes, and
+   failures.
+5. Calculate workflow duration from `created_at` to `stopped_at`.
+6. Check flaky tests with
+   `/api/v2/insights/gh/<owner>/<repo>/flaky-tests?branch=<branch>`.
+7. For service repos, collect job-level data with
+   `/api/v2/workflow/<workflow-id>/job` and report deploy health from jobs named
+   `deploy` rather than inferring deploys from tags alone.
+
+Use a successful completed workflow count as the denominator for success rate
+only after excluding running, on-hold, and not-run workflows.
+Report releases/tags separately from successful deploy jobs when both exist.
+When `max_auto_reruns` is configured, state that CircleCI workflow totals are
+API-visible completed workflow records after rerun behavior, not necessarily
+first-attempt pipeline outcomes.
+
+## Kubernetes And DigitalOcean
+
+Use operational sources only for service summaries or explicit user requests.
+Prefer read-only commands.
+
+Common environment variables and tools:
+
+- `DIGITALOCEAN_ACCESS_TOKEN`
+- `doctl`
+- `kubectl`
+
+Useful data:
+
+- deployment image and rollout status;
+- running, pending, crash-looping, or restarting pods;
+- deployment age and replica readiness;
+- recent Kubernetes events when they explain reliability issues.
+
+Do not change clusters, contexts, resources, deployments, secrets, or
+annotations while producing a summary.
+Label Kubernetes values as collection-time state unless historical metrics are
+available from a time-series source.
+
+For library/shared-tooling repos with no `.cd`, deployment manifest, Kubernetes
+object, service monitor, or explicit service mapping, skip DigitalOcean and
+Kubernetes instead of probing clusters.
+
+## UptimeRobot
+
+Use UptimeRobot data when a monitor ID, status page, repo config, README,
+environment variable, or user-provided URL maps the service to a monitor.
+
+Common environment variables:
+
+- `UPTIMEROBOT_API_KEY`
+- `UPTIMEROBOT_MONITOR_IDS`
+- `UPTIMEROBOT_STATUS_PAGE_URL`
+
+Prefer sources in this order:
+
+1. Public status page URL, when it has enough uptime and incident information
+   for the requested summary.
+2. One account/main API key plus monitor IDs for all relevant services.
+3. Monitor-specific API keys only when the user deliberately chooses
+   per-service least-privilege credentials.
+
+Do not require one UptimeRobot key per service. If the only available setup
+would require per-service keys, report UptimeRobot as unavailable for richer
+monitor data and use public status-page evidence instead.
+
+After creating a main API key, discover monitor IDs with `getMonitors` and map
+them to friendly names:
+
+```bash
+curl -fsS -X POST https://api.uptimerobot.com/v2/getMonitors \
+  -d "api_key=${UPTIMEROBOT_API_KEY}&format=json" |
+  jq -r '.monitors[] | "\(.id)\t\(.friendly_name)\t\(.url)"'
+```
+
+Set `UPTIMEROBOT_MONITOR_IDS` to the comma-separated IDs for the services in
+scope.
+
+Useful data:
+
+- current monitor status;
+- uptime ratio for the requested period;
+- average response time;
+- incidents, downtime windows, and recovery time.
+
+When only a public status page is available, report only the facts visible from
+that page and label them as public status-page evidence.
+When an API key is available, use `custom_uptime_ranges` with exact Unix-second
+window boundaries for current and comparison periods. UptimeRobot returns the
+range values as a hyphen-separated string in the same order as requested.
+Request `logs=1` for incidents and `response_times=1` for response-time
+samples. If response-time samples do not cover the comparison window, report the
+previous response time as `n/a` instead of reusing account-level averages.
+
+For library/shared-tooling repos with no `.cd` or repo-specific monitor mapping,
+skip UptimeRobot even when general UptimeRobot credentials are configured.
+
+## Missing Source Reporting
+
+For every unavailable source that would materially improve the summary, include
+one short data-source note:
+
+```text
+CircleCI: unavailable because CIRCLE_TOKEN is not set.
+UptimeRobot: unavailable because no monitor ID or status-page mapping was found.
+Kubernetes: skipped because this repo has no service/deployment evidence.
+```

--- a/skills/productivity-summary/scripts/collect.rb
+++ b/skills/productivity-summary/scripts/collect.rb
@@ -1,0 +1,609 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/ClassLength, Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+require 'json'
+require 'net/http'
+require 'open3'
+require 'optparse'
+require 'time'
+require 'uri'
+require 'yaml'
+
+# Collects read-only repository productivity evidence from local and remote
+# sources, then prints a JSON document for the skill to summarize.
+class ProductivityCollector
+  HTTP_TIMEOUT_SECONDS = 15
+
+  def initialize(options)
+    @repo_path = File.expand_path(options.fetch(:repo_path))
+    @timezone = options.fetch(:timezone)
+    @branch = options[:branch]
+    @include_jobs = options.fetch(:include_jobs)
+    @now = options[:now] ? parse_time(options[:now]) : Time.now
+    @current_end = options[:current_end] ? parse_time(options[:current_end]) : day_start(@now)
+    @current_start = options[:current_start] ? parse_time(options[:current_start]) : @current_end - (7 * 24 * 60 * 60)
+    @previous_end = @current_start
+    @previous_start = options[:previous_start] ? parse_time(options[:previous_start]) : @previous_end - window_seconds
+  end
+
+  def call
+    root = git_root
+    owner_repo = parse_owner_repo(git('remote', 'get-url', 'origin').strip)
+    branch = summary_branch(owner_repo)
+    mode = File.exist?(File.join(root, '.cd')) ? 'service' : 'library'
+    period = window_seconds <= 24 * 60 * 60 ? 'daily' : 'weekly'
+
+    result = {
+      repository: owner_repo,
+      repo_path: root,
+      branch: branch,
+      mode: "#{mode} #{period} summary",
+      timezone: @timezone,
+      window: window_hash(@current_start, @current_end),
+      comparison_window: window_hash(@previous_start, @previous_end),
+      local: collect_local(root),
+      github: collect_github(owner_repo),
+      circleci: collect_circleci(owner_repo, branch, mode, root),
+      digitalocean: mode == 'service' ? collect_digitalocean : skipped('not a service repo'),
+      kubernetes: mode == 'service' ? collect_kubernetes(owner_repo.split('/').last) : skipped('not a service repo'),
+      uptimerobot: mode == 'service' ? collect_uptimerobot(owner_repo.split('/').last) : skipped('not a service repo')
+    }
+
+    JSON.pretty_generate(result)
+  end
+
+  private
+
+  def parse_time(value)
+    with_timezone { Time.parse(value) }
+  end
+
+  def day_start(time)
+    with_timezone do
+      local = Time.local(time.year, time.month, time.day)
+      Time.parse(local.strftime('%Y-%m-%d 00:00:00 %z'))
+    end
+  end
+
+  def with_timezone
+    old = ENV.fetch('TZ', nil)
+    ENV['TZ'] = @timezone
+    yield
+  ensure
+    ENV['TZ'] = old
+  end
+
+  def window_seconds
+    @current_end.to_i - @current_start.to_i
+  end
+
+  def window_hash(start_time, end_time)
+    { start: start_time.iso8601, end: end_time.iso8601 }
+  end
+
+  def collect_local(root)
+    {
+      cd_file: File.exist?(File.join(root, '.cd')),
+      current: local_period(@current_start, @current_end),
+      previous: local_period(@previous_start, @previous_end),
+      circleci_config: circleci_config(root)
+    }
+  end
+
+  def local_period(start_time, end_time)
+    commits = git_lines(
+      'log', "--since=#{start_time.iso8601}", "--until=#{end_time.iso8601}",
+      '--no-merges', '--format=%H%x09%aI%x09%an%x09%s'
+    ).map do |line|
+      sha, authored_at, author, subject = line.split("\t", 4)
+      { sha: sha, authored_at: authored_at, author: author, subject: subject }
+    end
+
+    tags = git_lines('for-each-ref', 'refs/tags', '--sort=creatordate',
+                     '--format=%(refname:short)%09%(creatordate:iso-strict)')
+           .filter_map do |line|
+      tag, created_at = line.split("\t", 2)
+      next unless created_at
+
+      created = Time.parse(created_at)
+      { tag: tag, created_at: created_at } if created >= start_time && created < end_time
+    end
+
+    rollback_subjects = commits.filter_map { |commit| commit[:subject] if commit[:subject]&.match?(/revert|rollback/i) }
+
+    {
+      commit_count: commits.length,
+      commits: commits,
+      tag_count: tags.length,
+      tags: tags,
+      rollback_or_revert_count: rollback_subjects.length,
+      rollback_or_revert_subjects: rollback_subjects
+    }
+  end
+
+  def circleci_config(root)
+    path = File.join(root, '.circleci', 'config.yml')
+    return { present: false } unless File.exist?(path)
+
+    data = YAML.safe_load_file(path, aliases: true) || {}
+    workflow = data.fetch('workflows', {}).find { |key, _| key != 'version' }&.last || {}
+    {
+      present: true,
+      max_auto_reruns: workflow['max_auto_reruns'],
+      workflows: data.fetch('workflows', {}).keys.reject { |key| key == 'version' },
+      jobs: data.fetch('jobs', {}).keys
+    }
+  rescue Psych::SyntaxError => e
+    { present: true, error: e.message }
+  end
+
+  def collect_github(owner_repo)
+    return skipped('gh is not installed') unless command_available?('gh')
+
+    {
+      current: github_period(owner_repo, @current_start, @current_end),
+      previous: github_period(owner_repo, @previous_start, @previous_end),
+      open_pr_count: gh_json('pr', 'list', '--repo', owner_repo, '--state', 'open', '--json', 'number').length
+    }
+  rescue StandardError => e
+    unavailable(e.message)
+  end
+
+  def github_period(owner_repo, start_time, end_time)
+    date_range = "#{start_time.strftime('%Y-%m-%d')}..#{(end_time - 1).strftime('%Y-%m-%d')}"
+    merged = gh_json(
+      'pr', 'list', '--repo', owner_repo, '--state', 'merged', '--search', "merged:#{date_range}",
+      '--limit', '300', '--json', 'number,title,createdAt,mergedAt,url,reviews'
+    ).select { |pr| within?(Time.parse(pr.fetch('mergedAt')), start_time, end_time) }
+
+    created = gh_json(
+      'pr', 'list', '--repo', owner_repo, '--state', 'all', '--search', "created:#{date_range}",
+      '--limit', '300', '--json', 'number,createdAt'
+    ).count { |pr| within?(Time.parse(pr.fetch('createdAt')), start_time, end_time) }
+
+    closed_unmerged = gh_json(
+      'pr', 'list', '--repo', owner_repo, '--state', 'closed',
+      '--search', "closed:#{date_range} -merged:#{date_range}", '--limit', '300', '--json', 'number,closedAt,mergedAt'
+    ).count do |pr|
+      pr['mergedAt'].nil? && pr['closedAt'] && within?(Time.parse(pr.fetch('closedAt')), start_time,
+                                                       end_time)
+    end
+
+    review_latencies = merged.filter_map { |pr| first_review_latency(pr) }
+    {
+      pr_opened: created,
+      pr_merged: merged.length,
+      pr_closed_unmerged: closed_unmerged,
+      median_pr_age_seconds: median(merged.map do |pr|
+        Time.parse(pr.fetch('mergedAt')) - Time.parse(pr.fetch('createdAt'))
+      end),
+      median_review_latency_seconds: median(review_latencies),
+      prs_with_reviews: merged.count { |pr| pr.fetch('reviews', []).any? },
+      merged_prs: merged.map { |pr| pick(pr, 'number', 'title', 'createdAt', 'mergedAt', 'url') }
+    }
+  end
+
+  def first_review_latency(pull_request)
+    created = Time.parse(pull_request.fetch('createdAt'))
+    first = pull_request.fetch('reviews', [])
+                        .filter_map { |review| review['submittedAt'] }
+                        .map { |value| Time.parse(value) }
+                        .min
+    first - created if first
+  end
+
+  def collect_circleci(owner_repo, branch, mode, root)
+    root_config = circleci_config(root)
+    return skipped('no .circleci/config.yml') unless root_config[:present]
+
+    token = circleci_token
+    return unavailable('CircleCI token not found') if token.nil? || token.empty?
+
+    pipelines = circleci_pipelines(owner_repo, branch, token)
+    workflows = circleci_workflows(pipelines, token)
+    jobs = @include_jobs || mode == 'service' ? circleci_jobs(workflows, token) : []
+    flaky = circleci_get("/insights/gh/#{owner_repo}/flaky-tests?branch=#{url_query(branch)}", token)
+
+    {
+      current: circleci_period(workflows, jobs, @current_start, @current_end),
+      previous: circleci_period(workflows, jobs, @previous_start, @previous_end),
+      flaky_tests: {
+        total: flaky['total_flaky_tests'],
+        examples: flaky.fetch('flaky_tests', []).map do |test|
+          pick(test, 'classname', 'test_name', 'times_flaked', 'workflow_name', 'job_name', 'workflow_created_at')
+        end
+      },
+      config: root_config,
+      pipelines_collected: pipelines.length,
+      workflows_collected: workflows.length,
+      jobs_collected: jobs.length
+    }
+  rescue StandardError => e
+    unavailable(e.message)
+  end
+
+  def circleci_period(workflows, jobs, start_time, end_time)
+    period_workflows = workflows.select do |workflow|
+      within?(Time.parse(workflow.fetch('created_at')), start_time, end_time)
+    end
+    completed = period_workflows.select do |workflow|
+      workflow['stopped_at'] && !%w[running on_hold not_run].include?(workflow['status'])
+    end
+    successful = completed.count { |workflow| workflow['status'] == 'success' }
+    failed = completed.reject { |workflow| workflow['status'] == 'success' }
+    durations = completed.map do |workflow|
+      Time.parse(workflow.fetch('stopped_at')) - Time.parse(workflow.fetch('created_at'))
+    end
+
+    {
+      workflows_total: period_workflows.length,
+      workflows_completed: completed.length,
+      workflows_successful: successful,
+      workflows_failed: failed.length,
+      workflow_success_rate: completed.empty? ? nil : successful.to_f / completed.length,
+      median_workflow_duration_seconds: median(durations),
+      p95_workflow_duration_seconds: percentile(durations, 0.95),
+      failed_workflows: failed.map { |workflow| pick(workflow, 'name', 'status', 'created_at') },
+      jobs: job_summary(jobs, start_time, end_time)
+    }
+  end
+
+  def job_summary(jobs, start_time, end_time)
+    period_jobs = jobs.select do |job|
+      value = job['started_at'] || job['created_at'] || job['workflow_created_at']
+      value && within?(Time.parse(value), start_time, end_time)
+    end
+
+    period_jobs.group_by { |job| job['name'] }.transform_values do |items|
+      completed = items.select { |job| job['stopped_at'] && !%w[running on_hold not_run].include?(job['status']) }
+      successful = completed.count { |job| job['status'] == 'success' }
+      failed = completed.reject { |job| job['status'] == 'success' }
+      durations = completed.filter_map do |job|
+        started = job['started_at'] || job['created_at'] || job['workflow_created_at']
+        Time.parse(job.fetch('stopped_at')) - Time.parse(started) if started
+      end
+
+      {
+        total: completed.length,
+        successful: successful,
+        failed: failed.length,
+        median_duration_seconds: median(durations),
+        p95_duration_seconds: percentile(durations, 0.95),
+        failed_jobs: failed.map { |job| pick(job, 'status', 'started_at', 'created_at') }
+      }
+    end
+  end
+
+  def collect_digitalocean
+    token = ENV.fetch('DIGITALOCEAN_ACCESS_TOKEN', nil)
+    return unavailable('DIGITALOCEAN_ACCESS_TOKEN is not set') if token.nil? || token.empty?
+
+    data = http_json('https://api.digitalocean.com/v2/kubernetes/clusters', 'Authorization' => "Bearer #{token}")
+    { status: 'used', clusters: data.fetch('kubernetes_clusters', []).map do |cluster|
+      pick(cluster, 'name', 'region', 'version', 'status', 'created_at')
+    end }
+  rescue StandardError => e
+    unavailable(e.message)
+  end
+
+  def collect_kubernetes(name)
+    return unavailable('kubectl is not installed') unless command_available?('kubectl')
+
+    context = capture('kubectl', 'config', 'current-context', allow_failure: true).strip
+    deployments = kubectl_json('get', 'deployments', '-A', '-o', 'json').fetch('items', []).select do |item|
+      item.dig('metadata', 'name')&.include?(name) || item.dig('metadata', 'namespace')&.include?(name)
+    end
+
+    pods = deployments.flat_map do |deployment|
+      namespace = deployment.dig('metadata', 'namespace')
+      labels = deployment.dig('spec', 'selector', 'matchLabels') || {}
+      selector = labels.map { |key, value| "#{key}=#{value}" }.join(',')
+      next [] if selector.empty?
+
+      kubectl_json('get', 'pods', '-n', namespace, '-l', selector, '-o', 'json').fetch('items', [])
+    end
+
+    {
+      status: 'used',
+      context: context,
+      deployments: deployments.map { |deployment| deployment_summary(deployment) },
+      pods: pods.map { |pod| pod_summary(pod) }
+    }
+  rescue StandardError => e
+    unavailable(e.message)
+  end
+
+  def collect_uptimerobot(name)
+    key = ENV.fetch('UPTIMEROBOT_API_KEY', '').strip
+    return unavailable('UPTIMEROBOT_API_KEY is not set') if key.empty?
+
+    ranges = "#{@current_start.to_i}_#{@current_end.to_i}-#{@previous_start.to_i}_#{@previous_end.to_i}"
+    params = {
+      'api_key' => key,
+      'format' => 'json',
+      'logs' => '1',
+      'response_times' => '1',
+      'custom_uptime_ranges' => ranges
+    }
+    monitor_ids = ENV.fetch('UPTIMEROBOT_MONITOR_IDS', '').split(',').map(&:strip).reject(&:empty?)
+    params['monitors'] = monitor_ids.join('-') unless monitor_ids.empty?
+
+    data = uptimerobot(params)
+    monitor = find_uptimerobot_monitor(data, name)
+
+    if monitor.nil? && !monitor_ids.empty?
+      params.delete('monitors')
+      data = uptimerobot(params)
+      monitor = find_uptimerobot_monitor(data, name)
+    end
+    return unavailable("no UptimeRobot monitor matched #{name}") unless monitor
+
+    samples = monitor.fetch('response_times', [])
+    current_samples = response_samples(samples, @current_start, @current_end)
+    previous_samples = response_samples(samples, @previous_start, @previous_end)
+
+    {
+      status: 'used',
+      monitor: pick(monitor, 'id', 'friendly_name', 'url', 'status'),
+      uptime_ranges: monitor['custom_uptime_ranges'] || monitor['custom_uptime_range'],
+      logs: monitor.fetch('logs', []),
+      current_response_time_average_ms: average(current_samples),
+      current_response_time_samples: current_samples.length,
+      previous_response_time_average_ms: average(previous_samples),
+      previous_response_time_samples: previous_samples.length
+    }
+  rescue StandardError => e
+    unavailable(e.message)
+  end
+
+  def deployment_summary(deployment)
+    status = deployment.fetch('status', {})
+    spec = deployment.fetch('spec', {})
+    container = deployment.dig('spec', 'template', 'spec', 'containers', 0) || {}
+    {
+      namespace: deployment.dig('metadata', 'namespace'),
+      name: deployment.dig('metadata', 'name'),
+      desired_replicas: spec['replicas'],
+      ready_replicas: status['readyReplicas'] || 0,
+      available_replicas: status['availableReplicas'] || 0,
+      updated_replicas: status['updatedReplicas'] || 0,
+      image: container['image']
+    }
+  end
+
+  def pod_summary(pod)
+    statuses = pod.dig('status', 'containerStatuses') || []
+    {
+      namespace: pod.dig('metadata', 'namespace'),
+      name: pod.dig('metadata', 'name'),
+      phase: pod.dig('status', 'phase'),
+      ready: statuses.all? { |status| status['ready'] },
+      restarts: statuses.sum { |status| status['restartCount'].to_i },
+      started_at: pod.dig('status', 'startTime')
+    }
+  end
+
+  def response_samples(samples, start_time, end_time)
+    selected = samples.select do |sample|
+      timestamp = sample.fetch('datetime').to_i
+      timestamp >= start_time.to_i && timestamp < end_time.to_i
+    end
+    selected.map { |sample| sample.fetch('value').to_f }
+  end
+
+  def find_uptimerobot_monitor(data, name)
+    data.fetch('monitors', []).find do |item|
+      [item['friendly_name'], item['url']].compact.any? { |value| value.include?(name) }
+    end
+  end
+
+  def circleci_pipelines(owner_repo, branch, token)
+    pipelines = []
+    page_token = nil
+    loop do
+      path = "/project/gh/#{owner_repo}/pipeline?branch=#{url_query(branch)}"
+      path += "&page-token=#{URI.encode_www_form_component(page_token)}" if page_token
+      data = circleci_get(path, token)
+      items = data.fetch('items', [])
+      pipelines.concat(items)
+      oldest = items.filter_map { |pipeline| Time.parse(pipeline.fetch('created_at')) }.min
+      page_token = data['next_page_token']
+      break if items.empty? || page_token.nil? || (oldest && oldest < @previous_start)
+    end
+    pipelines
+  end
+
+  def circleci_workflows(pipelines, token)
+    pipelines.flat_map do |pipeline|
+      circleci_get("/pipeline/#{pipeline.fetch('id')}/workflow", token).fetch('items', []).map do |workflow|
+        workflow.merge('pipeline_created_at' => pipeline.fetch('created_at'),
+                       'pipeline_number' => pipeline.fetch('number'))
+      end
+    end
+  end
+
+  def circleci_jobs(workflows, token)
+    workflows.flat_map do |workflow|
+      circleci_get("/workflow/#{workflow.fetch('id')}/job", token).fetch('items', []).map do |job|
+        job.merge('workflow_id' => workflow.fetch('id'), 'workflow_created_at' => workflow.fetch('created_at'))
+      end
+    end
+  end
+
+  def circleci_get(path, token)
+    http_json("https://circleci.com/api/v2#{path}", 'Circle-Token' => token)
+  end
+
+  def circleci_token
+    token = ENV['CIRCLE_TOKEN'] || ENV.fetch('CIRCLECI_TOKEN', nil)
+    return token unless token.nil? || token.empty?
+
+    path = ENV['CIRCLECI_CLI_CONFIG'] || File.join(Dir.home, '.circleci', 'cli.yml')
+    return nil unless File.exist?(path)
+
+    YAML.safe_load_file(path).fetch('token')
+  end
+
+  def uptimerobot(params)
+    uri = URI('https://api.uptimerobot.com/v2/getMonitors')
+    request = Net::HTTP::Post.new(uri)
+    request.set_form_data(params)
+    response = http_response(uri, request)
+    raise "UptimeRobot #{response.code}: #{response.body}" unless response.is_a?(Net::HTTPSuccess)
+
+    data = JSON.parse(response.body)
+    error = data['error']
+    raise "UptimeRobot #{error['type']}: #{error['message']}" if data['stat'] == 'fail' && error
+
+    data
+  end
+
+  def http_json(url, headers = {})
+    uri = URI(url)
+    request = Net::HTTP::Get.new(uri)
+    headers.each { |key, value| request[key] = value }
+    response = http_response(uri, request)
+    raise "#{url} #{response.code}: #{response.body}" unless response.is_a?(Net::HTTPSuccess)
+
+    JSON.parse(response.body)
+  end
+
+  def http_response(uri, request)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    http.open_timeout = HTTP_TIMEOUT_SECONDS
+    http.read_timeout = HTTP_TIMEOUT_SECONDS
+    http.request(request)
+  end
+
+  def kubectl_json(*)
+    JSON.parse(capture('kubectl', *))
+  end
+
+  def gh_json(*)
+    JSON.parse(capture('gh', *))
+  end
+
+  def git_root
+    git('rev-parse', '--show-toplevel').strip
+  end
+
+  def git(*, allow_failure: false)
+    capture('git', '-C', @repo_path, *, allow_failure: allow_failure)
+  end
+
+  def git_lines(*)
+    git(*).lines.map(&:chomp).reject(&:empty?)
+  end
+
+  def summary_branch(owner_repo)
+    return @branch if @branch
+
+    branch = git('symbolic-ref', '--quiet', '--short', 'refs/remotes/origin/HEAD', allow_failure: true)
+             .strip
+             .sub(%r{\Aorigin/}, '')
+    return branch unless branch.empty?
+
+    if command_available?('gh')
+      branch = gh_json('repo', 'view', owner_repo, '--json', 'defaultBranchRef')
+               .dig('defaultBranchRef', 'name')
+      return branch if branch && !branch.empty?
+    end
+
+    git('branch', '--show-current').strip
+  end
+
+  def capture(*args, allow_failure: false)
+    output, error, status = Open3.capture3(*args)
+    raise "#{args.join(' ')} failed: #{error.strip}" if !allow_failure && !status.success?
+
+    output
+  end
+
+  def command_available?(name)
+    ENV.fetch('PATH', '').split(File::PATH_SEPARATOR).any? do |directory|
+      path = File.join(directory, name)
+      File.executable?(path) && !File.directory?(path)
+    end
+  end
+
+  def pick(hash, *keys)
+    keys.each_with_object({}) { |key, result| result[key] = hash[key] if hash.key?(key) }
+  end
+
+  def parse_owner_repo(remote)
+    clean = remote.delete_suffix('.git')
+    return Regexp.last_match(1) if clean.match(/\Agit@github\.com:(.+)\z/)
+    return Regexp.last_match(1) if clean.match(%r{\Assh://git@github\.com/(.+)\z})
+    return Regexp.last_match(1) if clean.match(%r{\Ahttps?://github\.com/(.+)\z})
+
+    clean
+  end
+
+  def url_query(value)
+    URI.encode_www_form_component(value)
+  end
+
+  def within?(time, start_time, end_time)
+    time >= start_time && time < end_time
+  end
+
+  def median(values)
+    sorted = values.compact.sort
+    return nil if sorted.empty?
+
+    sorted.length.odd? ? sorted[sorted.length / 2] : (sorted[(sorted.length / 2) - 1] + sorted[sorted.length / 2]) / 2.0
+  end
+
+  def percentile(values, percent)
+    sorted = values.compact.sort
+    return nil if sorted.empty?
+
+    sorted[[(sorted.length * percent).ceil - 1, 0].max]
+  end
+
+  def average(values)
+    return nil if values.empty?
+
+    values.sum / values.length
+  end
+
+  def skipped(reason)
+    { status: 'skipped', reason: reason }
+  end
+
+  def unavailable(reason)
+    { status: 'unavailable', reason: reason }
+  end
+end
+
+options = {
+  repo_path: Dir.pwd,
+  timezone: ENV.fetch('TZ', 'Europe/Berlin'),
+  include_jobs: false
+}
+
+OptionParser.new do |parser|
+  parser.banner = 'Usage: collect.rb [options]'
+  parser.on('--repo PATH', 'Repository path. Defaults to the current directory.') do |value|
+    options[:repo_path] = value
+  end
+  parser.on('--timezone TZ', 'Timezone for default windows. Defaults to TZ or Europe/Berlin.') do |value|
+    options[:timezone] = value
+  end
+  parser.on('--current-start TIME', 'Current window start.') { |value| options[:current_start] = value }
+  parser.on('--current-end TIME', 'Current window end.') { |value| options[:current_end] = value }
+  parser.on('--previous-start TIME', 'Comparison window start. Defaults to one window before current start.') do |value|
+    options[:previous_start] = value
+  end
+  parser.on('--branch BRANCH', 'CircleCI branch. Defaults to the repository default branch.') do |value|
+    options[:branch] = value
+  end
+  parser.on('--include-jobs', 'Collect CircleCI job-level data for library repos.') { options[:include_jobs] = true }
+end.parse!
+
+puts ProductivityCollector.new(options).call
+
+# rubocop:enable Metrics/ClassLength, Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity


### PR DESCRIPTION
## What

- Add a `productivity-summary` workflow for daily and weekly repository health reports across delivery flow, CI quality, release/deploy activity, and service reliability.
- Register the workflow in the shared agent guidance and document its evidence sources, metric definitions, output shape, credentials, and missing-data rules.
- Add an executable Ruby collector that gathers local git, GitHub, CircleCI, DigitalOcean, Kubernetes, and UptimeRobot evidence in one read-only command, with `.cd` service detection, default-branch CI collection, daily/weekly mode labeling, explicit unavailable-source reporting, and HTTP timeouts.

## Why

- Replaces repeated ad hoc API and CLI probes with one reusable collector, reducing approval friction while keeping operational collection read-only.
- Gives library and deployed-service repositories a consistent period-over-period summary path without ranking individuals, using line counts as productivity claims, or hiding missing external data.
- Makes deployed service summaries richer by combining CI deploy jobs, collection-time Kubernetes state, DigitalOcean cluster state, and UptimeRobot monitor evidence when credentials are configured.

## Testing

- `ruby -c skills/productivity-summary/scripts/collect.rb` - passed
- `RUBOCOP_CACHE_ROOT=/private/tmp/rubocop-cache make lint` - passed
- `make skills-lint` - passed
- `make dep` - passed
- `make clean-dep` - passed
- `make sec` - passed
- `make scripts-lint` - passed
- `make docker-lint` - passed
- `skills/productivity-summary/scripts/collect.rb --repo /Users/alejandro/code/bin --current-start '2026-06-14 00:00:00 +0200' --current-end '2026-06-15 00:00:00 +0200'` - passed; verified local library collection, explicit unavailable network sources under the sandbox, and `library daily summary` mode labeling.
- `skills/productivity-summary/scripts/collect.rb --repo /Users/alejandro/code/standort --current-start '2026-06-14 00:00:00 +0200' --current-end '2026-06-15 00:00:00 +0200'` - passed; verified service collection across GitHub, CircleCI jobs, DigitalOcean, Kubernetes, and UptimeRobot.

AI-assisted-by: [Codex](https://openai.com/codex/)
