### PR TITLE
feat(skills): require code evidence before finder issues

### DIFF
--- a/skills/code-issues/SKILL.md
+++ b/skills/code-issues/SKILL.md
@@ -26,6 +26,14 @@ Operate as a strict issue triager and ledger owner: separate confirmed code
 defects from test gaps, doc gaps, polish, and speculation; keep the scoped
 `ISSUES.md` actionable, deduplicated, and tied to user-visible or contract risk.
 
+Code is the default source of behavioral truth. Comments, GoDoc, README prose,
+examples, and other documentation can be stale. Do not record or implement a
+code issue merely because prose and implementation disagree. First prove the
+implementation is wrong using non-prose evidence such as executable behavior,
+tests, schemas, wire/API contracts, external standards, runtime failures, or
+history showing an unintended code regression. If implementation and tests agree
+while prose disagrees, treat it as a documentation gap and update the docs.
+
 ## Find Mode
 
 Follow `references/plan.md#find-mode-plan`.
@@ -50,6 +58,7 @@ These rules remain mandatory:
 - Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
 - Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity.
 - Confirm each candidate finding against the code before recording it. Findings must be concrete bugs, security issues, compatibility breaks, or violated public contracts with user-visible impact.
+- For candidates based on documentation or comments contradicting code, require non-prose proof that the implementation is wrong before recording a code issue. Existing tests, helper names, runtime behavior, or commit history that support the implementation mean the candidate is a doc gap, not a code issue.
 - Do not record standalone missing, weak, flaky, misleading, or wrong-layer tests as code issues unless they are tied to a confirmed bug, security issue, compatibility break, or violated public contract. Use `$test-gaps` for standalone missing or weak test coverage passes.
 - Do not record standalone missing, weak, stale, misleading, or wrong-location documentation, README, example, comment, or docstring gaps as code issues unless they reveal a confirmed bug, security issue, compatibility break, or violated public contract. Use `$doc-gaps` for standalone documentation review passes.
 - Do not report optional regression tests, unused convenience aliases, API symmetry, or documentation polish as findings by themselves. List them only as testing gaps, doc gaps, or optional follow-up notes when relevant.
@@ -95,6 +104,7 @@ These rules remain mandatory:
 - Work through code issues sequentially by ID unless the human explicitly names a different issue.
 - Stop after proposing the solution. Do not edit code, update `ISSUES.md`, or start validation until the human explicitly agrees to that issue's solution.
 - Ask questions when behavior, compatibility, security, validation, or user intent is ambiguous. Treat silence or a broad "implement code issues" request as permission to start the proposal workflow, not as permission to code.
+- When re-checking an issue whose evidence depends on documentation or comments contradicting implementation, prove the code is wrong before proposing a code change. If non-prose evidence supports the implementation, explain that the ledger item is invalid as a code issue and propose reclassifying or fixing the documentation instead.
 - After the human agrees and before editing, state the selected local code pattern, dominant relevant test harness, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
 - Implement only the agreed issue with the smallest safe change.
 - Use `$testing-standards` when deciding whether to add or update regression tests for the fix, and prefer its test-first or scenario-first loop when a behavior-changing fix has a credible test or BDD layer.

--- a/skills/code-issues/references/plan.md
+++ b/skills/code-issues/references/plan.md
@@ -65,7 +65,10 @@ repository root and keep `bin/` as shared guidance.
 11. Deduplicate candidates and directly re-check conflicting or overlapping
     conclusions.
 12. Confirm each finding is a concrete code issue, security issue,
-   compatibility break, or public contract violation.
+    compatibility break, or public contract violation. If the evidence is a
+    documentation/comment mismatch, prove the implementation is wrong with
+    non-prose evidence before treating it as a code issue; otherwise classify it
+    as a documentation gap.
 13. If no confirmed issues remain, report that result with the coverage state,
     do not create `ISSUES.md`, and stop.
 14. If confirmed issues remain, write the scoped `ISSUES.md` with
@@ -82,17 +85,21 @@ repository root and keep `bin/` as shared guidance.
    wiring.
 4. Select the next issue by ID unless the human named a specific issue.
 5. Re-check the issue evidence against current code and tests.
-6. Present the issue evidence, proposed solution, compatibility or behavior
+6. If the issue depends on prose contradicting implementation, prove the code is
+   wrong with non-prose evidence before proposing a code change. If code and
+   tests support the implementation, stop and propose reclassifying or fixing
+   the documentation instead.
+7. Present the issue evidence, proposed solution, compatibility or behavior
    tradeoffs, and intended validation.
-7. Stop until the human explicitly agrees to that issue's solution.
-8. After agreement, state the local code pattern, dominant relevant test
+8. Stop until the human explicitly agrees to that issue's solution.
+9. After agreement, state the local code pattern, dominant relevant test
    harness, planned validation, and any needed deviation.
