### PR TITLE
feat(skills): emit report-ready productivity evidence

### DIFF
--- a/skills/productivity-summary/SKILL.md
+++ b/skills/productivity-summary/SKILL.md
@@ -33,12 +33,14 @@ comparison period.
 3. Read `references/sources.md` before collecting data.
 4. Read `references/metrics.md` before calculating or naming metrics.
 5. Read `references/output.md` before writing the final summary.
-6. Prefer `scripts/collect.rb` for collection when Ruby is available. It
-   performs the local, GitHub, CircleCI, DigitalOcean/Kubernetes, and
-   UptimeRobot read-only collection in one command and returns JSON.
-7. If the script cannot cover the requested scope, collect the narrowest
-   credible evidence manually. Prefer local repository facts first, then
-   authenticated source APIs or CLIs when available.
+6. Use `scripts/collect.rb` as the default collection path when Ruby is
+   available. It performs the local, GitHub, CircleCI,
+   DigitalOcean/Kubernetes, and UptimeRobot read-only collection in one command
+   and returns report-ready JSON with metrics and source summaries.
+7. Collect evidence manually only for requested scope that `scripts/collect.rb`
+   cannot cover or when Ruby is unavailable. Keep the manual collection as
+   narrow as possible, and state why the collector was insufficient before
+   relying on local repository facts, authenticated source APIs, or CLIs.
 8. Keep missing data explicit. Use `n/a` only when the source is unavailable,
    not when the metric is inconvenient to compute.
 9. Keep collection read-only. API calls, `gh`, `curl`, `git log`, and
@@ -79,7 +81,8 @@ comparison period.
 
 ## References
 
-- Run `scripts/collect.rb --repo <path>` to collect summary evidence in JSON.
+- Run `scripts/collect.rb --repo <path>` first for report-ready metrics and
+  source summaries.
 - Read `references/sources.md` for source priority, credential names, and
   collection boundaries.
 - Read `references/metrics.md` for metric definitions, comparison logic, and

--- a/skills/productivity-summary/references/sources.md
+++ b/skills/productivity-summary/references/sources.md
@@ -18,11 +18,16 @@ Use this reference to choose evidence sources and report missing data clearly.
 
 ## Local Evidence
 
-Prefer the bundled collector when available:
+Use the bundled collector as the default collection path when Ruby is
+available:
 
 ```bash
 ruby <skill-dir>/scripts/collect.rb --repo <repo-path>
 ```
+
+The collector returns report-ready metrics and source summaries. Use the manual
+commands below only for requested scope that the collector cannot cover or when
+Ruby is unavailable; state that collector gap before relying on manual evidence.
 
 Useful local commands include:
 

--- a/skills/productivity-summary/scripts/collect.rb
+++ b/skills/productivity-summary/scripts/collect.rb
@@ -51,7 +51,7 @@ class ProductivityCollector
       uptimerobot: mode == 'service' ? collect_uptimerobot(owner_repo.split('/').last) : skipped('not a service repo')
     }
 
-    JSON.pretty_generate(result)
+    JSON.pretty_generate(summary_result(result))
   end
 
   private
@@ -142,10 +142,22 @@ class ProductivityCollector
   def collect_github(owner_repo)
     return skipped('gh is not installed') unless command_available?('gh')
 
+    open_prs = gh_json(
+      'pr', 'list', '--repo', owner_repo, '--state', 'open',
+      '--json', 'number,title,createdAt,updatedAt,url'
+    )
+    stale_prs = open_prs.select do |pull_request|
+      updated = pull_request['updatedAt'] && Time.parse(pull_request.fetch('updatedAt'))
+      updated && updated < @current_end - (7 * 24 * 60 * 60)
+    end
+
     {
       current: github_period(owner_repo, @current_start, @current_end),
       previous: github_period(owner_repo, @previous_start, @previous_end),
-      open_pr_count: gh_json('pr', 'list', '--repo', owner_repo, '--state', 'open', '--json', 'number').length
+      open_pr_count: open_prs.length,
+      open_prs: open_prs,
+      stale_pr_count: stale_prs.length,
+      stale_prs: stale_prs
     }
   rescue StandardError => e
     unavailable(e.message)
