### PR TITLE
feat(skills): improve agent trigger metadata

### DIFF
--- a/quality/skills/lint
+++ b/quality/skills/lint
@@ -138,7 +138,10 @@ require_pattern skills/code-issues/SKILL.md "After the human agrees and before e
 require_pattern skills/test-gaps/SKILL.md "After the human agrees and before editing, state the selected local test pattern"
 require_pattern skills/doc-gaps/SKILL.md "After the human agrees and before editing, state the selected local documentation pattern"
 require_pattern skills/reliability-gaps/SKILL.md "After the human agrees and before editing, state the selected local code/config/docs pattern"
-require_pattern skills/reliability-gaps/SKILL.md "asks what the fix is for REL-<number>"
+require_pattern skills/code-issues/SKILL.md "asks about issue IDs such as ISSUE-1"
+require_pattern skills/test-gaps/SKILL.md "asks about test gap IDs such as TEST-1"
+require_pattern skills/doc-gaps/SKILL.md "asks about doc gap IDs such as DOC-1"
+require_pattern skills/reliability-gaps/SKILL.md "asks about reliability gap IDs such as REL-1"
 require_pattern skills/reliability-gaps/SKILL.md "state the reliability execution checklist before editing"
 require_pattern skills/reliability-gaps/SKILL.md "\`Red\`, \`Green\`, \`Refactor\`, and \`Validation\`"
 
@@ -146,7 +149,10 @@ require_pattern skills/project-workflow/agents/openai.yaml "Treat AGENTS.md and 
 require_pattern skills/testing-standards/agents/openai.yaml "MUST identify the dominant relevant existing test harness before editing"
 require_pattern skills/testing-standards/agents/openai.yaml "stop on unexpected green tests"
 require_pattern skills/go-standards/agents/openai.yaml "MUST NOT invent import aliases for readability, caution, brevity, or personal clarity"
-require_pattern skills/reliability-gaps/agents/openai.yaml "answer REL-N follow-ups"
+require_pattern skills/reliability-gaps/agents/openai.yaml "answer reliability gap ID follow-ups such as REL-1"
+require_pattern skills/code-issues/agents/openai.yaml "answer issue ID follow-ups such as ISSUE-1"
+require_pattern skills/test-gaps/agents/openai.yaml "answer test gap ID follow-ups such as TEST-1"
+require_pattern skills/doc-gaps/agents/openai.yaml "answer doc gap ID follow-ups such as DOC-1"
 require_pattern skills/change-validation/agents/openai.yaml "file changes make prior validation stale"
 
 exit "$missing"

--- a/skills/change-safety/SKILL.md
+++ b/skills/change-safety/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: change-safety
-description: Protects compatibility, documented interfaces, migrations, generated files, dependencies, and user-facing behavior during changes. Use before edits to APIs, commands, flags, environment variables, file formats, Make targets, docs, auth, or shell execution; use code-review for general bug finding.
+description: Use when changes may affect compatibility, documented interfaces, migrations, generated files, dependencies, or user-facing behavior. Protect APIs, commands, flags, environment variables, file formats, Make targets, docs, auth, and shell execution; use code-review for general bug finding.
 ---
 
 # Change Safety

--- a/skills/change-validation/SKILL.md
+++ b/skills/change-validation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: change-validation
-description: Chooses and reports credible validation commands for tests, linting, CI checks, security checks, benchmarks, and generated outputs. Use when running or selecting validation after code, docs, Makefile, shell, Dockerfile, Go, Ruby, or shared ./bin changes.
+description: Use when running or selecting validation after code, docs, Makefile, shell, Dockerfile, Go, Ruby, generated-output, CI, security, benchmark, or shared ./bin changes. Choose and report credible repository-defined checks.
 ---
 
 # Change Validation

--- a/skills/code-issues/SKILL.md
+++ b/skills/code-issues/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: code-issues
-description: Finds concrete bugs, security issues, compatibility breaks, and public contract violations in a package or folder, records them in that scope's ISSUES.md, and later proposes and implements explicitly agreed fixes one code issue at a time. Use when the user asks to find $code-issues in a package or folder, find code issues in a package or folder, implement $code-issues in a package or folder, or implement code issues in a package or folder.
+description: Use when the user asks to find $code-issues in a package or folder, find code issues in a package or folder, implement $code-issues in a package or folder, implement code issues in a package or folder, asks about issue IDs such as ISSUE-1, asks what the fix is for ISSUE-1, asks to fix or verify ISSUE-1, or says ISSUE-1 is done. Find concrete bugs, security issues, compatibility breaks, and public contract violations, record them in scoped ISSUES.md, and later propose and implement agreed fixes one code issue at a time.
 ---
 
 # Code Issues
 
 Use this skill in two distinct modes:
 