-9. If a deviation is needed, stop and ask before editing.
-10. Implement only the agreed issue with the smallest safe change.
-11. Use `$testing-standards` for regression coverage decisions.
-12. Validate the fix with commands appropriate to the changed files.
-13. Report the result and ask the human to verify with `ISSUE-<number> is done`.
-14. Stop until that confirmation arrives.
-15. After confirmation, remove or revise the issue in scoped `ISSUES.md`.
-16. Continue with the next issue, or delete scoped `ISSUES.md` after all issues
+10. If a deviation is needed, stop and ask before editing.
+11. Implement only the agreed issue with the smallest safe change.
+12. Use `$testing-standards` for regression coverage decisions.
+13. Validate the fix with commands appropriate to the changed files.
+14. Report the result and ask the human to verify with `ISSUE-<number> is done`.
+15. Stop until that confirmation arrives.
+16. After confirmation, remove or revise the issue in scoped `ISSUES.md`.
+17. Continue with the next issue, or delete scoped `ISSUES.md` after all issues
     are confirmed resolved.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -11,6 +11,15 @@ Operate as a skeptical reviewer: prioritize confirmed behavioral risk over
 style, and report only findings grounded in changed code, concrete evidence,
 and credible user, compatibility, security, maintenance, or test impact.
 
+Treat running code and executable behavior as the default source of truth.
+Comments, GoDoc, README text, examples, and other prose can be stale. A mismatch
+between prose and implementation is not a code bug by itself; prove the
+implementation is wrong with non-prose evidence such as failing or missing
+behavioral coverage, a violated external standard, a schema or wire contract,
+runtime behavior, public API usage, or history showing an unintended code
+regression. If implementation and tests agree while prose disagrees, route the
+finding to documentation instead of changing code.
+
 ## Steps
 
 1. Identify the changed files or requested review scope.
@@ -18,13 +27,14 @@ and credible user, compatibility, security, maintenance, or test impact.
 3. Inspect behavior, tests, compatibility, security, docs, and maintenance risk before style preferences.
 4. First identify high-risk review leads, especially deletions, cross-boundary drift, silent behavior changes, changed contracts, unhandled sibling cases, and error-path changes. Then verify concrete findings instead of reviewing every line uniformly.
 5. Prefer precision over recall. Do not report plausible concerns unless they survive attempts to disprove them and are grounded in changed code, concrete evidence, and credible user, compatibility, security, maintenance, or test risk.
-6. Use `$doc-standards` when the review scope includes README files, user-facing docs, examples, command/config docs, public API comments, docstrings, or changed behavior that may make nearby existing documentation stale. Keep review scope to the current change and directly affected nearby docs unless the user explicitly asks for `$doc-gaps` or a broader documentation audit.
-7. Pair with relevant language standards (`$go-standards`, `$ruby-standards`, `$shell-standards`) when reviewing language-specific code, APIs, docs, tests, or tooling behavior. Pair with `$naming-standards` when names create concrete ambiguity, misuse risk, public contract confusion, inconsistent vocabulary, or maintenance cost. Treat idiomatic style concerns as findings only when they create concrete readability, maintenance, correctness, compatibility, or public API risk; use `$style-review` instead for non-blocking polish when the user asks for style nits or a readability pass.
-8. Use `$testing-standards` when judging whether tests are missing, weak, overfit to internals, hard to read, or at the wrong layer.
-9. If the review scope includes security-sensitive code, configuration, dependencies, shell execution, filesystem writes/deletes, network/auth/TLS behavior, secrets/env handling, Docker helpers, or CI/security tooling, consult `$security-audit` and the smallest matching security reference; keep this skill's findings format.
-10. Verify claims against concrete file and line references whenever possible.
-11. When code review is the final response, use the exact structure in `references/findings-format.md`; do not add, remove, rename, or reorder sections.
-12. When another skill embeds this review, preserve findings, open questions, testing gaps, and summary facts in the caller's output format.
+6. When a candidate depends on prose contradicting code, first disprove the implementation with non-prose evidence. If the code, tests, helper names, commit history, or runtime behavior support the implementation, do not report a code finding; use `$doc-standards` or `$doc-gaps` for the stale prose.
+7. Use `$doc-standards` when the review scope includes README files, user-facing docs, examples, command/config docs, public API comments, docstrings, or changed behavior that may make nearby existing documentation stale. Keep review scope to the current change and directly affected nearby docs unless the user explicitly asks for `$doc-gaps` or a broader documentation audit.
+8. Pair with relevant language standards (`$go-standards`, `$ruby-standards`, `$shell-standards`) when reviewing language-specific code, APIs, docs, tests, or tooling behavior. Pair with `$naming-standards` when names create concrete ambiguity, misuse risk, public contract confusion, inconsistent vocabulary, or maintenance cost. Treat idiomatic style concerns as findings only when they create concrete readability, maintenance, correctness, compatibility, or public API risk; use `$style-review` instead for non-blocking polish when the user asks for style nits or a readability pass.
+9. Use `$testing-standards` when judging whether tests are missing, weak, overfit to internals, hard to read, or at the wrong layer.
+10. If the review scope includes security-sensitive code, configuration, dependencies, shell execution, filesystem writes/deletes, network/auth/TLS behavior, secrets/env handling, Docker helpers, or CI/security tooling, consult `$security-audit` and the smallest matching security reference; keep this skill's findings format.
+11. Verify claims against concrete file and line references whenever possible.
+12. When code review is the final response, use the exact structure in `references/findings-format.md`; do not add, remove, rename, or reorder sections.
+13. When another skill embeds this review, preserve findings, open questions, testing gaps, and summary facts in the caller's output format.
 
 ## References
 

