### PR TITLE
feat(skills): require numeric confidence reports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,10 @@ Agents MUST:
 - Use sub-agents when the selected skill requires delegation, parallel review,
   or forward-testing. Do not treat required sub-agent use as optional based on
   scope size, convenience, or local confidence.
+- Report an explicit confidence percentage before treating a result, finding,
+  validation conclusion, or task as accepted or complete. Accept or mark work
+  complete only when confidence is at least 90%; below 90%, gather more
+  evidence or state the blocker instead of accepting completion.
 - Follow existing repository patterns over personal judgment.
 - Treat skill workflow steps using "must", "do not", or "stop" language as
   blocking requirements.

--- a/quality/skills/lint
+++ b/quality/skills/lint
@@ -114,8 +114,10 @@ require_pattern AGENTS.md "mandatory operating rules, not advisory guidance"
 require_pattern AGENTS.md "## Local pattern binding"
 require_pattern AGENTS.md "Re-read the selected skill and identify the governing instruction"
 require_pattern AGENTS.md "rerun Make targets through the initialized"
+require_pattern AGENTS.md "complete only when confidence is at least 90%"
 
 require_pattern skills/README.md "Skills are mandatory operating rules, not advisory notes."
+require_pattern skills/README.md "accept or mark work complete only when confidence is at least 90%"
 
 require_pattern skills/project-workflow/SKILL.md "Before editing code, tests, docs, config, scripts, or validation paths, identify the local pattern"
 require_pattern skills/project-workflow/references/bin-submodule.md "Treat the consuming repository's \`AGENTS.md\` as binding local policy"

--- a/skills/README.md
+++ b/skills/README.md
@@ -23,6 +23,12 @@ based on scope size, convenience, or local confidence, and do not claim extra
 delegation wording is needed when the selected skill says the user's invocation
 already grants permission.
 
+Agents must report an explicit confidence percentage before treating a result,
+finding, validation conclusion, or task as accepted or complete. They must
+accept or mark work complete only when confidence is at least 90%; below 90%,
+they must gather more evidence or state the blocker instead of accepting
+completion.
+
 ## Common Composition
 
 - `review-pr` orchestrates PR preparation with `project-workflow`,
@@ -118,9 +124,10 @@ format. When a skill is embedded by another skill, preserve its concrete facts
 and use the caller's output format.
 
 Findings must include confidence when the selected skill's format has findings
-or ledger entries. Use `skills/references/finding-severity.md`: record only
-`High (>=80%)` findings, gather more evidence for uncertain candidates, and
-discard candidates that cannot reach that threshold.
+or ledger entries. Use `skills/references/finding-severity.md`: record the
+agent's actual confidence percentage, record only findings at 90% confidence or
+higher, gather more evidence for uncertain candidates, and discard candidates
+that cannot reach that threshold.
 
 ## Testing Principle
 

--- a/skills/code-issues/SKILL.md
+++ b/skills/code-issues/SKILL.md
@@ -77,7 +77,7 @@ Use this structure:
 ## ISSUE-1: Short concrete title
 
 - Severity: Critical|High|Medium|Low
-- Confidence: High (>=80%)
+- Confidence: 93%
 - Scope: path/to/file-or-folder
 - Impact: User-visible impact or violated contract.
 - Evidence: Concrete file and line references, command output, or code path.

--- a/skills/code-review/references/findings-format.md
+++ b/skills/code-review/references/findings-format.md
@@ -22,9 +22,9 @@ Use this reference when the user asks for a review.
 
 - Use `../../references/finding-severity.md` to filter low-confidence
   candidates before assigning severity and confidence.
-- Every finding must include `Confidence: High (>=80%)`. If confidence cannot
-  reach that threshold after reasonable verification, do not report the
-  candidate as a finding.
+- Every finding must include the agent's actual confidence percentage, for
+  example `Confidence: 93%`. If confidence cannot reach 90% after reasonable
+  verification, do not report the candidate as a finding.
 - For code-review output, write severity values in lowercase:
   `critical`, `high`, `medium`, or `low`.
 - Do not inflate severity for style preferences, speculative risks, or missing
@@ -40,7 +40,7 @@ Use this reference when the user asks for a review.
 ## Findings
 
 - [severity] path/to/file:line - Finding title
-  Confidence: High (>=80%)
+  Confidence: 93%
   Impact: Describe the concrete bug, regression, or risk.
   Evidence: Point to the inspected code or behavior.
   Recommendation: Describe the smallest credible fix.