-- **Find mode**: `Find $code-issues in <package/folder>` or `Find code issues in <package/folder>`.
-- **Implement mode**: `Implement $code-issues in <package/folder>` or `Implement code issues in <package/folder>`.
+- **Find mode**: `Find $code-issues in PACKAGE_OR_FOLDER` or `Find code issues in PACKAGE_OR_FOLDER`.
+- **Implement mode**: `Implement $code-issues in PACKAGE_OR_FOLDER` or `Implement code issues in PACKAGE_OR_FOLDER`.
 
 Do not combine the two modes in one pass.
 
@@ -33,9 +33,9 @@ Follow `references/plan.md#find-mode-plan`.
 These rules remain mandatory:
 
 - If no scope is provided, stop and ask for the package or folder.
-- Use `ISSUES.md` in the requested package or folder as the review ledger, for example `<package/folder>/ISSUES.md`.
+- Use `ISSUES.md` in the requested package or folder as the review ledger, for example `PACKAGE_OR_FOLDER/ISSUES.md`.
 - If `ISSUES.md` already exists in the requested package or folder, stop. Tell the user the existing scoped ledger must be resolved first, or the human must delete that scoped `ISSUES.md` before a new find pass there.
-- Treat `Find $code-issues in <package/folder>` or `Find code issues in <package/folder>` as the user's explicit request to delegate review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
+- Treat `Find $code-issues in PACKAGE_OR_FOLDER` or `Find code issues in PACKAGE_OR_FOLDER` as the user's explicit request to delegate review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
 - Use sub-agents for Find mode whenever the active runtime provides them and runtime policy/tooling permits delegation. Do not treat sub-agents as optional based on scope size, and do not perform the find review locally first.
 - Do not claim that extra delegation wording is needed before launching review agents. The Find mode invocation is the explicit delegation request.
 - If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
@@ -50,7 +50,7 @@ These rules remain mandatory:
 - Do not report optional regression tests, unused convenience aliases, API symmetry, or documentation polish as findings by themselves. List them only as testing gaps, doc gaps, or optional follow-up notes when relevant.
 - If no confirmed code issues are found, report that no code issues were found and do not create `ISSUES.md`.
 - If confirmed code issues are found, write all findings to the scoped `ISSUES.md` before making any fixes.
-- Assign every finding a unique ID for the session in the form `ISSUE-<number>`.
+- Assign every finding a unique ID for the session in the form `ISSUE-N`.
 - Stop after presenting the ledger and plan. Do not fix findings in the same pass.
 
 ## `ISSUES.md` Format
@@ -93,7 +93,7 @@ These rules remain mandatory:
 - After the human agrees and before editing, state the selected local code pattern, dominant relevant test harness, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
 - Implement only the agreed issue with the smallest safe change.
 - Use `$testing-standards` when deciding whether to add or update regression tests for the fix, and prefer its test-first or scenario-first loop when a behavior-changing fix has a credible test or BDD layer.
-- Do not move to the next issue until the human says `ISSUE-<number> is done`.
+- Do not move to the next issue until the human says `ISSUE-N is done`.
 - After the human confirms an issue is done, remove that issue from scoped `ISSUES.md`. If an issue is deemed invalid or not actually a code issue, remove it only after explaining why and getting human agreement.
 - Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
 

--- a/skills/code-issues/agents/openai.yaml
+++ b/skills/code-issues/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Code Issues"
   short_description: "Find scoped code defects and risks"
-  default_prompt: "Use $code-issues with its active goal and plan to delegate scoped code issue finding, store confirmed findings in that scope's ISSUES.md, or propose and implement explicitly agreed fixes one code issue at a time."
+  default_prompt: "Use $code-issues with its active goal and plan to delegate scoped code issue finding, store confirmed findings in that scope's ISSUES.md, answer issue ID follow-ups such as ISSUE-1, or propose and implement explicitly agreed fixes one code issue at a time."

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: Reviews changed code for bugs, regressions, risky assumptions, missing tests, compatibility breaks, missing or stale documentation, and language-specific maintainability or idiom risks. Use when the user asks for a general code review, diff review, PR check, or pre-merge issue pass; pair documentation judgment with $doc-standards and delegate explicit security scope to $security-audit.
+description: Use when the user asks for a general code review, diff review, PR check, or pre-merge issue pass. Review changed code for bugs, regressions, risky assumptions, missing tests, compatibility breaks, missing or stale documentation, and language-specific maintainability or idiom risks; pair documentation judgment with $doc-standards and delegate explicit security scope to $security-audit.
 ---
 
 # Code Review