--- a/skills/code-review/references/findings-format.md
+++ b/skills/code-review/references/findings-format.md
@@ -11,6 +11,7 @@ Use this reference when the user asks for a review.
 - Prefer concrete findings over broad summaries.
 - Ground each finding in the inspected code and describe the consequence, not just the preference.
 - Avoid broad "consider checking" comments. Each finding needs a concrete changed location, behavior at risk, evidence, and a clear place to start fixing.
+- Do not report code findings based only on comments, GoDoc, README text, examples, or other prose contradicting implementation. Prose can be stale; cite non-prose evidence that proves the implementation is wrong, or report the mismatch as a documentation issue instead.
 
 ## Severity
 

--- a/skills/doc-gaps/SKILL.md
+++ b/skills/doc-gaps/SKILL.md
@@ -25,6 +25,13 @@ documentation quality judgment, use this skill for scope control and
 delegation, and fix confirmed documentation gaps in the same pass unless a stop
 gate requires human input.
 
+When documentation contradicts implementation, treat current code, tests,
+schemas, generated contracts, runtime behavior, external standards, and history
+as the evidence for actual behavior. Do not route the mismatch to code,
+security, reliability, or test workflows unless non-prose evidence proves the
+implementation is wrong; otherwise fix the documentation to match the behavior
+the repository implements.
+
 ## One-Pass Mode
 
 Follow `references/plan.md#one-pass-mode-plan`.
@@ -50,6 +57,7 @@ These rules remain mandatory:
 - Require each agent to return candidates in the candidate format below, without final IDs unless useful locally.
 - Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity.
 - Confirm each candidate gap against the code, current docs, examples, and documented interfaces before fixing it, using `$doc-standards` as the finding threshold. Do not confirm or dismiss a candidate merely because documentation exists; verify adequacy, ownership, discoverability, example coverage, and the relevant non-obvious contract.
+- When prose and implementation disagree, require non-prose evidence before treating the code as wrong or routing the candidate out to another workflow. If code, tests, runtime behavior, generated contracts, or history support the implementation, fix the stale prose as a doc gap.
 - Before fixing or dismissing a candidate, route it to the correct documentation surface: README, docs, examples, command help, package documentation, exported API comment, code comment, docstring, or no change. Do not treat package GoDoc or code-comment improvements as sufficient when first-use, setup, configuration, operational behavior, security expectations, or service-author workflows would reasonably be expected in README files, user-facing docs, examples, or command help. Do not treat README prose as sufficient when `$doc-standards` and the paired language standard route reusable API contracts to GoDoc, RDoc, docstrings, executable examples, specs, or features.
 - When dismissing a candidate because existing documentation is sufficient, identify the existing surface that covers the audience and action at risk in the final summary, and state why that surface is the authoritative owner under `$doc-standards`.
 - Do not fix candidates that `$doc-standards` routes to `$code-review`, `$code-issues`, `$security-audit`, `$testing-standards`, or `$test-gaps`. Report those as out of scope when relevant.

--- a/skills/doc-gaps/references/plan.md
+++ b/skills/doc-gaps/references/plan.md
@@ -68,27 +68,30 @@ repository root and keep `bin/` as shared guidance.
 12. Deduplicate candidates and directly re-check conflicting or overlapping
     conclusions against code, docs, examples, command help, package docs, and
     public interfaces.
-13. Route each candidate through `$doc-standards`' adequacy gate and identify
+13. When prose contradicts implementation, require non-prose evidence before
+    treating code as wrong or routing the candidate to code, security,
+    reliability, or test workflows; otherwise classify stale prose as a doc gap.
+14. Route each candidate through `$doc-standards`' adequacy gate and identify
     the public surface, intended audience, user action or maintenance decision
     at risk, current documentation surface, target surface, minimum successful
     example or command, adequacy failure, and any missing non-obvious contract.
-14. Confirm each finding is a concrete missing, weak, stale, misleading, or
+15. Confirm each finding is a concrete missing, weak, stale, misleading, or
     wrong-location documentation gap with real user, operator, package
     consumer, or maintainer risk. Documentation length, heading count, lint
     shape, or comment presence is not sufficient evidence of adequacy.
-15. Dismiss candidates already covered by the correct authoritative surface,
+16. Dismiss candidates already covered by the correct authoritative surface,
     candidates below the finding threshold, and candidates that belong to code,
     security, test, or reliability workflows. When dismissing, record why the
     existing surface owns the audience and action at risk.
