### PR TITLE
docs(readme): clarify shared tooling command contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@ include build/make/help.mak
 include build/make/ruby.mak
 include build/make/git.mak
 
-# Lint all scripts.
+# Lint Bash scripts under build/, quality/, and lib/ with ShellCheck.
 scripts-lint:
 	@quality/shell/lint
 
-# Lint shared skill policy markers.
+# Lint skill frontmatter, OpenAI metadata, and shared policy markers.
 skills-lint:
 	@quality/skills/lint
 

--- a/README.md
+++ b/README.md
@@ -88,8 +88,9 @@ repository Make targets.
 Some helpers intentionally depend on tools or services outside this repository:
 Docker helpers assume the consuming project supplies image names and release
 version files; security helpers assume Trivy is available; shell and Dockerfile
-lint targets depend on `shellcheck` and `hadolint`; `build/docker/env` needs SSH
-access to clone or update the sibling `../docker` repository when it is missing.
+lint targets depend on `shellcheck` and `hadolint`; `build/docker/env` pulls,
+rebases, and updates submodules in an existing sibling `../docker` checkout, or
+uses SSH to clone `git@github.com:alexfalkowski/docker.git` there when missing.
 
 ## 🔗 References
 

--- a/build/make/_service.mak
+++ b/build/make/_service.mak
@@ -26,17 +26,19 @@ tidy:
 vendor:
 	@go mod vendor
 
+# Run fieldalignment; .gofa may list comma-separated packages, default ./...
 field-alignment:
 	@$(BIN_ROOT)/build/go/fa
 
+# Auto-fix fieldalignment; .gofa may list comma-separated packages, default ./...
 fix-field-alignment:
 	@$(BIN_ROOT)/build/go/fa -fix
 
-# Run golangci-lint with build-tags=features. Set package=<path> to lint one package.
+# Run golangci-lint with build-tags=features. Use package=internal/foo, not ./...
 golangci-lint:
 	@$(BIN_ROOT)/build/go/lint run --build-tags features  --timeout 5m
 
-# Auto-fix golangci-lint issues with build-tags=features. Set package=<path> to lint one package.
+# Auto-fix golangci-lint with build-tags=features. Use package=internal/foo.
 fix-golangci-lint:
 	@$(BIN_ROOT)/build/go/lint run --build-tags features --timeout 5m --fix
 
@@ -73,6 +75,7 @@ ruby-outdated-dep:
 # List outdated Go modules and Ruby gems.
 outdated-dep: go-outdated-dep ruby-outdated-dep
 
+# Merge coverage into final.cov using .gocov regex, default test|\.pb|main\.go.
 sanitize-coverage:
 	@$(BIN_ROOT)/quality/go/covmerge
 
@@ -108,7 +111,7 @@ benchmarks: build
 	@make -C test benchmarks
 
 # Run Go tests with gotestsum (race + coverage) and write reports under test/reports/.
-# Set package=<path> to test one package.
+# Set package=internal/foo, not ./internal/foo, to test one package.
 specs:
 	@$(BIN_ROOT)/build/go/test "$(if $(package),,$(COVER_PACKAGES))" $(if $(package),,$(PACKAGES))
 
@@ -168,11 +171,11 @@ clean:
 go-sec:
 	@govulncheck -show verbose -test ./...
 
-# Scan the test image with Trivy (CRITICAL severity); set image_type=production for the versioned image.
+# Scan Docker image for platform=amd64|arm64; production no-ops without a release version file.
 trivy-image:
 	@$(BIN_ROOT)/build/sec/trivy-image "$${NAME}" "$${platform}" "$(or $(image_type),test)"
 
-# Scan the repository with Trivy (CRITICAL severity).
+# Scan the repository with Trivy, excluding .ruby-lsp, bin, vendor, and test/vendor.
 trivy-repo:
 	@$(BIN_ROOT)/build/sec/trivy-repo
 
@@ -187,23 +190,23 @@ build:
 build-test:
 	@go test -vet=off -race -mod vendor -c -tags features -covermode=atomic -coverpkg=$(COVER_PACKAGES) -o "$${NAME}" "$${MODULE}"
 
-# Build a test docker image; set image_type=production for the versioned image.
+# Build Docker image for platform=amd64|arm64; production no-ops without a release version file.
 build-docker:
 	@$(BIN_ROOT)/build/docker/build "$${NAME}" "$${platform}" "$(or $(image_type),test)"
 
 # Build and scan the test docker image.
 test-docker: build-docker trivy-image
 
