### PR TITLE
feat(skills): require high-confidence findings

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -117,6 +117,11 @@ When a skill is used as the final answer, use that skill's required output
 format. When a skill is embedded by another skill, preserve its concrete facts
 and use the caller's output format.
 
+Findings must include confidence when the selected skill's format has findings
+or ledger entries. Use `skills/references/finding-severity.md`: record only
+`High (>=80%)` findings, gather more evidence for uncertain candidates, and
+discard candidates that cannot reach that threshold.
+
 ## Testing Principle
 
 Use `testing-standards` when adding, reviewing, refactoring, or planning tests.

--- a/skills/code-issues/SKILL.md
+++ b/skills/code-issues/SKILL.md
@@ -56,7 +56,7 @@ These rules remain mandatory:
 - Do not present a broad requested scope as fully reviewed when any relevant slice was only skimmed or deferred. Name those slices in the final coverage notes and provide runnable follow-up scopes for deferred review.
 - Each assigned agent owns recursive review only within its bounded slice. Each agent must perform a thorough and accurate `$code-review` and `$security-audit` for that slice, using `$testing-standards` for concrete missing-coverage or weak-test analysis and `$change-validation` for likely validation commands.
 - Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
-- Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity.
+- Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity and confidence.
 - Confirm each candidate finding against the code before recording it. Findings must be concrete bugs, security issues, compatibility breaks, or violated public contracts with user-visible impact.
 - For candidates based on documentation or comments contradicting code, require non-prose proof that the implementation is wrong before recording a code issue. Existing tests, helper names, runtime behavior, or commit history that support the implementation mean the candidate is a doc gap, not a code issue.
 - Do not record standalone missing, weak, flaky, misleading, or wrong-layer tests as code issues unless they are tied to a confirmed bug, security issue, compatibility break, or violated public contract. Use `$test-gaps` for standalone missing or weak test coverage passes.
@@ -77,6 +77,7 @@ Use this structure:
 ## ISSUE-1: Short concrete title
 
 - Severity: Critical|High|Medium|Low
+- Confidence: High (>=80%)
 - Scope: path/to/file-or-folder
 - Impact: User-visible impact or violated contract.
 - Evidence: Concrete file and line references, command output, or code path.
@@ -115,7 +116,7 @@ These rules remain mandatory:
 ## References
 
 - Read `references/plan.md` before starting Find mode or Implement mode.
-- Use `../references/finding-severity.md` for confidence filtering and severity.
+- Use `../references/finding-severity.md` for confidence filtering, confidence labels, and severity.
 - Use `$code-review` for review rigor and finding quality.
 - Use `$security-audit` for security-sensitive review scope.
 - Use `$testing-standards` when deciding or reviewing regression coverage.

--- a/skills/code-review/references/findings-format.md
+++ b/skills/code-review/references/findings-format.md
@@ -21,7 +21,10 @@ Use this reference when the user asks for a review.
 ## Severity
 
 - Use `../../references/finding-severity.md` to filter low-confidence
-  candidates before assigning severity.
+  candidates before assigning severity and confidence.
+- Every finding must include `Confidence: High (>=80%)`. If confidence cannot
+  reach that threshold after reasonable verification, do not report the
+  candidate as a finding.
 - For code-review output, write severity values in lowercase:
   `critical`, `high`, `medium`, or `low`.
 - Do not inflate severity for style preferences, speculative risks, or missing
@@ -37,6 +40,7 @@ Use this reference when the user asks for a review.
 ## Findings
 
 - [severity] path/to/file:line - Finding title
+  Confidence: High (>=80%)
   Impact: Describe the concrete bug, regression, or risk.
   Evidence: Point to the inspected code or behavior.
   Recommendation: Describe the smallest credible fix.
@@ -61,7 +65,7 @@ Brief one- or two-sentence summary.
 - Keep the summary brief and secondary to the findings.
 - When useful, state the condition or scenario that triggers the problem so the risk is easy to verify.
 - If a section has no entries, write exactly `- None.`