-16. If no confirmed gaps remain, report that result with the coverage state, do
+17. If no confirmed gaps remain, report that result with the coverage state, do
     not create `ISSUES.md`, and skip edit and validation steps.
-17. Implement confirmed doc gaps with the smallest clear documentation changes.
-18. If a confirmed gap cannot be fixed correctly in this pass, write or update
+18. Implement confirmed doc gaps with the smallest clear documentation changes.
+19. If a confirmed gap cannot be fixed correctly in this pass, write or update
     the scoped `ISSUES.md` with `DOC-<number>` entries for unresolved gaps.
-19. If an existing doc-gap ledger is fully resolved, delete it.
-20. Validate the documentation change with commands appropriate to the changed
+20. If an existing doc-gap ledger is fully resolved, delete it.
+21. Validate the documentation change with commands appropriate to the changed
     files.
-21. Present fixed gaps, dismissed or out-of-scope candidates when relevant,
+22. Present fixed gaps, dismissed or out-of-scope candidates when relevant,
     coverage state for broad scopes, unresolved ledger entries if any, runnable
     follow-up scopes for deferred slices, and validation results.
 
@@ -107,7 +110,9 @@ repository root and keep `bin/` as shared guidance.
 6. Update coverage state for every planned slice before judging the requested
    scope.
 7. Deduplicate, route, and confirm candidates against code, docs, examples,
-   command help, package docs, and public interfaces.
+   command help, package docs, and public interfaces. When prose contradicts
+   implementation, require non-prose evidence before treating code as wrong;
+   otherwise classify stale prose as a doc gap.
 8. If no confirmed gaps remain, report that result with the coverage state, do
    not create `ISSUES.md`, and stop.
 9. If confirmed gaps remain, write the scoped `ISSUES.md` with `DOC-<number>`

--- a/skills/doc-standards/SKILL.md
+++ b/skills/doc-standards/SKILL.md
@@ -15,6 +15,13 @@ long, has many headings, follows an established local shape, or satisfies a
 linter. Pass documentation only after verifying that it is accurate, adequate,
 and in the authoritative location for the audience and action at risk.
 
+When documentation contradicts implementation, do not assume documentation is
+the source of truth. Treat code, tests, schemas, generated contracts, runtime
+behavior, and external standards as the evidence for current behavior. Route the
+mismatch to `$code-issues` only when non-prose evidence proves the
+implementation is wrong; otherwise fix the documentation to describe the
+behavior the repository actually implements.
+
 ## Steps
 
 1. Identify the documentation surface in scope: README files, docs, examples,
@@ -25,23 +32,26 @@ and in the authoritative location for the audience and action at risk.
    users need before they can use or maintain the surface safely.
 3. Compare documentation against the changed behavior, requested scope, tests,
    examples, command output, configuration schema, and public interfaces.
-4. Route each concern to the correct documentation owner before deciding whether
+4. If docs and implementation disagree, verify whether non-prose evidence proves
+   the code is wrong. If not, treat the prose as stale and fix the authoritative
+   documentation owner.
+5. Route each concern to the correct documentation owner before deciding whether
    existing documentation is adequate.
-5. For `$code-review` and `$review-pr`, inspect changed documentation and nearby
+6. For `$code-review` and `$review-pr`, inspect changed documentation and nearby
    documentation directly affected by the current change. Do not perform a
    package-wide documentation audit unless the user explicitly asks for
    `$doc-gaps` or a broader docs pass.
-6. For `$doc-gaps`, use these standards as the quality bar for fixing or
+7. For `$doc-gaps`, use these standards as the quality bar for fixing or
    recording confirmed missing, weak, stale, misleading, or wrong-location
    documentation.
-7. Pair with relevant language standards for language-specific public API
+8. Pair with relevant language standards for language-specific public API
    comments and docstrings. Pair with `$naming-standards` when terminology,
    command/API names, examples, or public vocabulary are unclear or
    inconsistent.
-8. Pair with `$change-safety` when documentation changes public contracts,
+9. Pair with `$change-safety` when documentation changes public contracts,
    compatibility expectations, migrations, security guidance, operational
    behavior, or documented support boundaries.
-9. Pair with `$change-validation` when selecting validation for documentation
+10. Pair with `$change-validation` when selecting validation for documentation
    changes, such as docs lint, generated-doc checks, example tests, command
    snapshots, or the repository's normal review target.
 
@@ -98,6 +108,9 @@ Route documentation to the surface that owns the reader's next action:
 - **Correctness**: Documentation must describe the current repository-owned
   behavior, command syntax, configuration shape, examples, defaults, limits,
   errors, compatibility expectations, and operational constraints accurately.