--- a/skills/doc-gaps/SKILL.md
+++ b/skills/doc-gaps/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: doc-gaps
-description: Finds and fixes concrete missing, weak, stale, or misleading documentation in a package or folder in one pass, including README files, user-facing docs, examples, command help, package docs, public API comments, code comments, and docstrings required by $doc-standards and relevant language standards. Uses parallel review agents when the active runtime provides them and permits delegation, applies confirmed documentation fixes, validates the changes, and writes ISSUES.md only for audit-only requests or unresolved gaps. Use when the user asks to run $doc-gaps in a package or folder, find doc gaps in a package or folder, fix doc gaps in a package or folder, review docs for gaps, or audit-only doc gaps.
+description: Use when the user asks to run $doc-gaps in a package or folder, find doc gaps in a package or folder, fix doc gaps in a package or folder, review docs for gaps, audit-only doc gaps, asks about doc gap IDs such as DOC-1, asks what the fix is for DOC-1, asks to fix or verify DOC-1, or says DOC-1 is done. Find and fix concrete missing, weak, stale, or misleading documentation in one pass, including README files, user-facing docs, examples, command help, package docs, public API comments, code comments, and docstrings required by $doc-standards and relevant language standards.
 ---
 
 # Doc Gaps
 
 Use this skill in one-pass mode by default:
 
-- **One-pass mode**: `Run $doc-gaps in <package/folder>`, `Find doc gaps in <package/folder>`, or `Fix doc gaps in <package/folder>`.
-- **Audit-only mode**: `Audit-only $doc-gaps in <package/folder>` or `Find doc gaps in <package/folder> without editing`.
+- **One-pass mode**: `Run $doc-gaps in PACKAGE_OR_FOLDER`, `Find doc gaps in PACKAGE_OR_FOLDER`, or `Fix doc gaps in PACKAGE_OR_FOLDER`.
+- **Audit-only mode**: `Audit-only $doc-gaps in PACKAGE_OR_FOLDER` or `Find doc gaps in PACKAGE_OR_FOLDER without editing`.
 
 Before starting one-pass mode or audit-only mode, read `references/plan.md` and
 use it to maintain the active execution plan. The active plan is runtime state;
@@ -32,7 +32,7 @@ Follow `references/plan.md#one-pass-mode-plan`.
 These rules remain mandatory:
 
 - If no scope is provided, stop and ask for the package or folder.
-- Treat `Run $doc-gaps in <package/folder>`, `Find doc gaps in <package/folder>`, or `Fix doc gaps in <package/folder>` as permission to delegate review, edit documentation in scope, run appropriate validation, and summarize the result in one pass.
+- Treat `Run $doc-gaps in PACKAGE_OR_FOLDER`, `Find doc gaps in PACKAGE_OR_FOLDER`, or `Fix doc gaps in PACKAGE_OR_FOLDER` as permission to delegate review, edit documentation in scope, run appropriate validation, and summarize the result in one pass.
 - Use audit-only mode only when the user explicitly asks not to edit or asks only for an audit or ledger. When a stop gate prevents a correct documentation fix during one-pass mode, record unresolved confirmed findings instead of switching modes.
 - If scoped `ISSUES.md` already exists, read it before reviewing. If it is a doc-gap ledger, include unresolved findings in the candidate set and update or delete the ledger after fixing them. If it is unrelated or ambiguous active work, stop and ask before editing it.
 - Use as many independent review agents as the runtime can safely run when the active runtime provides sub-agents and runtime policy/tooling permits delegation. Do not perform the doc-gap review locally first when delegation is available.
@@ -66,11 +66,11 @@ Follow `references/plan.md#audit-only-mode-plan`.
 These rules remain mandatory:
 
 - If no scope is provided, stop and ask for the package or folder.
-- Use `ISSUES.md` in the requested package or folder as the audit ledger, for example `<package/folder>/ISSUES.md`.
+- Use `ISSUES.md` in the requested package or folder as the audit ledger, for example `PACKAGE_OR_FOLDER/ISSUES.md`.
 - If `ISSUES.md` already exists in the requested package or folder, stop unless the human explicitly asked to refresh or overwrite that scoped ledger.
 - Use the same delegation, surface-routing, candidate confirmation, severity, and out-of-scope rules as one-pass mode.
 - If no confirmed doc gaps are found, report that no doc gaps were found and do not create `ISSUES.md`.
-- If confirmed doc gaps are found, write all findings to the scoped `ISSUES.md` with `DOC-<number>` IDs.
+- If confirmed doc gaps are found, write all findings to the scoped `ISSUES.md` with `DOC-N` IDs.
 - Stop after presenting the audit ledger. Do not make fixes in audit-only mode.
 
 ## Documentation Review Standards

--- a/skills/doc-gaps/agents/openai.yaml
+++ b/skills/doc-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Doc Gaps"
   short_description: "Find and fix scoped doc adequacy gaps"
-  default_prompt: "Use $doc-gaps with its active goal and plan plus $doc-standards to run a one-pass scoped documentation gap workflow: delegate review broadly, apply the adequacy gate, route each gap to the authoritative documentation surface, identify wrong-location or missing non-obvious contracts, apply confirmed doc fixes, validate, and write ISSUES.md only for audit-only requests or unresolved gaps."
+  default_prompt: "Use $doc-gaps with its active goal and plan plus $doc-standards to run a one-pass scoped documentation gap workflow, answer doc gap ID follow-ups such as DOC-1, apply confirmed doc fixes, validate, and write ISSUES.md only for audit-only requests or unresolved gaps."