-- When another skill embeds the review, keep the same finding severity, evidence, impact, recommendation, open-question, and testing-gap facts but use the caller's required output sections.
+- When another skill embeds the review, keep the same finding severity, confidence, evidence, impact, recommendation, open-question, and testing-gap facts but use the caller's required output sections.
 
 ## If No Findings
 

--- a/skills/diagnose-issue/references/ci.md
+++ b/skills/diagnose-issue/references/ci.md
@@ -44,7 +44,9 @@ are accepted for compatibility, but do not ask users for UUIDs.
 
 ## Fix Suggestions
 
-Order suggestions by confidence:
+Order suggestions by confidence. State a fix as a likely cause only when the
+selected target evidence supports `Confidence: High (>=80%)`; otherwise suggest
+the next evidence to collect.
 
 1. Direct fix supported by the failing job or error category.
 2. Narrow command to reproduce locally through the repository's documented

--- a/skills/diagnose-issue/references/deployment.md
+++ b/skills/diagnose-issue/references/deployment.md
@@ -41,7 +41,9 @@ file exists at the repository root.
 
 ## Fix Suggestions
 
-Order suggestions by confidence:
+Order suggestions by confidence. State a fix as a likely cause only when the
+selected target evidence supports `Confidence: High (>=80%)`; otherwise suggest
+the next evidence to collect.
 
 1. Failed deploy job or rollout fix supported by collected evidence.
 2. Runtime fix supported by image mismatch, unready deployments, failing pods,

--- a/skills/diagnose-issue/references/output.md
+++ b/skills/diagnose-issue/references/output.md
@@ -31,7 +31,9 @@ Then include these sections:
 
 Use 1-3 bullets. State only conclusions supported by the selected pipeline or
 deployment target. If evidence is insufficient, say that and name the missing
-source.
+source. Include `Confidence: High (>=80%)` for each stated likely-cause finding;
+if confidence is lower, move the item to `Data Gaps` or phrase it as evidence
+to collect instead of a likely cause.
 
 ## Evidence
 

--- a/skills/diagnose-issue/scripts/collect.rb
+++ b/skills/diagnose-issue/scripts/collect.rb
@@ -14,6 +14,7 @@ require 'yaml'
 # Performs read-only CI and deployment diagnosis for one repository target.
 class IssueDiagnosisCollector
   HTTP_TIMEOUT_SECONDS = 15
+  FINDING_CONFIDENCE = 'High (>=80%)'
 
   def initialize(options)
     @mode = options.fetch(:mode)
@@ -464,7 +465,13 @@ class IssueDiagnosisCollector
   end
 
   def finding(severity, area, evidence, suggestion)
-    { severity: severity, area: area, evidence: evidence, suggestion: suggestion }
+    {
+      severity: severity,
+      confidence: FINDING_CONFIDENCE,
+      area: area,
+      evidence: evidence,
+      suggestion: suggestion
+    }
   end
 
   def job_number(job)

--- a/skills/doc-gaps/SKILL.md
+++ b/skills/doc-gaps/SKILL.md
@@ -55,7 +55,7 @@ These rules remain mandatory:
 - Each assigned agent owns recursive review only within its bounded slice. Each agent must perform a thorough documentation review for that slice, pairing with `$doc-standards`, relevant language standards, `$naming-standards` when terminology is unclear or inconsistent, and `$change-validation` for likely validation commands.
 - Each agent must audit the relevant documentation surfaces before returning candidates: README files, docs, examples, command help, package documentation, exported API comments, code comments, and docstrings. For each candidate, apply `$doc-standards`' adequacy gate by identifying the public surface, intended audience, user action or maintenance decision at risk, existing documentation surface, correct target surface, minimum successful example or command, and missing non-obvious contract.
 - Require each agent to return candidates in the candidate format below, without final IDs unless useful locally.
-- Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity.
+- Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity and confidence.
 - Confirm each candidate gap against the code, current docs, examples, and documented interfaces before fixing it, using `$doc-standards` as the finding threshold. Do not confirm or dismiss a candidate merely because documentation exists; verify adequacy, ownership, discoverability, example coverage, and the relevant non-obvious contract.
 - When prose and implementation disagree, require non-prose evidence before treating the code as wrong or routing the candidate out to another workflow. If code, tests, runtime behavior, generated contracts, or history support the implementation, fix the stale prose as a doc gap.
 - Before fixing or dismissing a candidate, route it to the correct documentation surface: README, docs, examples, command help, package documentation, exported API comment, code comment, docstring, or no change. Do not treat package GoDoc or code-comment improvements as sufficient when first-use, setup, configuration, operational behavior, security expectations, or service-author workflows would reasonably be expected in README files, user-facing docs, examples, or command help. Do not treat README prose as sufficient when `$doc-standards` and the paired language standard route reusable API contracts to GoDoc, RDoc, docstrings, executable examples, specs, or features.
@@ -106,6 +106,7 @@ entries:
 
 - Type: Doc Gap
 - Severity: Critical|High|Medium|Low
+- Confidence: High (>=80%)
 - Scope: path/to/file-or-folder
 - Public surface: Command|API|package|service|configuration|example|file format|operator behavior.
 - Audience: Service author|Operator|Package consumer|Maintainer
@@ -133,6 +134,6 @@ Keep optional follow-up notes separate from findings:
 
 - Read `references/plan.md` before starting one-pass mode or audit-only mode.
 - Use `$doc-standards` as the documentation quality bar and routing threshold.
-- Use `../references/finding-severity.md` for confidence filtering and severity.
+- Use `../references/finding-severity.md` for confidence filtering, confidence labels, and severity.
 - Use `$project-workflow` for repository command discovery, documented entrypoints, CI expectations, examples, and `./bin` wiring before review planning or validation.
 - Use the paired language, naming, safety, and validation skills through `$doc-standards`.

--- a/skills/references/finding-severity.md
+++ b/skills/references/finding-severity.md
@@ -1,18 +1,30 @@
 # Finding Severity
 
-Use this reference whenever a skill assigns severity to code, test, doc, or
-security findings.
+Use this reference whenever a skill assigns severity or confidence to code,
+test, doc, reliability, diagnostic, or security findings.
 
 ## Confidence And Actionability
 
 Filter candidates before assigning severity. A finding should have concrete
 evidence, a trigger condition, credible impact, and a plausible fix direction.
+Recorded findings must have `Confidence: High (>=80%)`. Treat this percentage
+as an evidence-calibration threshold, not a statistical claim: after trying to
+disprove the candidate, the inspected evidence should make it at least roughly
+80% likely that the finding is real, repository-owned, and actionable.
 
 Discard candidates that are likely false positives, vague suggestions,
 unsupported guesses, style-only preferences, nitpicks, or comments whose impact
 cannot be explained from the inspected code, tests, docs, or command behavior.
 Do not classify uncertain or low-confidence candidates as `Low`; `Low` still
 means a real finding with limited impact.
+
+If confidence is below the high-confidence threshold, gather more evidence
+through code inspection, current tests, command output, generated contracts,
+scanner output, official sources, runtime behavior, or history. If confidence
+still cannot reach `High (>=80%)`, do not record it as a finding. Use the
+workflow's data-gap, open-question, or optional follow-up section only when that
+section is explicitly meant for unresolved evidence; otherwise discard the
+candidate.
 
 When a candidate depends on comments, GoDoc, README text, examples, or other
 prose contradicting implementation, do not treat the prose as source of truth.

--- a/skills/reliability-gaps/SKILL.md
+++ b/skills/reliability-gaps/SKILL.md
@@ -58,7 +58,7 @@ These rules remain mandatory:
 - Do not present a broad requested scope as fully reviewed when any relevant slice was only skimmed or deferred. Name those slices in the final coverage notes and provide runnable follow-up scopes for deferred review.
 - Each assigned agent owns recursive review only within its bounded slice. Each agent must perform a thorough `$reliability-standards` review for that slice, pairing with `$change-safety`, `$security-audit`, `$testing-standards`, and `$change-validation` as the surface requires.
 - Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
-- Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity.
+- Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity and confidence.
 - Confirm each candidate gap against current evidence before recording it. Try to disprove the candidate by tracing the current code path, reading the documented workflow, checking the relevant config, inspecting existing tests, or running an allowed local command. A gap must name the affected reliability promise or operational expectation, the trigger condition, the failure mode, the missing or weak control, and the likely user or operator impact.
 - For candidates based on documentation or comments contradicting code, require non-prose proof that the implementation or repository-owned reliability control is wrong before recording a reliability gap. If current code, tests, runtime behavior, CI, or history support the implementation, treat the prose as a doc gap.
 - Record reliability gaps only when they involve repository-owned behavior or documented/implicit operational contracts, such as:
@@ -93,6 +93,7 @@ Use this structure:
 
 - Type: Reliability Gap
 - Severity: Critical|High|Medium|Low
+- Confidence: High (>=80%)
 - Scope: path/to/file-or-folder
 - Impact: User, operator, incident, availability, recovery, data-integrity, or scaling risk.
 - Evidence: Concrete file and line references, command behavior, config, docs, tests, missing control, failure mode, calculation gap, and the verification path used to rule out a guess.
@@ -140,7 +141,7 @@ These rules remain mandatory:
 ## References
 
 - Read `references/plan.md` before starting Find mode or Implement mode.
-- Use `../references/finding-severity.md` for confidence filtering and severity.
+- Use `../references/finding-severity.md` for confidence filtering, confidence labels, and severity.
 - Use `$reliability-standards` for SRE, NALSD, resilience, recovery, overload, observability, release-safety, and production-readiness judgment.
 - Use `$project-workflow` for repository command discovery, CI expectations, documented entrypoints, operational docs, and `./bin` wiring before review planning or validation.
 - Use `$change-safety` when reliability changes affect public contracts, compatibility, migrations, config, deployment, security expectations, or documented operational behavior.

--- a/skills/security-audit/references/shared.md
+++ b/skills/security-audit/references/shared.md
@@ -57,6 +57,9 @@ Use this reference for any security audit, then load language-specific reference
 
 Use these security-specific examples after filtering out low-confidence or
 unsupported candidates. They align with `../../references/finding-severity.md`.
+Recorded security findings must include `confidence: High (>=80%)`; if the
+audited evidence cannot support that threshold, gather more evidence or discard
+the candidate.
 
 - Critical: near-certain remote code execution, credential exposure, auth bypass, data loss or corruption, or exploitable critical dependency issue with broad severe impact.
 - High: likely exploitable command injection, arbitrary file write/delete, path traversal to sensitive files, sensitive information disclosure, or other serious security issue with narrower impact.
@@ -71,6 +74,7 @@ unsupported candidates. They align with `../../references/finding-severity.md`.
 ## Findings
 
 - severity: Critical
+  confidence: High (>=80%)
   file: `path/to/file:42`
   risk: Untrusted input reaches shell execution.
   trigger: User-controlled CLI arguments are interpolated into a shell command.