+  If documentation conflicts with code and tests, prove the implementation is
+  wrong with non-prose evidence before changing code; otherwise update the
+  documentation.
 - **Completeness**: Public entrypoints, exported APIs, commands, configuration
   keys, setup paths, migrations, and examples need enough documentation for the
   intended user to use or maintain them without reading private implementation
@@ -348,8 +361,8 @@ discoverable owner:
   configuration examples, generated files, or extension points live.
 - Do not repeat full config schemas, generated API references, or package
   documentation when generated docs, sample config, `.proto` files, command
-  help, or package docs are the source of truth. Include one representative
-  example and link to the owner.
+  help, or package docs are the authoritative documentation owner. Include one
+  representative example and link to the owner.
 - Do not add "development workflow" sections that only name standard lint,
   test, format, security, or benchmark targets. Use the project workflow docs
   or `make help` for command discovery unless a command sequence is required

--- a/skills/references/finding-severity.md
+++ b/skills/references/finding-severity.md
@@ -14,6 +14,15 @@ cannot be explained from the inspected code, tests, docs, or command behavior.
 Do not classify uncertain or low-confidence candidates as `Low`; `Low` still
 means a real finding with limited impact.
 
+When a candidate depends on comments, GoDoc, README text, examples, or other
+prose contradicting implementation, do not treat the prose as source of truth.
+First prove the implementation is wrong with non-prose evidence such as
+runtime behavior, executable tests, schemas, generated or wire contracts,
+external standards, scanner output, or history showing an unintended code
+regression. If current code and tests support the implementation, classify the
+candidate as a documentation gap or discard it instead of assigning severity to
+a code, test, reliability, or security finding.
+
 ## Severity
 
 - `Critical`: Near-certain severe production breakage, data loss or corruption,

--- a/skills/reliability-gaps/SKILL.md
+++ b/skills/reliability-gaps/SKILL.md
@@ -29,6 +29,13 @@ command behavior show how a repository-owned reliability control can fail.
 Reject speculative scalability advice, generic SRE checklists, environment
 preferences, and findings that depend on undocumented future requirements.
 
+Comments, GoDoc, README prose, examples, and operational docs can reveal leads,
+but they are not source of truth when they contradict implementation. Before
+recording a reliability gap from such a mismatch, prove with non-prose evidence
+that the repository-owned reliability behavior or control is wrong. If code,
+tests, runtime behavior, CI, generated contracts, or history support the
+implementation, route the mismatch to `$doc-gaps` instead.
+
 ## Find Mode
 
 Follow `references/plan.md#find-mode-plan`.
@@ -53,6 +60,7 @@ These rules remain mandatory:
 - Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
 - Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity.
 - Confirm each candidate gap against current evidence before recording it. Try to disprove the candidate by tracing the current code path, reading the documented workflow, checking the relevant config, inspecting existing tests, or running an allowed local command. A gap must name the affected reliability promise or operational expectation, the trigger condition, the failure mode, the missing or weak control, and the likely user or operator impact.
+- For candidates based on documentation or comments contradicting code, require non-prose proof that the implementation or repository-owned reliability control is wrong before recording a reliability gap. If current code, tests, runtime behavior, CI, or history support the implementation, treat the prose as a doc gap.
 - Record reliability gaps only when they involve repository-owned behavior or documented/implicit operational contracts, such as:
    - missing or weak SLO, SLI, alertability, dashboard, runbook, or operator diagnostic coverage for behavior the repository claims or owns.
    - unbounded or unsafe timeouts, retries, backoff, jitter, concurrency, queues, subprocesses, files, disk, memory, network, or worker resources.
@@ -111,6 +119,7 @@ These rules remain mandatory:
 - If scoped `ISSUES.md` does not exist, stop and ask whether to run Find mode first for that scope.
 - Work through findings sequentially by ID unless the human explicitly names a different finding.
 - Before proposing a fix for each finding, re-check the current code, config, tests, docs, and CI. Treat the ledger as something that can go stale: dismiss or revise findings that are already addressed, no longer have a concrete failure mode, duplicate another issue, or belong in `$code-issues`, `$security-audit`, `$test-gaps`, or `$doc-gaps`.
+- When re-checking a finding whose evidence depends on documentation or comments contradicting implementation, prove the implementation or reliability control is wrong with non-prose evidence before proposing a reliability change. If non-prose evidence supports the implementation, explain that the ledger item is invalid as a reliability gap and propose reclassifying or fixing documentation instead.
 - Stop after proposing the solution. Do not edit files, update `ISSUES.md`, or start validation until the human explicitly agrees to that finding's solution.
 - Ask questions when SLOs, expected failure behavior, operator workflow, compatibility, rollout, validation, or user intent is ambiguous. Treat silence or a broad "implement reliability gaps" request as permission to start the proposal workflow, not as permission to edit.
 - After the human agrees and before editing, state the selected local code/config/docs pattern, dominant relevant test harness, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.