-# Push the versioned image to docker hub (only if the version file exists).
+# Push production image for platform=amd64|arm64; no-ops without a release version file.
 push-docker: override image_type := production
 push-docker:
 	@$(BIN_ROOT)/build/docker/push "$${NAME}" "$${platform}" "$(or $(image_type),production)"
 
-# Build, scan, and push the versioned docker image.
+# Build, scan, and push production image; no-ops without a release version file.
 release-docker: override image_type := production
 release-docker: build-docker trivy-image push-docker
 
-# Create and push multi-arch manifests (only if the version file exists).
+# Create and push multi-arch manifests; no-ops without a release version file.
 manifest-docker:
 	@$(BIN_ROOT)/build/docker/manifest "$${NAME}"
 
@@ -217,7 +220,7 @@ create-certs:
 	@mkcert -client -key-file test/certs/client-key.pem -cert-file test/certs/client-cert.pem localhost
 	@cp "$$(mkcert -CAROOT)/rootCA.pem" test/certs/rootCA.pem
 
-# Generate a dependency graph PNG for package=$(package), or the module root when unset.
+# Generate assets/<package>.png with goda+dot; package=internal/foo, default assets/diagram.png.
 create-diagram:
 	@$(BIN_ROOT)/quality/go/create-diagram
 
@@ -229,10 +232,10 @@ analyse:
 cost:
 	@scc --no-duplicates --no-min-gen
 
-# Start shared docker environment via the sibling ../docker repo.
+# Start shared docker env, cloning/updating sibling ../docker over SSH as needed.
 start:
 	@$(BIN_ROOT)/build/docker/env start
 
-# Stop shared docker environment via the sibling ../docker repo.
+# Stop shared docker env, cloning/updating sibling ../docker over SSH as needed.
 stop:
 	@$(BIN_ROOT)/build/docker/env stop

--- a/build/make/buf.mak
+++ b/build/make/buf.mak
@@ -20,7 +20,7 @@ update-all-dep:
 generate:
 	@buf generate
 
-# Check whether generated protobuf outputs are stale.
+# Regenerate protobuf outputs, then fail if git diff finds stale generated files.
 stale: generate
 	@git diff --exit-code
 

--- a/build/make/git.mak
+++ b/build/make/git.mak
@@ -49,38 +49,38 @@ update-submodule:
 branch:
 	@printf "bin: current branch '%s'\n" "$$BRANCH"
 
-# Create and checkout a new branch named $(USER)/$(branch).
+# Create and checkout username-random/$(branch).
 checkout:
 	@git checkout -b "$(USER)/$(branch)"
 
 new-branch: latest checkout
 	@echo "bin: new branch '$(USER)/$(branch)'"
 
-# Start a new feature.
+# Start a new feature branch (name=<branch>, runs latest first).
 new-feature: branch=feat/$(NEW_BRANCH)
 new-feature: new-branch
 
-# Start a new fix.
+# Start a new fix branch (name=<branch>, runs latest first).
 new-fix: branch=fix/$(NEW_BRANCH)
 new-fix: new-branch
 
-# Start a new build.
+# Start a new build branch (name=<branch>, runs latest first).
 new-build: branch=build/$(NEW_BRANCH)
 new-build: new-branch
 
-# Start a new test.
+# Start a new test branch (name=<branch>, runs latest first).
 new-test: branch=test/$(NEW_BRANCH)
 new-test: new-branch
 
-# Start a new docs branch.
+# Start a new docs branch (name=<branch>, runs latest first).
 new-docs: branch=docs/$(NEW_BRANCH)
 new-docs: new-branch
 
-# Start with a refactor.
+# Start a new refactor branch (name=<branch>, runs latest first).
 new-refactor: branch=refactor/$(NEW_BRANCH)
 new-refactor: new-branch
 
-# Start a new release.
+# Start a new release branch (name=<branch>, runs latest first).
 new-release: branch=release/$(NEW_BRANCH)
 new-release: new-branch
 

--- a/build/make/go.mak
+++ b/build/make/go.mak
@@ -54,17 +54,19 @@ clean-lint:
 clean:
 	@$(BIN_ROOT)/build/go/clean
 