--- a/skills/doc-standards/SKILL.md
+++ b/skills/doc-standards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doc-standards
-description: Applies strict documentation adequacy standards for README files, user-facing docs, examples, command/config docs, public API comments, docstrings, and behavior changes that may make existing documentation stale. Use when writing, reviewing, or updating documentation; when changed code affects documented behavior; when $code-review or $review-pr needs documentation judgment; and when $doc-gaps needs criteria for scoped documentation triage.
+description: Use when writing, reviewing, or updating documentation; when changed code affects documented behavior; when $code-review or $review-pr needs documentation judgment; or when $doc-gaps needs criteria for scoped documentation triage. Apply strict documentation adequacy standards for README files, user-facing docs, examples, command/config docs, public API comments, docstrings, and stale-doc review.
 ---
 
 # Doc Standards
@@ -237,20 +237,20 @@ omit irrelevant sections rather than keeping placeholders to satisfy the
 example shape.
 
 ```markdown
-# 📦 <Project Name>
+# Project Name
 
-<One or two sentences explaining what this project does and who should use it.>
+One or two sentences explaining what this project does and who should use it.
 
 ## 🎯 Why This Exists
 
-<The problem it solves, the boundary it owns, and the tradeoff or design choice
-that helps users decide whether it fits.>
+The problem it solves, the boundary it owns, and the tradeoff or design choice
+that helps users decide whether it fits.
 
 ## 🚀 Install Or Bootstrap
 
-<Only the commands required before the first useful command can run, such as
+Only the commands required before the first useful command can run, such as
 package installation, submodule initialization, dependency setup, or required
-runtime assets.>
+runtime assets.
 
 ## 💻 Usage
 

--- a/skills/go-standards/SKILL.md
+++ b/skills/go-standards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: go-standards
-description: Applies this repository ecosystem's Go coding, documentation, import, naming idiom, and testing conventions. Use when writing, reviewing, refactoring, or documenting Go packages in repos that use this shared ./bin tooling; pair with $naming-standards when names or renames are part of the change.
+description: Use when writing, reviewing, refactoring, or documenting Go packages in repos that use this shared ./bin tooling. Apply this repository ecosystem's Go coding, documentation, import, naming idiom, and testing conventions; pair with $naming-standards when names or renames are part of the change.
 ---
 
 # Go Standards
@@ -20,7 +20,7 @@ description: Applies this repository ecosystem's Go coding, documentation, impor
 8. Pair this skill with `$naming-standards` when creating, reviewing, or renaming Go identifiers, packages, files, tests, or documentation terms.
 9. Add or update tests when behavior changes and the repository supports tests, but do not assume they should be Go tests just because the implementation is Go. Use `$testing-standards` to identify the majority relevant existing harness first, including cross-language harnesses.
 10. Add or recommend Go `*_test.go` coverage only when the nearby majority relevant tests for that behavior are Go-based, the changed surface is a Go package/API contract that cannot be covered through the dominant harness, or the repository explicitly asks for Go-level coverage. Agents MUST stop and explain before creating Go tests when another harness owns the behavior.
-11. Before writing any Go `*_test.go` file, choose the test package deliberately. Default to an external `<package>_test` package. If you think the test must use the production package instead, stop and explain why the public or documented entrypoint cannot cover the behavior before writing that test.
+11. Before writing any Go `*_test.go` file, choose the test package deliberately. Default to an external `package_test` package. If you think the test must use the production package instead, stop and explain why the public or documented entrypoint cannot cover the behavior before writing that test.
 12. Pair this skill with `$testing-standards` when designing, reviewing, or refactoring Go test coverage.
 13. Pair this skill with `$change-validation` when selecting Go test, lint, coverage, or benchmark commands.
 

--- a/skills/naming-standards/SKILL.md
+++ b/skills/naming-standards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: naming-standards
-description: Applies cross-language naming judgment for domain clarity, vocabulary consistency, abstraction level, ambiguity, boolean phrasing, public API terminology, and rename safety. Use when writing, reviewing, refactoring, documenting, or discussing names across code, tests, commands, configuration, docs, and public interfaces; pair with $go-standards, $ruby-standards, or $shell-standards for language-specific idioms.
+description: Use when writing, reviewing, refactoring, documenting, or discussing names across code, tests, commands, configuration, docs, and public interfaces. Apply cross-language naming judgment for domain clarity, vocabulary consistency, abstraction level, ambiguity, boolean phrasing, public API terminology, and rename safety; pair with $go-standards, $ruby-standards, or $shell-standards for language-specific idioms.
 ---
 
 # Naming Standards

--- a/skills/productivity-summary/SKILL.md
+++ b/skills/productivity-summary/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: productivity-summary
-description: Produces daily or weekly repository productivity summaries across delivery flow, CI quality, release/deploy activity, and service reliability. Use when the user asks for a productivity summary, delivery health report, weekly or daily engineering metrics, repo health comparison, service health summary, library maintenance summary, or period-over-period view for a specific GitHub repository using local git, GitHub, CircleCI, Kubernetes/DigitalOcean, and UptimeRobot evidence.
+description: Use when the user asks for a productivity summary, delivery health report, weekly or daily engineering metrics, repo health comparison, service health summary, library maintenance summary, or period-over-period view for a specific GitHub repository. Produce daily or weekly summaries across delivery flow, CI quality, release/deploy activity, and service reliability using local git, GitHub, CircleCI, Kubernetes/DigitalOcean, and UptimeRobot evidence.
 ---
 
 # Productivity Summary
@@ -81,7 +81,7 @@ comparison period.
 
 ## References
 
-- Run `scripts/collect.rb --repo <path>` first for report-ready metrics and
+- Run `scripts/collect.rb --repo PATH` first for report-ready metrics and
   source summaries.
 - Read `references/sources.md` for source priority, credential names, and
   collection boundaries.

--- a/skills/project-workflow/SKILL.md
+++ b/skills/project-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-workflow
-description: Discovers project-local workflow, command surfaces, CI expectations, shared ./bin submodule wiring, and reusable build/make/*.mak fragment behavior before work begins. Use when starting in a project, inspecting how to run tasks, deciding trusted entrypoints, or editing/debugging shared Makefile fragments.
+description: Use when starting in a project, inspecting how to run tasks, deciding trusted entrypoints, or editing/debugging shared Makefile fragments. Discover project-local workflow, command surfaces, CI expectations, shared ./bin submodule wiring, and reusable build/make/*.mak fragment behavior before work begins.
 ---
 
 # Project Workflow

--- a/skills/reliability-gaps/SKILL.md
+++ b/skills/reliability-gaps/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: reliability-gaps
-description: Finds verified missing or weak reliability, operability, SLO, overload, observability, release-safety, recovery, data-integrity, disaster-readiness, or NALSD design evidence in a package or folder, records confirmed gaps in that scope's ISSUES.md, and later proposes and implements explicitly agreed fixes gap by gap. Use when the user asks to find $reliability-gaps in a package or folder, find reliability gaps in a package or folder, review production readiness for a package or folder, implement $reliability-gaps in a package or folder, implement reliability gaps in a package or folder, asks what the fix is for REL-<number>, asks to fix REL-<number>, asks to verify REL-<number>, or says REL-<number> is done.
+description: Use when the user asks to find $reliability-gaps in a package or folder, find reliability gaps in a package or folder, review production readiness for a package or folder, implement $reliability-gaps in a package or folder, implement reliability gaps in a package or folder, asks about reliability gap IDs such as REL-1, asks what the fix is for REL-1, asks to fix or verify REL-1, or says REL-1 is done. Find verified reliability, operability, SLO, overload, observability, release-safety, recovery, data-integrity, disaster-readiness, or NALSD evidence gaps and implement agreed fixes gap by gap.
 ---
 
 # Reliability Gaps
 
 Use this skill in two distinct modes:
 
-- **Find mode**: `Find $reliability-gaps in <package/folder>` or `Find reliability gaps in <package/folder>`.
-- **Implement mode**: `Implement $reliability-gaps in <package/folder>` or `Implement reliability gaps in <package/folder>`.
+- **Find mode**: `Find $reliability-gaps in PACKAGE_OR_FOLDER` or `Find reliability gaps in PACKAGE_OR_FOLDER`.
+- **Implement mode**: `Implement $reliability-gaps in PACKAGE_OR_FOLDER` or `Implement reliability gaps in PACKAGE_OR_FOLDER`.
 
 Do not combine the two modes in one pass.
 
@@ -36,9 +36,9 @@ Follow `references/plan.md#find-mode-plan`.
 These rules remain mandatory:
 
 - If no scope is provided, stop and ask for the package or folder.