--- a/skills/reliability-gaps/references/plan.md
+++ b/skills/reliability-gaps/references/plan.md
@@ -69,19 +69,22 @@ plan from the consuming repository root and keep `bin/` as shared guidance.
     scope.
 12. Deduplicate candidates and directly re-check conflicting or overlapping
     conclusions against code, config, tests, docs, and CI.
-13. Confirm each gap names a current reliability promise or operational
+13. For candidates based on prose contradicting implementation, prove with
+    non-prose evidence that the implementation or repository-owned reliability
+    control is wrong; otherwise classify the mismatch as a documentation gap.
+14. Confirm each gap names a current reliability promise or operational
     expectation, trigger, failure mode, missing or weak control, and user or
     operator impact.
-14. Reject generic maturity advice, future-scale assumptions, private
+15. Reject generic maturity advice, future-scale assumptions, private
     preferences, and findings that belong in code, security, test, or doc
     ledgers.
-15. If no confirmed gaps remain, report that result with the coverage state, do
+16. If no confirmed gaps remain, report that result with the coverage state, do
     not create `ISSUES.md`, and stop.
-16. If confirmed gaps remain, write the scoped `ISSUES.md` with `REL-<number>`
+17. If confirmed gaps remain, write the scoped `ISSUES.md` with `REL-<number>`
     IDs.
-17. Present the scoped ledger, proposed reliability-fix plan, coverage state for
+18. Present the scoped ledger, proposed reliability-fix plan, coverage state for
     broad scopes, and runnable follow-up scopes for deferred slices.
-18. Stop before making fixes.
+19. Stop before making fixes.
 
 ## Implement Mode Plan
 
@@ -91,24 +94,28 @@ plan from the consuming repository root and keep `bin/` as shared guidance.
    commands, operational docs, release/config surfaces, and `./bin` wiring.
 4. Select the next finding by ID unless the human named a specific finding.
 5. Re-check the finding against current code, config, tests, docs, and CI.
-6. Present the finding evidence, affected reliability promise or operational
+6. If the finding depends on prose contradicting implementation, prove the
+   implementation or reliability control is wrong with non-prose evidence
+   before proposing a reliability change; otherwise propose reclassification as
+   a documentation gap.
+7. Present the finding evidence, affected reliability promise or operational
    expectation, proposed solution, tradeoffs, and intended validation.
-7. Stop until the human explicitly agrees to that finding's solution.
-8. After agreement, state the local code/config/docs pattern, dominant relevant
+8. Stop until the human explicitly agrees to that finding's solution.
+9. After agreement, state the local code/config/docs pattern, dominant relevant
    test harness, planned validation, and any needed deviation.
-9. If a deviation is needed, stop and ask before editing.
-10. For behavior-changing fixes, state the reliability execution checklist:
+10. If a deviation is needed, stop and ask before editing.
+11. For behavior-changing fixes, state the reliability execution checklist:
     TDD decision, first test/scenario, expected red, intended green change,
     refactor checkpoint, and validation.
-11. Implement only the agreed reliability gap with the smallest clear change.
-12. Use `$reliability-standards`, `$change-safety`, `$testing-standards`,
+12. Implement only the agreed reliability gap with the smallest clear change.
+13. Use `$reliability-standards`, `$change-safety`, `$testing-standards`,
     `$change-validation`, and `$security-audit` as required by the touched
     surface.
-13. Validate the reliability change through repository Make targets or
+14. Validate the reliability change through repository Make targets or
     documented entrypoints.
-14. Report `Red`, `Green`, `Refactor`, and `Validation`, then ask the human to
+15. Report `Red`, `Green`, `Refactor`, and `Validation`, then ask the human to
     verify with `REL-<number> is done`.
-15. Stop until that confirmation arrives.
-16. After confirmation, remove or revise the finding in scoped `ISSUES.md`.
-17. Continue with the next finding, or delete scoped `ISSUES.md` after all gaps
+16. Stop until that confirmation arrives.
+17. After confirmation, remove or revise the finding in scoped `ISSUES.md`.
+18. Continue with the next finding, or delete scoped `ISSUES.md` after all gaps
     are confirmed resolved.

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -11,6 +11,14 @@ Operate as a practical security auditor: follow concrete data and control flow,
 rank exploitable paths first, and avoid checklist findings that do not have a
 specific trigger in the audited code or configuration.
 
+Comments, GoDoc, README prose, examples, and other documentation can be stale.
+Do not report a security finding merely because prose contradicts
+implementation. Trace the actual data/control flow and prove exploitable
+behavior, a violated security contract, scanner evidence, unsafe runtime
+behavior, or an unintended regression with non-prose evidence. If the code is
+supported by current behavior and tests while prose disagrees, route the issue
+to documentation instead.
+
 ## Steps
 
 1. Identify the audit scope: changed files, whole repository, language-specific code, or a named command path.
@@ -23,9 +31,10 @@ specific trigger in the audited code or configuration.
 3. Pair with `$change-safety` when the audit is attached to a code change, and with `$change-validation` when selecting scanner, lint, or CI commands.
 4. Ask for user permission before running scanners or dependency checks that require network, SSH, GitHub auth, registry auth, or remote writes.
 5. Inspect concrete data/control flow before reporting a risk. Prefer file and line references over general advice.