--- a/skills/diagnose-issue/references/ci.md
+++ b/skills/diagnose-issue/references/ci.md
@@ -45,8 +45,8 @@ are accepted for compatibility, but do not ask users for UUIDs.
 ## Fix Suggestions
 
 Order suggestions by confidence. State a fix as a likely cause only when the
-selected target evidence supports `Confidence: High (>=80%)`; otherwise suggest
-the next evidence to collect.
+selected target evidence supports at least 90% confidence, and state the actual
+percentage; otherwise suggest the next evidence to collect.
 
 1. Direct fix supported by the failing job or error category.
 2. Narrow command to reproduce locally through the repository's documented

--- a/skills/diagnose-issue/references/deployment.md
+++ b/skills/diagnose-issue/references/deployment.md
@@ -42,8 +42,8 @@ file exists at the repository root.
 ## Fix Suggestions
 
 Order suggestions by confidence. State a fix as a likely cause only when the
-selected target evidence supports `Confidence: High (>=80%)`; otherwise suggest
-the next evidence to collect.
+selected target evidence supports at least 90% confidence, and state the actual
+percentage; otherwise suggest the next evidence to collect.
 
 1. Failed deploy job or rollout fix supported by collected evidence.
 2. Runtime fix supported by image mismatch, unready deployments, failing pods,

--- a/skills/diagnose-issue/references/output.md
+++ b/skills/diagnose-issue/references/output.md
@@ -31,9 +31,10 @@ Then include these sections:
 
 Use 1-3 bullets. State only conclusions supported by the selected pipeline or
 deployment target. If evidence is insufficient, say that and name the missing
-source. Include `Confidence: High (>=80%)` for each stated likely-cause finding;
-if confidence is lower, move the item to `Data Gaps` or phrase it as evidence
-to collect instead of a likely cause.
+source. Include the actual confidence percentage, for example `Confidence: 93%`,
+for each stated likely-cause finding; if confidence is lower than 90%, move the
+item to `Data Gaps` or phrase it as evidence to collect instead of a likely
+cause.
 
 ## Evidence
 

--- a/skills/diagnose-issue/scripts/collect.rb
+++ b/skills/diagnose-issue/scripts/collect.rb
@@ -14,7 +14,6 @@ require 'yaml'
 # Performs read-only CI and deployment diagnosis for one repository target.
 class IssueDiagnosisCollector
   HTTP_TIMEOUT_SECONDS = 15
-  FINDING_CONFIDENCE = 'High (>=80%)'
 
   def initialize(options)
     @mode = options.fetch(:mode)