-- Use `ISSUES.md` in the requested package or folder as the review ledger, for example `<package/folder>/ISSUES.md`.
+- Use `ISSUES.md` in the requested package or folder as the review ledger, for example `PACKAGE_OR_FOLDER/ISSUES.md`.
 - If `ISSUES.md` already exists in the requested package or folder, stop. Tell the user the existing scoped ledger must be resolved first, or the human must delete that scoped `ISSUES.md` before a new find pass there.
-- Treat `Find $reliability-gaps in <package/folder>` or `Find reliability gaps in <package/folder>` as the user's explicit request to delegate reliability review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
+- Treat `Find $reliability-gaps in PACKAGE_OR_FOLDER` or `Find reliability gaps in PACKAGE_OR_FOLDER` as the user's explicit request to delegate reliability review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
 - Use sub-agents for Find mode whenever the active runtime provides them and runtime policy/tooling permits delegation. Do not treat sub-agents as optional based on scope size, and do not perform the reliability-gap review locally first.
 - Do not claim that extra delegation wording is needed before launching review agents. The Find mode invocation is the explicit delegation request.
 - If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
@@ -66,7 +66,7 @@ These rules remain mandatory:
 - Do not report optional maturity improvements, cloud-architecture preferences, private implementation preferences, or "best practice" checkboxes as findings by themselves. List them only as optional follow-up notes when relevant.
 - If no confirmed reliability gaps are found, report that no reliability gaps were found and do not create `ISSUES.md`.
 - If confirmed reliability gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