-6. Report exploitable findings first.
-7. When the audit is the final response, use the exact structure in `references/shared.md`; do not add, remove, rename, or reorder sections.
-8. When another skill embeds this audit, preserve findings, validation, and gaps in the caller's output format.
+6. When a candidate depends on prose contradicting implementation, first prove the implementation is insecure or wrong with non-prose evidence. If current code, tests, runtime behavior, scanner output, or history support the implementation, do not report a security finding; use `$doc-gaps` for the stale prose.
+7. Report exploitable findings first.
+8. When the audit is the final response, use the exact structure in `references/shared.md`; do not add, remove, rename, or reorder sections.
+9. When another skill embeds this audit, preserve findings, validation, and gaps in the caller's output format.
 
 ## References
 

--- a/skills/security-audit/references/shared.md
+++ b/skills/security-audit/references/shared.md
@@ -97,5 +97,11 @@ unsupported candidates. They align with `../../references/finding-severity.md`.
 - Findings must be ordered by severity, with exploitable risks before hardening items.
 - Each finding should state: risk, trigger condition, impact, and remediation.
 - Do not report generic checklist items as findings unless they apply to the audited code.
+- Do not report findings based only on comments, GoDoc, README text, examples,
+  or other prose contradicting implementation. Prose can be stale; prove the
+  actual code or configuration is insecure or wrong with non-prose evidence
+  such as data/control flow, runtime behavior, scanner output, external security
+  standards, generated contracts, tests, or history. If current behavior is
+  supported and the prose is stale, report a documentation gap instead.
 - If no findings are found, say that clearly and list meaningful gaps, such as scanners not installed or dynamic behavior not exercised.
 - When another skill embeds the audit, keep the same factual content and severity meaning but use the caller's required output sections.

--- a/skills/test-gaps/SKILL.md
+++ b/skills/test-gaps/SKILL.md
@@ -26,6 +26,14 @@ Operate as a coverage triager: protect repository-owned behavior through the
 narrowest credible established test layer, and reject gaps that only test
 dependency semantics, private implementation detail, or coverage vanity.
 
+Use code, executable behavior, existing tests, schemas, generated contracts,
+runtime evidence, external standards, and history to establish expected
+behavior. Comments, GoDoc, README prose, examples, and other documentation can
+be stale. Do not record a test gap merely to make tests enforce stale prose; if
+prose and implementation disagree, first prove which behavior is wrong with
+non-prose evidence, then route code bugs to `$code-issues` and stale prose to
+`$doc-gaps`.
+
 ## Find Mode
 
 Follow `references/plan.md#find-mode-plan`.
@@ -50,6 +58,7 @@ These rules remain mandatory:
 - Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally. Each finding must name the repository-owned behavior being protected; reject findings that only test dependency semantics, aliases, or pass-through wrappers.
 - Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity.
 - Confirm each candidate gap against the code and existing tests before recording it. Gaps must be concrete missing, weak, misleading, flaky, or wrong-layer coverage with credible risk to changed behavior, public contracts, compatibility, release-sensitive workflows, or documented command/API behavior.
+- For candidates based on documentation or comments contradicting code, require non-prose evidence for the expected behavior before recording a test gap. If current code and tests support the implementation, treat the prose as a doc gap instead of adding tests that would encode stale documentation.
 - For each candidate, explicitly identify the nearby existing test shape and why extending existing tests, fixtures, tables, helpers, or assertions does not already cover the behavior. Do not record a gap when the proposed fix would duplicate coverage already provided by that local shape.
 - Do not record gaps whose only meaningful test would assert pass-through behavior to an upstream library, standard library, or framework. This includes aliases, type aliases, thin wrappers, direct option forwarding, direct global setter/getter calls, dependency injection container behavior, validator tag behavior, encoder/parser behavior, and constructors where the repository adds no branching, validation, transformation, error handling, lifecycle behavior, compatibility policy, or composition contract of its own.
 - Only record a gap around third-party integration when the untested behavior is repository-owned. Examples include local validation/normalization before calling the dependency, local input/output mapping, local error wrapping/classification/recovery, lifecycle ordering or cleanup owned by the repository, documented compatibility behavior promised across dependency versions, or end-to-end behavior through a supported public repo entrypoint where multiple repo-owned pieces are composed.
@@ -100,6 +109,7 @@ These rules remain mandatory:
 - If scoped `ISSUES.md` does not exist, stop and ask whether to run Find mode first for that scope.
 - Work through findings sequentially by ID unless the human explicitly names a different finding.
 - Before proposing a fix for each finding, re-check the current code and nearby tests. Treat the ledger as something that can go stale: dismiss or revise findings that are already covered, would duplicate the local test shape, test only underlying libraries/frameworks, or require validation modes the repository does not run.