+# Run fieldalignment; .gofa may list comma-separated packages, default ./...
 field-alignment:
 	@$(BIN_ROOT)/build/go/fa
 
+# Auto-fix fieldalignment; .gofa may list comma-separated packages, default ./...
 fix-field-alignment:
 	@$(BIN_ROOT)/build/go/fa -fix
 
-# Run golangci-lint. Set package=<path> to lint one package.
+# Run golangci-lint. Set package=internal/foo, not ./internal/foo, for one package.
 golangci-lint:
 	@$(BIN_ROOT)/build/go/lint run --timeout 5m
 
-# Auto-fix golangci-lint issues. Set package=<path> to lint one package.
+# Auto-fix golangci-lint. Set package=internal/foo, not ./internal/foo.
 fix-golangci-lint:
 	@$(BIN_ROOT)/build/go/lint run --timeout 5m --fix
 
@@ -79,11 +81,11 @@ format:
 	@go fmt ./...
 
 # Run tests with gotestsum (race + coverage) and write reports under test/reports/.
-# Set package=<path> to test one package.
+# Set package=internal/foo, not ./internal/foo, to test one package.
 specs:
 	@$(BIN_ROOT)/build/go/test "$(if $(package),,$(COVER_PACKAGES))" $(if $(package),,$(PACKAGES))
 
-# Run benchmarks for package=$(package), or the module root when unset.
+# Run benchmarks for package=internal/foo, or the module root when unset.
 # Set benchtime=<duration-or-count> to pass -benchtime to go test.
 benchmark:
 	@$(BIN_ROOT)/quality/go/benchmark
@@ -92,6 +94,7 @@ benchmark:
 benchmark-pprof:
 	@$(BIN_ROOT)/quality/go/benchmark-pprof
 
+# Filter test/reports/profile.cov into final.cov using .gocov regex, default test.
 remove-generated-coverage:
 	@$(BIN_ROOT)/quality/go/covfilter
 
@@ -118,7 +121,7 @@ clean-reports:
 govulncheck:
 	@govulncheck -show verbose -test ./...
 
-# Scan the repository with Trivy (CRITICAL severity).
+# Scan the repository with Trivy, excluding .ruby-lsp, bin, vendor, and test/vendor.
 trivy-repo:
 	@$(BIN_ROOT)/build/sec/trivy-repo
 
@@ -135,7 +138,7 @@ create-certs:
 	@mkcert -client -key-file test/certs/client-key.pem -cert-file test/certs/client-cert.pem localhost
 	@cp "$$(mkcert -CAROOT)/rootCA.pem" test/certs/rootCA.pem
 
-# Generate a dependency graph PNG for package=$(package), or the module root when unset.
+# Generate assets/<package>.png with goda+dot; package=internal/foo, default assets/diagram.png.
 create-diagram:
 	@$(BIN_ROOT)/quality/go/create-diagram
 
@@ -147,10 +150,10 @@ analyse:
 cost:
 	@scc --no-duplicates --no-min-gen
 
-# Start shared docker environment via the sibling ../docker repo.
+# Start shared docker env, cloning/updating sibling ../docker over SSH as needed.
 start:
 	@$(BIN_ROOT)/build/docker/env start
 
-# Stop shared docker environment via the sibling ../docker repo.
+# Stop shared docker env, cloning/updating sibling ../docker over SSH as needed.
 stop:
 	@$(BIN_ROOT)/build/docker/env stop

--- a/build/make/grpc.mak
+++ b/build/make/grpc.mak
@@ -29,7 +29,7 @@ proto-breaking:
 proto-generate:
 	@make -C api generate
 
-# Check whether generated code from api/ protobufs is stale.
+# Regenerate api/ protobuf outputs, then fail if git diff finds stale files.
 proto-stale:
 	@make -C api stale
 

--- a/build/make/ruby.mak
+++ b/build/make/ruby.mak
@@ -57,7 +57,7 @@ clean-reports:
 codecov-upload:
 	@codecovcli --verbose upload-process --fail-on-error -F service -f test/reports/coverage.xml
 
-# Scan the repository with Trivy (CRITICAL severity).
+# Scan the repository with Trivy, excluding .ruby-lsp, bin, vendor, and test/vendor.
 trivy-repo:
 	@$(BIN_ROOT)/build/sec/trivy-repo
 
@@ -68,10 +68,10 @@ sec: trivy-repo
 cost:
 	@scc --no-duplicates --no-min-gen
 