@@ -89,9 +93,10 @@ unsupported candidates. They align with `../../references/finding-severity.md`.
 ```
 
 - Use only these severity values for findings: `Critical`, `High`, `Medium`, `Low`. Use `None` only for the required no-findings entry.
+- Use only `High (>=80%)` for finding confidence. Use `n/a` only for the required no-findings entry.
 - Use only these validation results: `passed`, `failed`, `not run`, `no-op`.
 - Use `file: n/a` only for repository-wide dependency, configuration, or validation findings that do not have a precise source line.
-- If there are no findings, write exactly one finding entry with `severity: None`, `file: n/a`, `risk: No findings.`, `trigger: n/a`, `impact: n/a`, and `remediation: n/a`.
+- If there are no findings, write exactly one finding entry with `severity: None`, `confidence: n/a`, `file: n/a`, `risk: No findings.`, `trigger: n/a`, `impact: n/a`, and `remediation: n/a`.
 - If no validation ran, write one `Validation` entry with `command: none`, `result: not run`, and a concise coverage explanation.
 - If there are no gaps, write exactly `- None.`
 - Findings must be ordered by severity, with exploitable risks before hardening items.
@@ -104,4 +109,4 @@ unsupported candidates. They align with `../../references/finding-severity.md`.
   standards, generated contracts, tests, or history. If current behavior is
   supported and the prose is stale, report a documentation gap instead.
 - If no findings are found, say that clearly and list meaningful gaps, such as scanners not installed or dynamic behavior not exercised.
-- When another skill embeds the audit, keep the same factual content and severity meaning but use the caller's required output sections.
+- When another skill embeds the audit, keep the same factual content, confidence, and severity meaning but use the caller's required output sections.

--- a/skills/test-gaps/SKILL.md
+++ b/skills/test-gaps/SKILL.md
@@ -56,7 +56,7 @@ These rules remain mandatory:
 - Do not present a broad requested scope as fully reviewed when any relevant slice was only skimmed or deferred. Name those slices in the final coverage notes and provide runnable follow-up scopes for deferred review.
 - Each assigned agent owns recursive review only within its bounded slice. Each agent must perform a thorough and accurate `$testing-standards` review for that slice, pairing with relevant language standards and `$change-validation` for likely validation commands.
 - Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally. Each finding must name the repository-owned behavior being protected; reject findings that only test dependency semantics, aliases, or pass-through wrappers.
-- Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity.
+- Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity and confidence.
 - Confirm each candidate gap against the code and existing tests before recording it. Gaps must be concrete missing, weak, misleading, flaky, or wrong-layer coverage with credible risk to changed behavior, public contracts, compatibility, release-sensitive workflows, or documented command/API behavior.
 - For candidates based on documentation or comments contradicting code, require non-prose evidence for the expected behavior before recording a test gap. If current code and tests support the implementation, treat the prose as a doc gap instead of adding tests that would encode stale documentation.
 - For each candidate, explicitly identify the nearby existing test shape and why extending existing tests, fixtures, tables, helpers, or assertions does not already cover the behavior. Do not record a gap when the proposed fix would duplicate coverage already provided by that local shape.
@@ -83,6 +83,7 @@ Use this structure:
 
 - Type: Test Gap
 - Severity: Critical|High|Medium|Low
+- Confidence: High (>=80%)
 - Scope: path/to/file-or-folder
 - Impact: Risk created by the missing, weak, misleading, flaky, or wrong-layer coverage.
 - Evidence: Concrete file and line references, existing test behavior, command output, or untested code path.
@@ -122,7 +123,7 @@ These rules remain mandatory:
 ## References
 
 - Read `references/plan.md` before starting Find mode or Implement mode.
-- Use `../references/finding-severity.md` for confidence filtering and severity.
+- Use `../references/finding-severity.md` for confidence filtering, confidence labels, and severity.
 - Use `$testing-standards` for cross-language test quality, coverage, fixtures, determinism, and test-layer decisions.
 - Use relevant language standards for local test idioms.
 - Use `$doc-gaps` instead when the user asks for a standalone missing, stale, misleading, or weak documentation, README, example, comment, or docstring pass.


### PR DESCRIPTION
## What

- Require recorded findings to include `Confidence: High (>=80%)` across shared review, audit, gap, and diagnostic output formats.
- Add the high-confidence threshold to the shared finding-severity reference, including instructions to gather more evidence or discard candidates below the threshold.
- Include confidence in diagnose-issue collector JSON findings and preserve confidence when embedded review or audit findings flow through another workflow.

## Why

- Keeps finding ledgers and review output actionable by making confidence explicit instead of allowing uncertain candidates to be reported as low severity.
- Gives agents one shared threshold for deciding whether to record a finding, continue investigating, move the issue to a data-gap or follow-up section, or discard it.

## Testing

- `make dep` - passed
- `make clean-dep` - passed
- `make skills-lint` - passed
- `make lint` - passed
- `make scripts-lint` - passed
- `make docker-lint` - passed
- `make sec` - passed
- `git diff --check` - passed