+- When re-checking a finding whose evidence depends on documentation or comments contradicting implementation, prove the expected behavior with non-prose evidence before proposing tests. If non-prose evidence supports the implementation, explain that the ledger item is invalid as a test gap and propose reclassifying or fixing documentation instead.
 - Stop after proposing the solution. Do not edit code, update `ISSUES.md`, or start validation until the human explicitly agrees to that finding's solution.
 - Ask questions when behavior, compatibility, test layer, fixture strategy, validation, or user intent is ambiguous. Treat silence or a broad "implement test gaps" request as permission to start the proposal workflow, not as permission to code.
 - After the human agrees and before editing, state the selected local test pattern, dominant relevant test harness, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.

--- a/skills/test-gaps/references/plan.md
+++ b/skills/test-gaps/references/plan.md
@@ -66,15 +66,18 @@ repository root and keep `bin/` as shared guidance.
     scope.
 12. Deduplicate candidates and directly re-check conflicting or overlapping
     conclusions against code and tests.
-13. Confirm each gap protects repository-owned behavior and is not duplicate,
+13. For candidates based on prose contradicting implementation, prove the
+    expected behavior with non-prose evidence before treating missing coverage
+    as a test gap; otherwise classify the mismatch as a documentation gap.
+14. Confirm each gap protects repository-owned behavior and is not duplicate,
     private-only, dependency-only, optional, or better handled by another skill.
-14. If no confirmed gaps remain, report that result with the coverage state, do
+15. If no confirmed gaps remain, report that result with the coverage state, do
     not create `ISSUES.md`, and stop.
-15. If confirmed gaps remain, write the scoped `ISSUES.md` with `TEST-<number>`
+16. If confirmed gaps remain, write the scoped `ISSUES.md` with `TEST-<number>`
     IDs.
-16. Present the scoped ledger, proposed test-fix plan, coverage state for broad
+17. Present the scoped ledger, proposed test-fix plan, coverage state for broad
     scopes, and runnable follow-up scopes for deferred slices.
-17. Stop before making fixes.
+18. Stop before making fixes.
 
 ## Implement Mode Plan
 
@@ -84,17 +87,20 @@ repository root and keep `bin/` as shared guidance.
    wiring.
 4. Select the next finding by ID unless the human named a specific finding.
 5. Re-check the finding against current code, tests, fixtures, and harnesses.
-6. Present the finding evidence, proposed test solution, repository-owned
+6. If the finding depends on prose contradicting implementation, prove the
+   expected behavior with non-prose evidence before proposing tests; otherwise
+   propose reclassification as a documentation gap.
+7. Present the finding evidence, proposed test solution, repository-owned
    behavior, existing coverage gap, tradeoffs, and intended validation.
-7. Stop until the human explicitly agrees to that finding's solution.
-8. After agreement, state the local test pattern, dominant relevant test
+8. Stop until the human explicitly agrees to that finding's solution.
+9. After agreement, state the local test pattern, dominant relevant test
    harness, planned validation, and any needed deviation.
-9. If a deviation is needed, stop and ask before editing.
-10. Implement only the agreed test gap with the smallest clear test change.
-11. Use `$testing-standards` and the relevant language standard for test design.
-12. Validate the test change with commands appropriate to the changed tests.
-13. Report the result and ask the human to verify with `TEST-<number> is done`.
-14. Stop until that confirmation arrives.
-15. After confirmation, remove or revise the finding in scoped `ISSUES.md`.
-16. Continue with the next finding, or delete scoped `ISSUES.md` after all gaps
+10. If a deviation is needed, stop and ask before editing.
+11. Implement only the agreed test gap with the smallest clear test change.
+12. Use `$testing-standards` and the relevant language standard for test design.
+13. Validate the test change with commands appropriate to the changed tests.
+14. Report the result and ask the human to verify with `TEST-<number> is done`.
+15. Stop until that confirmation arrives.
+16. After confirmation, remove or revise the finding in scoped `ISSUES.md`.
+17. Continue with the next finding, or delete scoped `ISSUES.md` after all gaps
     are confirmed resolved.


### PR DESCRIPTION
## What

- Require finder and audit workflows to prove implementation is wrong with
  non-prose evidence before recording code, test, reliability, or security
  findings.
- Route prose and implementation mismatches to documentation fixes when code,
  tests, runtime behavior, contracts, or history support the implementation.
- Apply the rule across code review, code issues, test gaps, doc gaps,
  reliability gaps, security audit, doc standards, and shared severity guidance.

## Why

- Comments, GoDoc, README prose, and examples can be stale, so they should start
  an investigation rather than define expected behavior by themselves.
- The finder ledgers should contain proven code problems, while stale prose
  should be handled as documentation work.

## Testing

- `git diff --check` - passed
- `zsh -lic 'make skills-lint'` - passed
- `zsh -lic 'make lint'` - passed
- The zsh shell emitted local oh-my-zsh permission warnings before the make
  commands, but both make commands exited 0.