@@ -397,6 +409,175 @@ class ProductivityCollector
     data.fetch('monitors', []).find do |item|
       [item['friendly_name'], item['url']].compact.any? { |value| value.include?(name) }
     end
+  end
+
+  def summary_result(result)
+    {
+      repository: result[:repository],
+      repo_path: result[:repo_path],
+      branch: result[:branch],
+      mode: result[:mode],
+      timezone: result[:timezone],
+      window: result[:window],
+      comparison_window: result[:comparison_window],
+      sources: source_summary(result),
+      delivery_flow: summary_delivery_flow(result),
+      ci_quality: summary_ci_quality(result),
+      release_and_deploy: summary_release_and_deploy(result),
+      service_reliability: summary_service_reliability(result),
+      notable_work: summary_notable_work(result)
+    }
+  end
+
+  def source_summary(result)
+    %i[local github circleci digitalocean kubernetes uptimerobot].to_h do |name|
+      value = result[name]
+      status = value.is_a?(Hash) && value[:status] ? value[:status] : 'used'
+      notes = value.is_a?(Hash) ? value[:reason] : nil
+      [name, notes ? { status: status, notes: notes } : { status: status }]
+    end
+  end
+
+  def summary_delivery_flow(result)
+    github = result[:github]
+    {
+      current: summary_delivery_period(result.dig(:local, :current), summary_github_period(github, :current)),
+      previous: summary_delivery_period(result.dig(:local, :previous), summary_github_period(github, :previous)),
+      open_pr_count: github_value(github, :open_pr_count),
+      stale_pr_count: github_value(github, :stale_pr_count),
+      stale_prs: github_value(github, :stale_prs)
+    }
+  end
+
+  def summary_delivery_period(local, github)
+    {
+      commit_count: local && local[:commit_count],
+      pr_opened: github && github[:pr_opened],
+      pr_merged: github && github[:pr_merged],
+      pr_closed_unmerged: github && github[:pr_closed_unmerged],
+      median_pr_age_seconds: github && github[:median_pr_age_seconds],
+      median_review_latency_seconds: github && github[:median_review_latency_seconds],
+      prs_with_reviews: github && github[:prs_with_reviews],
+      rollback_or_revert_count: local && local[:rollback_or_revert_count]
+    }
+  end
+
+  def summary_ci_quality(result)
+    circleci = result[:circleci]
+    return circleci if unavailable_source?(circleci)
+
+    {
+      current: summary_ci_period(circleci[:current]),
+      previous: summary_ci_period(circleci[:previous]),
+      flaky_tests: circleci[:flaky_tests],
+      config: circleci[:config],
+      pipelines_collected: circleci[:pipelines_collected],
+      workflows_collected: circleci[:workflows_collected],
+      jobs_collected: circleci[:jobs_collected]
+    }
+  end
+
+  def summary_ci_period(period)
+    return nil unless period
+
+    {
+      workflows_total: period[:workflows_total],
+      workflows_completed: period[:workflows_completed],
+      workflows_successful: period[:workflows_successful],
+      workflows_failed: period[:workflows_failed],
+      workflow_success_rate: period[:workflow_success_rate],
+      median_workflow_duration_seconds: period[:median_workflow_duration_seconds],
+      p95_workflow_duration_seconds: period[:p95_workflow_duration_seconds],
+      failed_workflows: period[:failed_workflows],
+      deploy_job: period.dig(:jobs, 'deploy')
+    }
+  end
+
+  def summary_release_and_deploy(result)
+    {
+      current: summary_release_period(result.dig(:local, :current), result.dig(:circleci, :current)),
+      previous: summary_release_period(result.dig(:local, :previous), result.dig(:circleci, :previous))
+    }
+  end
+
+  def summary_release_period(local, circleci)
+    deploy_job = circleci&.dig(:jobs, 'deploy')
+    {
+      tag_count: local && local[:tag_count],
+      tags: local && local[:tags],
+      rollback_or_revert_count: local && local[:rollback_or_revert_count],
+      rollback_or_revert_subjects: local && local[:rollback_or_revert_subjects],
+      deploy_job: deploy_job
+    }
+  end
+
+  def summary_service_reliability(result)
+    {
+      digitalocean: result[:digitalocean],
+      kubernetes: summary_kubernetes(result[:kubernetes]),
+      uptimerobot: summary_uptimerobot(result[:uptimerobot])
+    }
+  end
+
+  def summary_kubernetes(kubernetes)
+    return kubernetes if unavailable_source?(kubernetes)
+
+    pods = kubernetes.fetch(:pods, [])
+    {
+      status: kubernetes[:status],
+      context: kubernetes[:context],
+      deployments: kubernetes[:deployments],
+      pod_count: pods.length,
+      ready_pod_count: pods.count { |pod| pod[:ready] },
+      pod_restart_count: pods.sum { |pod| pod[:restarts].to_i },
+      pods: pods
+    }
+  end
+
+  def summary_uptimerobot(uptimerobot)
+    return uptimerobot if unavailable_source?(uptimerobot)
+
+    current_uptime, previous_uptime = uptime_ranges(uptimerobot)
+    {
+      status: uptimerobot[:status],
+      monitor: uptimerobot[:monitor],
+      current_uptime: current_uptime,
+      previous_uptime: previous_uptime,
+      logs: uptimerobot[:logs],
+      current_response_time_average_ms: uptimerobot[:current_response_time_average_ms],
+      current_response_time_samples: uptimerobot[:current_response_time_samples],
+      previous_response_time_average_ms: uptimerobot[:previous_response_time_average_ms],
+      previous_response_time_samples: uptimerobot[:previous_response_time_samples]
+    }
+  end
+
+  def summary_notable_work(result)
+    github = result[:github]
+    return github[:current][:merged_prs].first(20) if github.is_a?(Hash) && github.dig(:current, :merged_prs)
+
+    result.dig(:local, :current, :commits)&.map do |commit|
+      pick_symbol(commit, :sha, :authored_at, :subject)
+    end&.first(20)
+  end
+
+  def summary_github_period(github, period)
+    github[period] if github.is_a?(Hash) && !github[:status]
+  end
+
+  def github_value(github, key)
+    github[key] if github.is_a?(Hash) && !github[:status]
+  end
+
+  def unavailable_source?(value)
+    value.is_a?(Hash) && %w[skipped unavailable].include?(value[:status])
+  end
+
+  def uptime_ranges(uptimerobot)
+    uptimerobot.fetch(:uptime_ranges, '').split('-', 2)
+  end
+
+  def pick_symbol(hash, *keys)
+    keys.each_with_object({}) { |key, result| result[key] = hash[key] if hash.key?(key) }
   end
 
   def circleci_pipelines(owner_repo, branch, token)


### PR DESCRIPTION
## What

- Change the productivity summary collector to always emit report-ready JSON with delivery, CI, release/deploy, service reliability, source, and notable-work summaries.
- Add GitHub open and stale PR evidence to the collector output so review bottleneck metrics come from the bundled collection path.
- Tighten the productivity summary instructions so agents run `scripts/collect.rb --repo <path>` first and only collect manual evidence when the collector cannot cover the requested scope.

## Why

- Keeps productivity summaries on the repository-owned collector path instead of ad hoc one-off commands.
- Removes the compact/full output decision point, reducing workflow drift while preserving read-only source collection inside the script.

## Testing

- `zsh -lic 'ruby -c skills/productivity-summary/scripts/collect.rb'` - passed
- `zsh -lic 'make lint'` - passed
- `zsh -lic 'make skills-lint'` - passed
- `git diff --check` - passed
- `/usr/local/opt/ruby@4/bin/ruby skills/productivity-summary/scripts/collect.rb --repo /Users/alejandro/code/bezeichner --timezone Europe/Berlin --current-start '2026-06-08 00:00:00 +0200' --current-end '2026-06-15 00:00:00 +0200' --previous-start '2026-06-01 00:00:00 +0200'` - passed