-- Assign every finding a unique ID for the session in the form `REL-<number>`.
+- Assign every finding a unique ID for the session in the form `REL-N`.
 - Stop after presenting the ledger and plan. Do not fix findings in the same pass.
 
 ## `ISSUES.md` Format
@@ -118,8 +118,8 @@ These rules remain mandatory:
    - `Validation`: the focused and expanded commands intended after refactor.
 - Implement only the agreed finding with the smallest clear reliability change.
 - Use `$reliability-standards` for reliability design, `$change-safety` for public or operational compatibility, `$testing-standards` for failure-path tests, and `$change-validation` for checks. Pair with `$security-audit` when the fix touches auth, secrets, privilege, DoS, logs, supply chain, or incident containment.
-- Report the result for that finding with `Red`, `Green`, `Refactor`, and `Validation` entries. Use `Refactor: none` when no cleanup was needed after green. Then ask the human to verify and explicitly say `REL-<number> is done`.
-- Do not move to the next finding until the human says `REL-<number> is done`.
+- Report the result for that finding with `Red`, `Green`, `Refactor`, and `Validation` entries. Use `Refactor: none` when no cleanup was needed after green. Then ask the human to verify and explicitly say `REL-N is done`.
+- Do not move to the next finding until the human says `REL-N is done`.
 - After the human confirms a finding is done, remove that finding from scoped `ISSUES.md`. If a finding is deemed invalid or not actually a reliability gap, remove it only after explaining why and getting human agreement.
 - Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
 

--- a/skills/reliability-gaps/agents/openai.yaml
+++ b/skills/reliability-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Reliability Gaps"
   short_description: "Find scoped SRE readiness gaps"
-  default_prompt: "Use $reliability-gaps with its active goal and plan to find scoped reliability gaps, answer REL-N follow-ups, and implement agreed fixes. For behavior-changing fixes, report the TDD decision plus Red, Green, Refactor, and Validation; otherwise use the appropriate docs/config validation path."
+  default_prompt: "Use $reliability-gaps with its active goal and plan to find scoped reliability gaps, answer reliability gap ID follow-ups such as REL-1, and implement agreed fixes. For behavior-changing fixes, report the TDD decision plus Red, Green, Refactor, and Validation; otherwise use the appropriate docs/config validation path."

--- a/skills/reliability-standards/SKILL.md
+++ b/skills/reliability-standards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reliability-standards
-description: Applies SRE, NALSD, and secure/reliable systems standards to code, designs, scripts, Make targets, services, jobs, deployment/config, observability, incident, recovery, capacity, and production-readiness work. Use when reviewing or changing reliability-sensitive behavior, retries, timeouts, backpressure, SLOs, SLIs, error budgets, monitoring, alerting, runbooks, release safety, overload handling, cascading failures, data integrity, disaster recovery, or concrete NALSD design estimates; pair with $reliability-gaps for scoped reliability-gap discovery.
+description: Use when reviewing or changing reliability-sensitive behavior, retries, timeouts, backpressure, SLOs, SLIs, error budgets, monitoring, alerting, runbooks, release safety, overload handling, cascading failures, data integrity, disaster recovery, or concrete NALSD design estimates. Apply SRE, NALSD, and secure/reliable systems standards to code, designs, scripts, Make targets, services, jobs, deployment/config, observability, incident, recovery, capacity, and production-readiness work; pair with $reliability-gaps for scoped reliability-gap discovery.
 ---
 
 # Reliability Standards

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-pr
-description: Reviews, validates, commits, force-pushes, and opens a draft pull request with the repository review target. Use only when the user explicitly asks to prepare, open, update, or run a review PR from local changes.
+description: Use when, and only when, the user explicitly asks to prepare, open, update, or run a review PR from local changes. Review, validate, commit, force-push, and open a draft pull request with the repository review target.
 ---
 
 # Review PR