-# Start shared docker environment via the sibling ../docker repo.
+# Start shared docker env, cloning/updating sibling ../docker over SSH as needed.
 start:
 	@$(BIN_ROOT)/build/docker/env start
 
-# Stop shared docker environment via the sibling ../docker repo.
+# Stop shared docker env, cloning/updating sibling ../docker over SSH as needed.
 stop:
 	@$(BIN_ROOT)/build/docker/env stop

--- a/skills/productivity-summary/agents/openai.yaml
+++ b/skills/productivity-summary/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Productivity Summary"
   short_description: "Summarize repo delivery and health"
-  default_prompt: "Use $productivity-summary to produce a weekly delivery, quality, and reliability summary for this repository."
+  default_prompt: "Use $productivity-summary to produce daily or weekly delivery, CI quality, release/deploy, and service-reliability summaries for the requested repository and period, with explicit comparison windows and missing-source boundaries."

--- a/skills/productivity-summary/scripts/collect.rb
+++ b/skills/productivity-summary/scripts/collect.rb
@@ -768,15 +768,20 @@ options = {
 
 OptionParser.new do |parser|
   parser.banner = 'Usage: collect.rb [options]'
+  parser.separator 'Windows of 24 hours or less are classified as daily; longer windows are weekly.'
   parser.on('--repo PATH', 'Repository path. Defaults to the current directory.') do |value|
     options[:repo_path] = value
   end
   parser.on('--timezone TZ', 'Timezone for default windows. Defaults to TZ or Europe/Berlin.') do |value|
     options[:timezone] = value
   end
-  parser.on('--current-start TIME', 'Current window start.') { |value| options[:current_start] = value }
-  parser.on('--current-end TIME', 'Current window end.') { |value| options[:current_end] = value }
-  parser.on('--previous-start TIME', 'Comparison window start. Defaults to one window before current start.') do |value|
+  parser.on('--current-start TIME', 'Window start parsed by Ruby Time.parse; default is 7 days before end.') do |value|
+    options[:current_start] = value
+  end
+  parser.on('--current-end TIME', 'Window end parsed by Ruby Time.parse; default is local day start.') do |value|
+    options[:current_end] = value
+  end
+  parser.on('--previous-start TIME', 'Comparison start parsed by Time.parse; default is one window earlier.') do |value|
     options[:previous_start] = value
   end
   parser.on('--branch BRANCH', 'CircleCI branch. Defaults to the repository default branch.') do |value|

--- a/skills/reliability-gaps/agents/openai.yaml
+++ b/skills/reliability-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Reliability Gaps"
   short_description: "Find scoped SRE readiness gaps"
-  default_prompt: "Use $reliability-gaps with its active goal and plan to find scoped reliability gaps, answer REL-N follow-ups, and implement each agreed fix with explicit TDD, red, green, refactor, and validation reporting."
+  default_prompt: "Use $reliability-gaps with its active goal and plan to find scoped reliability gaps, answer REL-N follow-ups, and implement agreed fixes. For behavior-changing fixes, report the TDD decision plus Red, Green, Refactor, and Validation; otherwise use the appropriate docs/config validation path."


### PR DESCRIPTION
## What

- Tighten command help for shared Make targets so package arguments, Docker release behavior, coverage filtering, diagram output, stale generation checks, Trivy exclusions, and docker environment side effects are explicit.
- Clarify the root README operations note for the sibling docker environment checkout/update behavior.
- Update skill metadata and productivity summary CLI help so agent prompts and time-window defaults match the implemented workflows.

## Why

- Reduces ambiguity in shared tooling that downstream projects consume through ./bin, especially where a short target comment is the primary command contract in make help.
- Makes the doc-gap pass stricter by documenting non-obvious defaults, side effects, and no-op conditions in the surface users actually see before running a target.
- Resolves pre-PR review findings around Docker release version-file wording and direct checkout behavior before publishing the draft PR.

## Testing

- `make dep` - passed
- `make clean-dep` - passed
- `make help` - passed
- `make lint` - passed
- `make skills-lint` - passed
- `make scripts-lint` - passed
- `make docker-lint` - passed
- `make sec` - passed
- `git diff --check` - passed
- Known gap: there is no dedicated automated assertion for `collect.rb --help` text, the exact 24-hour daily/weekly boundary, or semantic drift between `agents/openai.yaml` prompts and their skill bodies.