@@ -467,7 +466,6 @@ class IssueDiagnosisCollector
   def finding(severity, area, evidence, suggestion)
     {
       severity: severity,
-      confidence: FINDING_CONFIDENCE,
       area: area,
       evidence: evidence,
       suggestion: suggestion

--- a/skills/doc-gaps/SKILL.md
+++ b/skills/doc-gaps/SKILL.md
@@ -106,7 +106,7 @@ entries:
 
 - Type: Doc Gap
 - Severity: Critical|High|Medium|Low
-- Confidence: High (>=80%)
+- Confidence: 93%
 - Scope: path/to/file-or-folder
 - Public surface: Command|API|package|service|configuration|example|file format|operator behavior.
 - Audience: Service author|Operator|Package consumer|Maintainer

--- a/skills/references/finding-severity.md
+++ b/skills/references/finding-severity.md
@@ -7,10 +7,12 @@ test, doc, reliability, diagnostic, or security findings.
 
 Filter candidates before assigning severity. A finding should have concrete
 evidence, a trigger condition, credible impact, and a plausible fix direction.
-Recorded findings must have `Confidence: High (>=80%)`. Treat this percentage
-as an evidence-calibration threshold, not a statistical claim: after trying to
-disprove the candidate, the inspected evidence should make it at least roughly
-80% likely that the finding is real, repository-owned, and actionable.
+Recorded findings must state the agent's actual confidence percentage, for
+example `Confidence: 93%`, and that percentage must be at least 90%. Treat this
+percentage as an evidence-calibration threshold, not a statistical claim: after
+trying to disprove the candidate, the inspected evidence should make it at
+least roughly 90% likely that the finding is real, repository-owned, and
+actionable.
 
 Discard candidates that are likely false positives, vague suggestions,
 unsupported guesses, style-only preferences, nitpicks, or comments whose impact
@@ -21,7 +23,7 @@ means a real finding with limited impact.
 If confidence is below the high-confidence threshold, gather more evidence
 through code inspection, current tests, command output, generated contracts,
 scanner output, official sources, runtime behavior, or history. If confidence
-still cannot reach `High (>=80%)`, do not record it as a finding. Use the
+still cannot reach 90%, do not record it as a finding. Use the
 workflow's data-gap, open-question, or optional follow-up section only when that
 section is explicitly meant for unresolved evidence; otherwise discard the
 candidate.

--- a/skills/reliability-gaps/SKILL.md
+++ b/skills/reliability-gaps/SKILL.md
@@ -93,7 +93,7 @@ Use this structure:
 
 - Type: Reliability Gap
 - Severity: Critical|High|Medium|Low
-- Confidence: High (>=80%)
+- Confidence: 93%
 - Scope: path/to/file-or-folder
 - Impact: User, operator, incident, availability, recovery, data-integrity, or scaling risk.
 - Evidence: Concrete file and line references, command behavior, config, docs, tests, missing control, failure mode, calculation gap, and the verification path used to rule out a guess.

--- a/skills/security-audit/references/shared.md
+++ b/skills/security-audit/references/shared.md
@@ -57,9 +57,9 @@ Use this reference for any security audit, then load language-specific reference
 
 Use these security-specific examples after filtering out low-confidence or
 unsupported candidates. They align with `../../references/finding-severity.md`.
-Recorded security findings must include `confidence: High (>=80%)`; if the
-audited evidence cannot support that threshold, gather more evidence or discard
-the candidate.
+Recorded security findings must include the agent's actual confidence
+percentage, for example `confidence: 93%`; if the audited evidence cannot
+support at least 90% confidence, gather more evidence or discard the candidate.
 
 - Critical: near-certain remote code execution, credential exposure, auth bypass, data loss or corruption, or exploitable critical dependency issue with broad severe impact.
 - High: likely exploitable command injection, arbitrary file write/delete, path traversal to sensitive files, sensitive information disclosure, or other serious security issue with narrower impact.
@@ -74,7 +74,7 @@ the candidate.
 ## Findings
 
 - severity: Critical
-  confidence: High (>=80%)
+  confidence: 93%
   file: `path/to/file:42`
   risk: Untrusted input reaches shell execution.
   trigger: User-controlled CLI arguments are interpolated into a shell command.
@@ -93,7 +93,7 @@ the candidate.
 ```
 
 - Use only these severity values for findings: `Critical`, `High`, `Medium`, `Low`. Use `None` only for the required no-findings entry.
-- Use only `High (>=80%)` for finding confidence. Use `n/a` only for the required no-findings entry.
+- Use an actual percentage of at least 90% for finding confidence. Use `n/a` only for the required no-findings entry.
 - Use only these validation results: `passed`, `failed`, `not run`, `no-op`.
 - Use `file: n/a` only for repository-wide dependency, configuration, or validation findings that do not have a precise source line.
 - If there are no findings, write exactly one finding entry with `severity: None`, `confidence: n/a`, `file: n/a`, `risk: No findings.`, `trigger: n/a`, `impact: n/a`, and `remediation: n/a`.

--- a/skills/test-gaps/SKILL.md
+++ b/skills/test-gaps/SKILL.md
@@ -83,7 +83,7 @@ Use this structure:
 
 - Type: Test Gap
 - Severity: Critical|High|Medium|Low
-- Confidence: High (>=80%)
+- Confidence: 93%
 - Scope: path/to/file-or-folder
 - Impact: Risk created by the missing, weak, misleading, flaky, or wrong-layer coverage.
 - Evidence: Concrete file and line references, existing test behavior, command output, or untested code path.


### PR DESCRIPTION
## What

- Require agents to report an explicit confidence percentage before accepting results, findings, validation conclusions, or task completion.
- Raise shared finding workflows to the same 90% acceptance floor while changing report examples to show actual percentages such as `Confidence: 93%`.
- Add skill lint markers for the mandatory confidence policy and remove the diagnostic collector's hard-coded confidence claim so the final report reflects the agent's own estimate.

## Why

- Review and diagnostic reports should show the agent's stated confidence, not only that it cleared a threshold.
- Keeping the threshold in shared policy, finding references, workflow formats, and lint guards makes the rule consistent for downstream repositories that consume this tooling.

## Testing

- `make dep` - passed
- `make lint` - passed
- `make skills-lint` - passed
- `make scripts-lint` - passed
- `make sec` - passed
- `make docker-lint` - passed