--- a/skills/ruby-standards/SKILL.md
+++ b/skills/ruby-standards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ruby-standards
-description: Applies this repository ecosystem's Ruby coding, API, documentation, naming idiom, style, and test-entrypoint conventions. Use when writing, reviewing, refactoring, documenting, linting, or validating Ruby code in repos that use this shared ./bin tooling; pair with $naming-standards when names or renames are part of the change.
+description: Use when writing, reviewing, refactoring, documenting, linting, or validating Ruby code in repos that use this shared ./bin tooling. Apply this repository ecosystem's Ruby coding, API, documentation, naming idiom, style, and test-entrypoint conventions; pair with $naming-standards when names or renames are part of the change.
 ---
 
 # Ruby Standards

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-audit
-description: Reviews security-sensitive code, scripts, Makefile glue, Docker helpers, skills, dependencies, and configuration. Use when the user asks for a security audit, vulnerability or secret check, unsafe shell/filesystem/network/auth review, or language-specific security inspection.
+description: Use when the user asks for a security audit, vulnerability or secret check, unsafe shell/filesystem/network/auth review, or language-specific security inspection. Review security-sensitive code, scripts, Makefile glue, Docker helpers, skills, dependencies, and configuration.
 ---
 
 # Security Audit

--- a/skills/shell-standards/SKILL.md
+++ b/skills/shell-standards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shell-standards
-description: Applies this repository ecosystem's Bash scripting, ShellCheck, text-processing, directory-scope, naming idiom, and function documentation conventions. Use when writing, reviewing, refactoring, linting, or documenting shell scripts in repos that use this shared ./bin tooling; pair with $naming-standards when names or renames are part of the change.
+description: Use when writing, reviewing, refactoring, linting, or documenting shell scripts in repos that use this shared ./bin tooling. Apply this repository ecosystem's Bash scripting, ShellCheck, text-processing, directory-scope, naming idiom, and function documentation conventions; pair with $naming-standards when names or renames are part of the change.
 ---
 
 # Shell Standards

--- a/skills/style-review/SKILL.md
+++ b/skills/style-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: style-review
-description: Reviews code, tests, docs-adjacent comments, scripts, and diffs for non-blocking style polish, readability, local consistency, idiom, small simplifications, naming polish, and maintainability cleanup suggestions. Use when the user asks for style nits, polish, readability review, cleanup suggestions, non-blocking review comments, idiomatic cleanup, or a softer pass after code-review; do not use for bugs, security issues, compatibility breaks, or missing test/doc findings.
+description: Use when the user asks for style nits, polish, readability review, cleanup suggestions, non-blocking review comments, idiomatic cleanup, or a softer pass after code-review. Review code, tests, docs-adjacent comments, scripts, and diffs for non-blocking style polish, readability, local consistency, idiom, small simplifications, naming polish, and maintainability cleanup suggestions; do not use for bugs, security issues, compatibility breaks, or missing test/doc findings.
 ---
 
 # Style Review

--- a/skills/test-gaps/SKILL.md
+++ b/skills/test-gaps/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: test-gaps
-description: Finds concrete missing, weak, misleading, flaky, or wrong-layer test coverage in a package or folder, records confirmed gaps in that scope's ISSUES.md, and later proposes and implements explicitly agreed test fixes gap by gap. Use when the user asks to find $test-gaps in a package or folder, find test gaps in a package or folder, find flaky tests in a package or folder, find wrong-layer tests in a package or folder, implement $test-gaps in a package or folder, or implement test gaps in a package or folder.
+description: Use when the user asks to find $test-gaps in a package or folder, find test gaps in a package or folder, find flaky tests in a package or folder, find wrong-layer tests in a package or folder, implement $test-gaps in a package or folder, implement test gaps in a package or folder, asks about test gap IDs such as TEST-1, asks what the fix is for TEST-1, asks to fix or verify TEST-1, or says TEST-1 is done. Find concrete missing, weak, misleading, flaky, or wrong-layer test coverage, record confirmed gaps in scoped ISSUES.md, and later propose and implement agreed test fixes gap by gap.
 ---
 
 # Test Gaps
 
 Use this skill in two distinct modes:
 
-- **Find mode**: `Find $test-gaps in <package/folder>` or `Find test gaps in <package/folder>`.
-- **Implement mode**: `Implement $test-gaps in <package/folder>` or `Implement test gaps in <package/folder>`.
+- **Find mode**: `Find $test-gaps in PACKAGE_OR_FOLDER` or `Find test gaps in PACKAGE_OR_FOLDER`.
+- **Implement mode**: `Implement $test-gaps in PACKAGE_OR_FOLDER` or `Implement test gaps in PACKAGE_OR_FOLDER`.
 
 Do not combine the two modes in one pass.
 
@@ -33,9 +33,9 @@ Follow `references/plan.md#find-mode-plan`.
 These rules remain mandatory:
 
 - If no scope is provided, stop and ask for the package or folder.
-- Use `ISSUES.md` in the requested package or folder as the review ledger, for example `<package/folder>/ISSUES.md`.
+- Use `ISSUES.md` in the requested package or folder as the review ledger, for example `PACKAGE_OR_FOLDER/ISSUES.md`.
 - If `ISSUES.md` already exists in the requested package or folder, stop. Tell the user the existing scoped ledger must be resolved first, or the human must delete that scoped `ISSUES.md` before a new find pass there.
-- Treat `Find $test-gaps in <package/folder>` or `Find test gaps in <package/folder>` as the user's explicit request to delegate test-gap review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
+- Treat `Find $test-gaps in PACKAGE_OR_FOLDER` or `Find test gaps in PACKAGE_OR_FOLDER` as the user's explicit request to delegate test-gap review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
 - Use sub-agents for Find mode whenever the active runtime provides them and runtime policy/tooling permits delegation. Do not treat sub-agents as optional based on scope size, and do not perform the test-gap review locally first.
 - Do not claim that extra delegation wording is needed before launching review agents. The Find mode invocation is the explicit delegation request.
 - If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
@@ -55,7 +55,7 @@ These rules remain mandatory:
 - Do not report optional nice-to-have tests, private implementation coverage, arbitrary coverage percentage improvements, style preferences, or docs-only validation as findings by themselves. List them only as doc gaps or optional follow-up notes when relevant.
 - If no confirmed test gaps are found, report that no test gaps were found and do not create `ISSUES.md`.
 - If confirmed test gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
-- Assign every finding a unique ID for the session in the form `TEST-<number>`.
+- Assign every finding a unique ID for the session in the form `TEST-N`.
 - Stop after presenting the ledger and plan. Do not fix findings in the same pass.
 
 ## `ISSUES.md` Format
@@ -100,7 +100,7 @@ These rules remain mandatory:
 - After the human agrees and before editing, state the selected local test pattern, dominant relevant test harness, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
 - Implement only the agreed finding with the smallest clear test change, preferring the existing local test shape over new standalone structure.
 - Use `$testing-standards` for test design and pair with the relevant language standard for local idioms. If implementing the test gap requires production behavior to change, prefer the test-first or scenario-first loop from `$testing-standards`.
-- Do not move to the next finding until the human says `TEST-<number> is done`.
+- Do not move to the next finding until the human says `TEST-N is done`.
 - After the human confirms a finding is done, remove that finding from scoped `ISSUES.md`. If a finding is deemed invalid or not actually a test gap, remove it only after explaining why and getting human agreement.
 - Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
 

--- a/skills/test-gaps/agents/openai.yaml
+++ b/skills/test-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Test Gaps"
   short_description: "Find scoped weak, flaky, or wrong-layer tests"
-  default_prompt: "Use $test-gaps with its active goal and plan to find scoped missing, weak, misleading, flaky, or wrong-layer test coverage, store confirmed gaps in ISSUES.md, or implement agreed test fixes one gap at a time."
+  default_prompt: "Use $test-gaps with its active goal and plan to find scoped missing, weak, misleading, flaky, or wrong-layer test coverage, store confirmed gaps in ISSUES.md, answer test gap ID follow-ups such as TEST-1, or implement agreed test fixes one gap at a time."

--- a/skills/testing-standards/SKILL.md
+++ b/skills/testing-standards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testing-standards
-description: Applies language-agnostic test design, test-first/TDD or scenario-first/BDD workflow, coverage, fixtures, determinism, and test-layer conventions. Use when adding, reviewing, refactoring, or planning tests across languages; pair with $go-standards, $ruby-standards, or $shell-standards for language-specific idioms and $change-validation for commands.
+description: Use when adding, reviewing, refactoring, or planning tests across languages. Apply language-agnostic test design, test-first/TDD or scenario-first/BDD workflow, coverage, fixtures, determinism, and test-layer conventions; pair with $go-standards, $ruby-standards, or $shell-standards for language-specific idioms and $change-validation for commands.
 ---
 
 # Testing Standards


### PR DESCRIPTION
## What

- Updated shared skill descriptions to use trigger-oriented `Use when...` phrasing and avoid angle-bracket placeholders.
- Added concrete ledger ID follow-up triggers such as `ISSUE-1`, `TEST-1`, `DOC-1`, and `REL-1` to the scoped ledger skills and matching OpenAI metadata.
- Extended the skill linter markers so the ledger ID trigger wording and OpenAI prompts stay aligned.

## Why

- Improves Codex and agnix compatibility by keeping trigger metadata explicit and free of XML-like placeholders.
- Makes short follow-up prompts such as `fix ISSUE-1`, `verify TEST-1`, or `REL-1 is done` more likely to activate the intended skill.
- Keeps the shared skill suite consistent so reliability-gap ID handling is not a one-off behavior.

## Testing

- `make dep` - passed
- `make clean-dep` - passed
- `make skills-lint` - passed
- `agnix skills` - passed
- `make docker-lint` - passed
- `make lint` - passed
- `make scripts-lint` - passed
- `make sec` - passed
- `git diff --check` - passed
- `agnix .` - passed with unrelated existing `AGENTS.md` warnings outside this change

AI-assisted-by: [Codex](https://openai.com/codex/)
