### PR TITLE
feat(skills): separate review workflow ledgers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .bundle/
 ISSUES.md
+TESTS.md
+DOCS.md
+RELIABILITY.md
+FEATURES.md
 vendor

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,11 +91,14 @@ skill instead of one broad default:
   suggestions that should not be reported as code-review findings.
 - `security-audit`: security reviews, vulnerability checks, unsafe shell/filesystem/network/auth inspection, and Go/Ruby/shell audit guidance.
 - `code-issues`: find confirmed code issues into `ISSUES.md`, then implement agreed fixes one code issue at a time.
-- `test-gaps`: find confirmed missing or weak tests into `ISSUES.md`, then implement agreed test fixes gap by gap.
-- `doc-gaps`: find and fix confirmed missing, stale, or misleading docs/comments in one pass, using `ISSUES.md` only for audit-only requests or unresolved gaps.
+- `test-gaps`: find confirmed missing or weak tests into `TESTS.md`, then implement agreed test fixes gap by gap.
+- `doc-gaps`: find and fix confirmed missing, stale, or misleading docs/comments in one pass, using `DOCS.md` only for audit-only requests or unresolved gaps.
+- `feature-gaps`: find concrete product or developer-experience feature
+  opportunities into `FEATURES.md`, then implement agreed feature changes one
+  at a time.
 - `reliability-standards`: SRE, NALSD, production-readiness, SLO, overload,
   observability, release-safety, recovery, and operability guidance.
-- `reliability-gaps`: find confirmed reliability gaps into `ISSUES.md`, then
+- `reliability-gaps`: find confirmed reliability gaps into `RELIABILITY.md`, then
   implement agreed reliability fixes gap by gap.
 - `repo-health`: daily or weekly repository delivery, CI quality,
   release/deploy, and service reliability summaries using GitHub, CircleCI,
@@ -142,16 +145,20 @@ Common composition:
   `ISSUES.md`, then implement agreed fixes one code issue at a time.
 - `test-gaps` orchestrates a two-phase test-gap workflow: aggregate confirmed
   `project-workflow` context and missing or weak test coverage into
-  `ISSUES.md`, then implement agreed test fixes gap by gap.
+  `TESTS.md`, then implement agreed test fixes gap by gap.
 - `doc-gaps` orchestrates a one-pass doc-gap workflow: aggregate confirmed
   `project-workflow` context and `$doc-standards` findings for missing, stale,
   or misleading README, docs, examples, comments, and docstrings, implement
-  confirmed documentation fixes, validate them, and use `ISSUES.md` only for
+  confirmed documentation fixes, validate them, and use `DOCS.md` only for
   audit-only requests or unresolved gaps.
+- `feature-gaps` orchestrates a two-phase feature-opportunity workflow:
+  aggregate confirmed `project-workflow` context, current repository behavior,
+  and comparable product or developer-experience evidence into `FEATURES.md`,
+  then implement agreed feature changes one feature at a time.
 - `reliability-gaps` orchestrates a two-phase reliability-gap workflow:
   aggregate confirmed `project-workflow` context and SRE, NALSD, operability,
   overload, observability, release-safety, recovery, or data-integrity gaps into
-  `ISSUES.md`, then implement agreed reliability fixes gap by gap.
+  `RELIABILITY.md`, then implement agreed reliability fixes gap by gap.
 - `repo-health` orchestrates delivery, quality, release/deploy, and
   service-reliability reporting; pair it with `project-workflow` for repository
   discovery and `change-validation` only when the summary process changes files

--- a/quality/skills/lint
+++ b/quality/skills/lint
@@ -5,91 +5,6 @@ set -eo pipefail
 
 missing=0
 
-check_skill_yaml() {
-  ruby <<'RUBY'
-require "yaml"
-
-ok = true
-
-Dir["skills/*/SKILL.md"].sort.each do |path|
-  text = File.read(path)
-  match = text.match(/\A---\n(.*?)\n---/m)
-  unless match
-    warn "missing frontmatter: #{path}"
-    ok = false
-    next
-  end
-
-  begin
-    data = YAML.safe_load(match[1])
-  rescue Psych::SyntaxError => e
-    warn "invalid frontmatter YAML in #{path}: #{e.message}"
-    ok = false
-    next
-  end
-
-  unless data.is_a?(Hash)
-    warn "frontmatter must be a mapping: #{path}"
-    ok = false
-    next
-  end
-
-  extra = data.keys - %w[name description]
-  unless extra.empty?
-    warn "unexpected frontmatter keys in #{path}: #{extra.join(", ")}"
-    ok = false
-  end
-
-  %w[name description].each do |key|
-    unless data[key].is_a?(String) && !data[key].strip.empty?
-      warn "missing or empty #{key} in #{path}"
-      ok = false
-    end
-  end
-end
-
-Dir["skills/*/agents/openai.yaml"].sort.each do |path|
-  skill_name = path.split("/")[1]
-
-  begin
-    data = YAML.safe_load(File.read(path))
-  rescue Psych::SyntaxError => e
-    warn "invalid agent YAML in #{path}: #{e.message}"
-    ok = false
-    next
-  end
-
-  interface = data.is_a?(Hash) ? data["interface"] : nil
-  unless interface.is_a?(Hash)
-    warn "missing interface mapping: #{path}"
-    ok = false
-    next
-  end
-
-  %w[display_name short_description default_prompt].each do |key|
-    unless interface[key].is_a?(String) && !interface[key].strip.empty?
-      warn "missing or empty interface.#{key} in #{path}"
-      ok = false
-    end
-  end
-
-  short_description = interface["short_description"]
-  if short_description.is_a?(String) && !(25..64).cover?(short_description.length)
-    warn "interface.short_description must be 25-64 chars in #{path}"
-    ok = false
-  end
-
-  default_prompt = interface["default_prompt"]
-  if default_prompt.is_a?(String) && !default_prompt.include?("$#{skill_name}")
-    warn "interface.default_prompt must mention $#{skill_name} in #{path}"
-    ok = false
-  end
-end
-
-exit(ok ? 0 : 1)
-RUBY
-}
-
 require_pattern() {
   local file="$1"
   local pattern="$2"
@@ -106,7 +21,7 @@ require_pattern() {
   fi
 }
 
-if ! check_skill_yaml; then
+if ! ruby quality/skills/metadata; then
   missing=1
 fi
 
@@ -139,11 +54,14 @@ require_pattern skills/go-standards/references/conventions.md "Being cautious is
 require_pattern skills/code-issues/SKILL.md "After the human agrees and before editing, state the selected local code pattern"
 require_pattern skills/test-gaps/SKILL.md "After the human agrees and before editing, state the selected local test pattern"
 require_pattern skills/doc-gaps/SKILL.md "After the human agrees and before editing, state the selected local documentation pattern"
+require_pattern skills/feature-gaps/SKILL.md "After the human agrees and before editing, state the selected local code/config/docs pattern"
 require_pattern skills/reliability-gaps/SKILL.md "After the human agrees and before editing, state the selected local code/config/docs pattern"
 require_pattern skills/code-issues/SKILL.md "asks about issue IDs such as ISSUE-1"
 require_pattern skills/test-gaps/SKILL.md "asks about test gap IDs such as TEST-1"
 require_pattern skills/doc-gaps/SKILL.md "asks about doc gap IDs such as DOC-1"
+require_pattern skills/feature-gaps/SKILL.md "asks about feature IDs such as FEATURE-1"
 require_pattern skills/reliability-gaps/SKILL.md "asks about reliability gap IDs such as REL-1"
+require_pattern skills/feature-gaps/SKILL.md "state the feature execution checklist before"
 require_pattern skills/reliability-gaps/SKILL.md "state the reliability execution checklist before editing"
 require_pattern skills/reliability-gaps/SKILL.md "\`Red\`, \`Green\`, \`Refactor\`, and \`Validation\`"
 
@@ -155,6 +73,7 @@ require_pattern skills/reliability-gaps/agents/openai.yaml "answer reliability g
 require_pattern skills/code-issues/agents/openai.yaml "answer issue ID follow-ups such as ISSUE-1"
 require_pattern skills/test-gaps/agents/openai.yaml "answer test gap ID follow-ups such as TEST-1"
 require_pattern skills/doc-gaps/agents/openai.yaml "answer doc gap ID follow-ups such as DOC-1"
+require_pattern skills/feature-gaps/agents/openai.yaml "answer feature ID follow-ups such as FEATURE-1"
 require_pattern skills/change-validation/agents/openai.yaml "file changes make prior validation stale"
 
 exit "$missing"

--- a/quality/skills/metadata
+++ b/quality/skills/metadata
@@ -1,0 +1,100 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'yaml'
+
+def present_string?(value)
+  value.is_a?(String) && !value.strip.empty?
+end
+
+def report_failure(message)
+  warn message
+  nil
+end
+
+def safe_load_frontmatter(path)
+  text = File.read(path)
+  match = text.match(/\A---\n(.*?)\n---/m)
+  return report_failure("missing frontmatter: #{path}") unless match
+
+  YAML.safe_load(match[1])
+rescue Psych::SyntaxError => e
+  report_failure("invalid frontmatter YAML in #{path}: #{e.message}")
+end
+
+def safe_load_file(path)
+  YAML.safe_load_file(path)
+rescue Psych::SyntaxError => e
+  report_failure("invalid agent YAML in #{path}: #{e.message}")
+end
+
+def mapping?(data, path, message)
+  return true if data.is_a?(Hash)
+
+  report_failure("#{message}: #{path}")
+end
+
+def valid_required_strings?(data, keys, path, prefix: nil)
+  keys.map do |key|
+    name = [prefix, key].compact.join('.')
+    present_string?(data[key]) || report_failure("missing or empty #{name} in #{path}")
+  end.all?
+end
+
+def valid_skill_keys?(data, path)
+  extra = data.keys - %w[name description]
+  return true if extra.empty?
+
+  report_failure("unexpected frontmatter keys in #{path}: #{extra.join(', ')}")
+end
+
+def valid_short_description?(interface, path)
+  short_description = interface['short_description']
+  return true unless short_description.is_a?(String)
+  return true if (25..64).cover?(short_description.length)
+
+  report_failure("interface.short_description must be 25-64 chars in #{path}")
+end
+
+def valid_default_prompt?(interface, path)
+  skill_name = path.split('/')[1]
+  default_prompt = interface['default_prompt']
+  return true unless default_prompt.is_a?(String)
+  return true if default_prompt.include?("$#{skill_name}")
+
+  report_failure("interface.default_prompt must mention $#{skill_name} in #{path}")
+end
+
+def valid_skill?(path)
+  data = safe_load_frontmatter(path)
+  return false unless mapping?(data, path, 'frontmatter must be a mapping')
+
+  [valid_skill_keys?(data, path), valid_required_strings?(data, %w[name description], path)].all?
+end
+
+def agent_interface(path)
+  data = safe_load_file(path)
+  return false unless mapping?(data, path, 'agent YAML must be a mapping')
+
+  interface = data['interface']
+  return interface if interface.is_a?(Hash)
+
+  report_failure("missing interface mapping: #{path}")
+end
+
+def valid_agent?(path)
+  interface = agent_interface(path)
+  return false unless interface
+
+  [
+    valid_required_strings?(interface, %w[display_name short_description default_prompt], path, prefix: 'interface'),
+    valid_short_description?(interface, path),
+    valid_default_prompt?(interface, path)
+  ].all?
+end
+
+ok = true
+Dir['skills/*/SKILL.md'].each { |path| ok = false unless valid_skill?(path) }
+Dir['skills/*/agents/openai.yaml'].each { |path| ok = false unless valid_agent?(path) }
+
+exit(ok ? 0 : 1)

--- a/skills/README.md
+++ b/skills/README.md
@@ -40,16 +40,20 @@ completion.
   `ISSUES.md`, then implement agreed fixes one code issue at a time.
 - `test-gaps` orchestrates a two-phase test-gap workflow: first aggregate
   `project-workflow` context and confirmed missing or weak test coverage into
-  `ISSUES.md`, then implement agreed test fixes one gap at a time.
+  `TESTS.md`, then implement agreed test fixes one gap at a time.
 - `doc-gaps` orchestrates a one-pass doc-gap workflow: aggregate
   `project-workflow` context and confirmed `$doc-standards` findings for
   README, docs, examples, comments, and docstring gaps, implement confirmed
-  documentation fixes, validate them, and use `ISSUES.md` only for audit-only
+  documentation fixes, validate them, and use `DOCS.md` only for audit-only
   requests or unresolved gaps.
+- `feature-gaps` orchestrates a two-phase feature-opportunity workflow: first
+  aggregate `project-workflow` context, current repository behavior, and
+  comparable product or developer-experience evidence into `FEATURES.md`, then
+  implement agreed feature changes one feature at a time.
 - `reliability-gaps` orchestrates a two-phase reliability-gap workflow: first
   aggregate `project-workflow` context and verified SRE, NALSD, operability,
   overload, observability, release-safety, recovery, or data-integrity gaps into
-  `ISSUES.md`, then implement agreed reliability fixes one gap at a time.
+  `RELIABILITY.md`, then implement agreed reliability fixes one gap at a time.
 - `repo-health` orchestrates daily or weekly repository health
   reporting across delivery flow, CI quality, release/deploy activity, and
   service reliability. It should use `project-workflow` for repository
@@ -109,10 +113,10 @@ condition. Goals are per-session runtime state, like active plans; do not write
 them into the repository unless the human explicitly asks for a durable goal
 artifact.
 
-Goals do not bypass skill steps, stop gates, permission gates, scoped
-`ISSUES.md` ledgers, human confirmation requirements, or validation freshness
-rules. The selected skill still owns the workflow plan; the goal only makes the
-intended outcome and current state explicit.
+Goals do not bypass skill steps, stop gates, permission gates, scoped ledger
+files, human confirmation requirements, or validation freshness rules. The
+selected skill still owns the workflow plan; the goal only makes the intended
+outcome and current state explicit.
 When the runtime has stricter status-transition rules, follow those runtime
 rules and use the skill's goal rules to explain the waiting, blocked, or done
 reason.

--- a/skills/code-issues/SKILL.md
+++ b/skills/code-issues/SKILL.md
@@ -41,6 +41,9 @@ Follow `references/plan.md#find-mode-plan`.
 These rules remain mandatory:
 
 - If no scope is provided, stop and ask for the package or folder.
+- Before checking, reading, creating, or updating the scoped `ISSUES.md`
+  ledger, ensure the consuming repository root `.gitignore` exists and contains
+  `ISSUES.md` as a standalone pattern. If the pattern is missing, add it.
 - Use `ISSUES.md` in the requested package or folder as the review ledger, for example `PACKAGE_OR_FOLDER/ISSUES.md`.
 - If `ISSUES.md` already exists in the requested package or folder, stop. Tell the user the existing scoped ledger must be resolved first, or the human must delete that scoped `ISSUES.md` before a new find pass there.
 - Treat `Find $code-issues in PACKAGE_OR_FOLDER` or `Find code issues in PACKAGE_OR_FOLDER` as the user's explicit request to delegate review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
@@ -100,6 +103,9 @@ Follow `references/plan.md#implement-mode-plan`.
 These rules remain mandatory:
 
 - If no scope is provided, stop and ask for the package or folder.
+- Before checking, reading, creating, or updating the scoped `ISSUES.md`
+  ledger, ensure the consuming repository root `.gitignore` exists and contains
+  `ISSUES.md` as a standalone pattern. If the pattern is missing, add it.
 - Read `ISSUES.md` in the requested package or folder first and treat it as the working review ledger.
 - If scoped `ISSUES.md` does not exist, stop and ask whether to run Find mode first for that scope.
 - Work through code issues sequentially by ID unless the human explicitly names a different issue.

--- a/skills/code-issues/references/plan.md
+++ b/skills/code-issues/references/plan.md
@@ -14,6 +14,9 @@ repository root and keep `bin/` as shared guidance.
 - Update the active plan when scope, validation, delegation, or ledger state
   changes.
 - Treat validation as stale when files change after a command ran.
+- Before checking, reading, creating, or updating the scoped `ISSUES.md`
+  ledger, ensure the consuming repository root `.gitignore` exists and contains
+  `ISSUES.md` as a standalone pattern. If the pattern is missing, add it.
 - Record durable findings only in the scoped `ISSUES.md` ledger defined by the
   skill.
 - Track broad-scope coverage explicitly as reviewed deeply, skimmed, excluded,

--- a/skills/doc-gaps/SKILL.md
+++ b/skills/doc-gaps/SKILL.md
@@ -41,7 +41,10 @@ These rules remain mandatory:
 - If no scope is provided, stop and ask for the package or folder.
 - Treat `Run $doc-gaps in PACKAGE_OR_FOLDER`, `Find doc gaps in PACKAGE_OR_FOLDER`, or `Fix doc gaps in PACKAGE_OR_FOLDER` as permission to delegate review, edit documentation in scope, run appropriate validation, and summarize the result in one pass.
 - Use audit-only mode only when the user explicitly asks not to edit or asks only for an audit or ledger. When a stop gate prevents a correct documentation fix during one-pass mode, record unresolved confirmed findings instead of switching modes.
-- If scoped `ISSUES.md` already exists, read it before reviewing. If it is a doc-gap ledger, include unresolved findings in the candidate set and update or delete the ledger after fixing them. If it is unrelated or ambiguous active work, stop and ask before editing it.
+- Before checking, reading, creating, or updating the scoped `DOCS.md` ledger,
+  ensure the consuming repository root `.gitignore` exists and contains
+  `DOCS.md` as a standalone pattern. If the pattern is missing, add it.
+- If scoped `DOCS.md` already exists, read it before reviewing. If it is a doc-gap ledger, include unresolved findings in the candidate set and update or delete the ledger after fixing them. If it is unrelated or ambiguous active work, stop and ask before editing it.
 - Use as many independent review agents as the runtime can safely run when the active runtime provides sub-agents and runtime policy/tooling permits delegation. Do not perform the doc-gap review locally first when delegation is available.
 - Treat the doc-gap invocation as the user's explicit request to delegate documentation review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
 - If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
@@ -65,11 +68,11 @@ These rules remain mandatory:
 - For unresolved-ledger fixes or any case where human approval is still required: After the human agrees and before editing, state the selected local documentation pattern, dominant relevant validation path, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
 - Implement confirmed doc gaps with the smallest clear documentation change using the established documentation location and style.
 - Stop and ask before editing when behavior, audience, documentation location, public-contract wording, examples, validation, or user intent is ambiguous enough that a correct documentation change cannot be inferred from local context.
-- Write unresolved confirmed findings to the scoped `ISSUES.md` only when they cannot be fixed in the same pass, the user requested audit-only mode, validation or permission is blocked, or the scope is too large to complete.
+- Write unresolved confirmed findings to the scoped `DOCS.md` only when they cannot be fixed in the same pass, the user requested audit-only mode, validation or permission is blocked, or the scope is too large to complete.
 - Validate documentation changes with commands appropriate to the changed files.
-- If no confirmed doc gaps are found, report that no doc gaps were found and do not create `ISSUES.md`.
-- If all confirmed doc gaps are fixed, do not leave a new `ISSUES.md` behind. If an existing doc-gap ledger is fully resolved, delete it.
-- Final output must summarize fixed gaps, dismissed or out-of-scope candidates when relevant, broad-scope coverage notes when the requested scope was too broad for complete deep review, unresolved findings written to `ISSUES.md` if any, and validation results.
+- If no confirmed doc gaps are found, report that no doc gaps were found and do not create `DOCS.md`.
+- If all confirmed doc gaps are fixed, do not leave a new `DOCS.md` behind. If an existing doc-gap ledger is fully resolved, delete it.
+- Final output must summarize fixed gaps, dismissed or out-of-scope candidates when relevant, broad-scope coverage notes when the requested scope was too broad for complete deep review, unresolved findings written to `DOCS.md` if any, and validation results.
 
 ## Audit-Only Mode
 
@@ -78,11 +81,14 @@ Follow `references/plan.md#audit-only-mode-plan`.
 These rules remain mandatory:
 
 - If no scope is provided, stop and ask for the package or folder.
-- Use `ISSUES.md` in the requested package or folder as the audit ledger, for example `PACKAGE_OR_FOLDER/ISSUES.md`.
-- If `ISSUES.md` already exists in the requested package or folder, stop unless the human explicitly asked to refresh or overwrite that scoped ledger.
+- Before checking, reading, creating, or updating the scoped `DOCS.md` ledger,
+  ensure the consuming repository root `.gitignore` exists and contains
+  `DOCS.md` as a standalone pattern. If the pattern is missing, add it.
+- Use `DOCS.md` in the requested package or folder as the audit ledger, for example `PACKAGE_OR_FOLDER/DOCS.md`.
+- If `DOCS.md` already exists in the requested package or folder, stop unless the human explicitly asked to refresh or overwrite that scoped ledger.
 - Use the same delegation, surface-routing, candidate confirmation, severity, and out-of-scope rules as one-pass mode.
-- If no confirmed doc gaps are found, report that no doc gaps were found and do not create `ISSUES.md`.
-- If confirmed doc gaps are found, write all findings to the scoped `ISSUES.md` with `DOC-N` IDs.
+- If no confirmed doc gaps are found, report that no doc gaps were found and do not create `DOCS.md`.
+- If confirmed doc gaps are found, write all findings to the scoped `DOCS.md` with `DOC-N` IDs.
 - Stop after presenting the audit ledger. Do not make fixes in audit-only mode.
 
 ## Documentation Review Standards
@@ -94,13 +100,13 @@ recording findings. Keep GoDoc details in `$go-standards`, RDoc details in
 `$ruby-standards`, and shell script/function comment rules in
 `$shell-standards`.
 
-## Candidate And `ISSUES.md` Format
+## Candidate And `DOCS.md` Format
 
 Use this structure for review candidates and unresolved or audit-only ledger
 entries:
 
 ```markdown
-# Issues
+# Docs
 
 ## DOC-1: Short concrete title
 

--- a/skills/doc-gaps/agents/openai.yaml
+++ b/skills/doc-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Doc Gaps"
   short_description: "Find and fix scoped doc adequacy gaps"
-  default_prompt: "Use $doc-gaps with its active goal and plan plus $doc-standards to run a one-pass scoped documentation gap workflow, answer doc gap ID follow-ups such as DOC-1, apply confirmed doc fixes, validate, and write ISSUES.md only for audit-only requests or unresolved gaps."
+  default_prompt: "Use $doc-gaps with its active goal and plan plus $doc-standards to run a one-pass scoped documentation gap workflow, answer doc gap ID follow-ups such as DOC-1, apply confirmed doc fixes, validate, and write DOCS.md only for audit-only requests or unresolved gaps."

--- a/skills/doc-gaps/references/plan.md
+++ b/skills/doc-gaps/references/plan.md
@@ -14,7 +14,10 @@ repository root and keep `bin/` as shared guidance.
 - Update the active plan when scope, documentation location, validation,
   delegation, edits, summary, or unresolved ledger state changes.
 - Treat validation as stale when files change after a command ran.
-- Use a scoped `ISSUES.md` ledger only for audit-only mode, unresolved confirmed
+- Before checking, reading, creating, or updating the scoped `DOCS.md` ledger,
+  ensure the consuming repository root `.gitignore` exists and contains
+  `DOCS.md` as a standalone pattern. If the pattern is missing, add it.
+- Use a scoped `DOCS.md` ledger only for audit-only mode, unresolved confirmed
   gaps, or an existing doc-gap ledger being completed.
 - Track broad-scope coverage explicitly as reviewed deeply, skimmed, excluded,
   and deferred. Deferred entries must name runnable follow-up scopes.
@@ -26,7 +29,7 @@ repository root and keep `bin/` as shared guidance.
   validated, no confirmed gaps are found and reported, or unresolved findings
   are recorded because a stop gate prevents a correct fix.
 - In audit-only mode, the goal is complete when no confirmed doc gaps are found
-  and reported, or when the scoped `ISSUES.md` ledger is written and presented.
+  and reported, or when the scoped `DOCS.md` ledger is written and presented.
 - For broad scopes, a no-gap result is complete only when the summary states
   whether all high-risk slices were deeply reviewed. If any relevant slice was
   skimmed or deferred, completion requires coverage notes and runnable
@@ -39,7 +42,7 @@ repository root and keep `bin/` as shared guidance.
 ## One-Pass Mode Plan
 
 1. Confirm the requested package or folder scope.
-2. If scoped `ISSUES.md` exists, read it. Incorporate doc-gap ledger findings,
+2. If scoped `DOCS.md` exists, read it. Incorporate doc-gap ledger findings,
    or stop if the file is unrelated or ambiguous active work.
 3. Run `$project-workflow` discovery for entrypoints, CI, documented commands,
    public APIs, examples, and `./bin` wiring.
@@ -84,10 +87,10 @@ repository root and keep `bin/` as shared guidance.
     security, test, or reliability workflows. When dismissing, record why the
     existing surface owns the audience and action at risk.
 17. If no confirmed gaps remain, report that result with the coverage state, do
-    not create `ISSUES.md`, and skip edit and validation steps.
+    not create `DOCS.md`, and skip edit and validation steps.
 18. Implement confirmed doc gaps with the smallest clear documentation changes.
 19. If a confirmed gap cannot be fixed correctly in this pass, write or update
-    the scoped `ISSUES.md` with `DOC-<number>` entries for unresolved gaps.
+    the scoped `DOCS.md` with `DOC-<number>` entries for unresolved gaps.
 20. If an existing doc-gap ledger is fully resolved, delete it.
 21. Validate the documentation change with commands appropriate to the changed
     files.
@@ -98,7 +101,7 @@ repository root and keep `bin/` as shared guidance.
 ## Audit-Only Mode Plan
 
 1. Confirm the requested package or folder scope.
-2. Check whether scoped `ISSUES.md` already exists and stop unless the human
+2. Check whether scoped `DOCS.md` already exists and stop unless the human
    explicitly asked to refresh or overwrite that ledger.
 3. Run `$project-workflow` discovery for entrypoints, CI, documented commands,
    public APIs, examples, and `./bin` wiring.
@@ -114,8 +117,8 @@ repository root and keep `bin/` as shared guidance.
    implementation, require non-prose evidence before treating code as wrong;
    otherwise classify stale prose as a doc gap.
 8. If no confirmed gaps remain, report that result with the coverage state, do
-   not create `ISSUES.md`, and stop.
-9. If confirmed gaps remain, write the scoped `ISSUES.md` with `DOC-<number>`
+   not create `DOCS.md`, and stop.
+9. If confirmed gaps remain, write the scoped `DOCS.md` with `DOC-<number>`
    IDs.
 10. Present the scoped audit ledger, coverage state for broad scopes, and
     runnable follow-up scopes for deferred slices, then stop before making

--- a/skills/feature-gaps/SKILL.md
+++ b/skills/feature-gaps/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: feature-gaps
+description: Use when the user asks to find $feature-gaps in a package or folder, find feature gaps in a package or folder, find product or developer-experience opportunities, propose feature ideas that fit the current repository, implement $feature-gaps in a package or folder, implement feature gaps in a package or folder, asks about feature IDs such as FEATURE-1, asks what the proposal is for FEATURE-1, asks to fix or verify FEATURE-1, or says FEATURE-1 is done. Find concrete repository-fit feature opportunities, record confirmed proposals in scoped FEATURES.md, and later propose and implement agreed feature changes one at a time.
+---
+
+# Feature Gaps
+
+Use this skill in two distinct modes:
+
+- **Find mode**: `Find $feature-gaps in PACKAGE_OR_FOLDER` or `Find feature gaps in PACKAGE_OR_FOLDER`.
+- **Implement mode**: `Implement $feature-gaps in PACKAGE_OR_FOLDER` or `Implement feature gaps in PACKAGE_OR_FOLDER`.
+
+Do not combine the two modes in one pass.
+
+Before starting Find mode or Implement mode, read `references/plan.md` and use
+it to maintain the active execution plan. The active plan is runtime state; do
+not write it into the repository unless the human explicitly asks for a durable
+plan file.
+When the runtime supports goals, bind the selected mode and requested scope to
+one active goal and update that goal as ledger, proposal, approval, validation,
+or human-confirmation state changes.
+
+## Operating Stance
+
+Operate as a scoped product and developer-experience triager: propose only
+feature opportunities that fit the repository's purpose, current architecture,
+documented workflows, and likely user or maintainer needs. A feature gap is not
+a bug, test gap, doc gap, reliability gap, or style preference. It is an
+actionable improvement that the repository does not currently provide and that
+would make an existing user, developer, maintainer, or operator workflow
+meaningfully better.
+
+Treat local repository evidence as the primary source of fit. Comparable
+products, libraries, CLIs, frameworks, and systems can reveal useful patterns,
+but do not record a feature merely because another tool has it. First prove the
+opportunity maps to this repository's scope, audience, and implementation
+surface.
+
+Use external product or library research when it would materially improve the
+proposal and the runtime provides an allowed research tool. Prefer official
+docs, project repositories, release notes, and mature tool behavior over blog
+posts or generic trend lists. Ask for human permission before running commands
+that require network, SSH, GitHub auth, registry auth, remote writes, cloning,
+or other approval-gated access.
+
+## Acceptance Gate
+
+Apply this gate before recording any candidate in `FEATURES.md`. A feature
+proposal must satisfy every item below at 90% confidence or higher. If any item
+cannot be answered from concrete evidence, gather more evidence or reject the
+candidate instead of recording it as low priority.
+
+- **Audience**: Name the user, developer, maintainer, operator, package
+  consumer, or service author who benefits.
+- **Current limitation**: State the existing workflow limitation, missing
+  capability, or friction. The limitation must exist today and must not already
+  be solved by current code, docs, examples, or command behavior.
+- **Repository ownership**: Show that this repository owns the behavior,
+  interface, workflow, helper, or documentation surface where the feature
+  belongs.
+- **Evidence**: Cite concrete local evidence such as code, docs, examples,
+  command behavior, tests, recurring maintainer workflow, or comparable mature
+  tool behavior. Comparable-tool evidence is supporting evidence, not a
+  sufficient reason by itself.
+- **Repository fit**: Explain why the feature matches the repository purpose,
+  current architecture, local naming, file layout, command style, dependency
+  posture, and downstream `./bin` reuse model.
+- **Smallest useful version**: Define the smallest feature slice that creates
+  real value without a broad rewrite or speculative platform work.
+- **Compatibility and maintenance**: Identify public behavior, migration,
+  dependency, security, support, and long-term maintenance tradeoffs. Reject
+  proposals whose cost or compatibility risk outweighs the demonstrated value.
+- **Validation path**: Name the repository-defined command, test, lint, docs
+  check, or manual verification path that can credibly validate the change.
+- **Correct workflow**: Confirm the candidate is not primarily a code bug,
+  security issue, reliability gap, test gap, doc gap, naming issue, style
+  preference, or unsupported roadmap decision.
+
+Reject ideas whose support is only novelty, taste, competitor parity, a trend,
+an imagined future user, framework preference, private implementation
+preference, or generic "nice to have" polish.
+
+## Find Mode
+
+Follow `references/plan.md#find-mode-plan`.
+
+These rules remain mandatory:
+
+- If no scope is provided, stop and ask for the package or folder.
+- Before checking, reading, creating, or updating the scoped `FEATURES.md`
+  ledger, ensure the consuming repository root `.gitignore` exists and contains
+  `FEATURES.md` as a standalone pattern. If the pattern is missing, add it.
+- Use `FEATURES.md` in the requested package or folder as the proposal ledger,
+  for example `PACKAGE_OR_FOLDER/FEATURES.md`.
+- If `FEATURES.md` already exists in the requested package or folder, stop.
+  Tell the user the existing scoped feature ledger must be resolved first, or
+  the human must delete that scoped `FEATURES.md` before a new find pass there.
+- Treat `Find $feature-gaps in PACKAGE_OR_FOLDER` or `Find feature gaps in
+  PACKAGE_OR_FOLDER` as the user's explicit request to delegate feature-gap
+  discovery for that scope. Do not require the user to separately say "use
+  sub-agents", "spawn agents", or "delegate".
+- Use sub-agents for Find mode whenever the active runtime provides them and
+  runtime policy/tooling permits delegation. Do not treat sub-agents as
+  optional based on scope size, and do not perform the feature-gap review
+  locally first.
+- Do not claim that extra delegation wording is needed before launching review
+  agents. The Find mode invocation is the explicit delegation request.
+- If delegation is denied, stop instead of falling back to a local review. If
+  sub-agents are unavailable, say so briefly and perform the review locally for
+  the requested scope.
+- Ask for human permission before agents run commands that require approval,
+  such as network, SSH, GitHub auth, registry auth, remote writes, cloning,
+  destructive operations, or non-read-only validation.
+- Exclude generated files and folders, vendored dependencies, caches, build
+  output, generated API docs, and generated lockfile churn unless the requested
+  scope is explicitly about them.
+- Before assigning review agents, build a recursive scope inventory for the
+  requested package or folder: relevant file count, first-level subfolders,
+  nested packages, dominant languages, tests, public entrypoints, generated,
+  vendor, build, and cache exclusions, user-facing surfaces, developer-facing
+  surfaces, docs, examples, command help, and likely extension points.
+- Do not assign broad recursive subtrees merely because they are first-level
+  subfolders. When a subtree contains many independent products, packages,
+  workflows, or audiences, split it into smaller behavior-owned or
+  audience-owned slices before delegation.
+- Prefer slices based on repository-owned feature surface and user value:
+  public commands/APIs, developer workflows, documented examples, setup and
+  onboarding paths, release or validation workflows, integrations, extension
+  points, changed or recently touched areas, and nearby tests. Use depth only
+  as a discovery aid, not as the review boundary.
+- If the requested scope is too broad to review credibly in one pass, review
+  the highest-value slices first and record explicit coverage: reviewed deeply,
+  skimmed, excluded, and deferred.
+- Do not present a broad requested scope as fully reviewed when any relevant
+  slice was only skimmed or deferred. Name those slices in the final coverage
+  notes and provide runnable follow-up scopes for deferred review.
+- Each assigned agent owns recursive review only within its bounded slice. Each
+  agent must perform feature-gap discovery for that slice, pairing with
+  `$project-workflow`, `$doc-standards`, `$naming-standards`, relevant language
+  standards, `$change-safety`, `$testing-standards`, and `$change-validation`
+  as the proposed feature surface requires.
+- Require each agent to return proposals in the same shape as the `FEATURES.md`
+  format, without final IDs unless useful locally.
+- Confirm each candidate feature against the acceptance gate, code, docs,
+  tests, examples, command behavior, current architecture, and available
+  comparable-tool evidence before recording it. Try to disprove the candidate
+  by asking whether the workflow is already supported, whether the repository
+  owns the behavior, whether the likely audience exists, and whether the
+  feature can be added incrementally using local patterns.
+- Record feature gaps only when the proposal names the audience, current
+  workflow limitation, repository-owned surface, evidence of user or developer
+  value, fit with existing patterns, smallest plausible implementation path,
+  compatibility risk, and validation path.
+- Do not record confirmed bugs, security issues, compatibility breaks,
+  reliability gaps, missing tests, stale docs, or unclear naming as feature
+  gaps. Route them to `$code-issues`, `$security-audit`, `$reliability-gaps`,
+  `$test-gaps`, `$doc-gaps`, or `$naming-standards` as appropriate.
+- Do not record feature ideas whose evidence is only novelty, personal
+  preference, a competitor checklist, a trend, an undocumented future roadmap,
+  a broad rewrite, a new framework preference, or optional polish with no
+  concrete workflow improvement.
+- Do not record feature proposals that require a new product direction,
+  breaking public behavior, new external service, new dependency class, or
+  significant maintenance commitment unless the current repository already
+  points to that direction and the proposal explains the compatibility and
+  maintenance tradeoff.
+- If a candidate would mostly require documentation, examples, tests, or
+  reliability controls for existing behavior, route it to the matching gap
+  workflow instead of recording it here.
+- If no confirmed feature gaps are found, report that no feature gaps were
+  found and do not create `FEATURES.md`.
+- If confirmed feature gaps are found, write all proposals to the scoped
+  `FEATURES.md` before making any changes.
+- Assign every proposal a unique ID for the session in the form `FEATURE-N`.
+- Stop after presenting the ledger and plan. Do not implement proposals in the
+  same pass.
+
+## `FEATURES.md` Format
+
+Use this structure:
+
+```markdown
+# Features
+
+## FEATURE-1: Short concrete title
+
+- Type: Feature Gap
+- Priority: High|Medium|Low
+- Confidence: 93%
+- Scope: path/to/file-or-folder
+- Audience: User|Developer|Maintainer|Operator|Package consumer|Service author
+- Current limitation: The workflow limitation, missing capability, or friction.
+- Evidence: Concrete file and line references, command behavior, docs, examples, comparable-tool evidence, or user/developer workflow evidence.
+- Repository fit: Why this belongs in the current repository and matches existing patterns.
+- Proposed feature: Smallest useful capability to add.
+- Compatibility and maintenance: Public behavior, dependency, migration, support, or maintenance tradeoffs.
+- Validation: Suggested checks for the feature change.
+```
+
+Keep optional follow-up notes separate from proposals:
+
+```markdown
+## Optional Feature Follow-Ups
+
+- Optional or non-blocking idea.
+```
+
+## Priority And Confidence
+
+Use confidence as a hard actionability gate: record only proposals at 90%
+confidence or higher. Below 90%, gather more evidence or discard the candidate.
+Confidence means the inspected evidence makes it very likely that the feature
+is repository-owned, not already supported, valuable to the named audience, and
+implementable without violating local patterns.
+
+Assign priority by user value and fit, not implementation ease:
+
+- `High`: Improves a primary workflow, unlocks a documented use case, removes
+  recurring maintainer/developer friction, or aligns strongly with comparable
+  mature tools while fitting the repository's existing direction.
+- `Medium`: Improves a real secondary workflow or extension point with clear
+  fit and manageable maintenance cost.
+- `Low`: Useful but narrow improvement with limited audience, limited urgency,
+  or meaningful tradeoffs that still fit the repository.
+
+Do not use `Low` for vague ideas. Low-priority proposals still need concrete
+evidence, audience, fit, and a plausible implementation path.
+
+## Implement Mode
+
+Follow `references/plan.md#implement-mode-plan`.
+
+These rules remain mandatory:
+
+- If no scope is provided, stop and ask for the package or folder.
+- Before checking, reading, creating, or updating the scoped `FEATURES.md`
+  ledger, ensure the consuming repository root `.gitignore` exists and contains
+  `FEATURES.md` as a standalone pattern. If the pattern is missing, add it.
+- Read `FEATURES.md` in the requested package or folder first and treat it as
+  the working feature ledger.
+- If scoped `FEATURES.md` does not exist, stop and ask whether to run Find mode
+  first for that scope.
+- Work through feature proposals sequentially by ID unless the human explicitly
+  names a different proposal.
+- Before proposing an implementation for each feature, re-check the current
+  code, docs, tests, examples, command behavior, and comparable-tool evidence.
+  Treat the ledger as something that can go stale: dismiss or revise proposals
+  that are already supported, duplicate another feature, no longer fit the
+  repository, or belong in another workflow.
+- Stop after proposing the solution. Do not edit files, update `FEATURES.md`,
+  or start validation until the human explicitly agrees to that feature's
+  solution.
+- Ask questions when audience, product direction, compatibility, dependency
+  policy, UX/DX behavior, test layer, validation, or user intent is ambiguous.
+  Treat silence or a broad "implement feature gaps" request as permission to
+  start the proposal workflow, not as permission to edit.
+- After the human agrees and before editing, state the selected local code/config/docs pattern, dominant relevant test harness, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
+- For behavior-changing features, state the feature execution checklist before
+  editing:
+   - `TDD decision`: yes/no, with the concrete reason if no.
+   - `First test/scenario`: the narrowest test, fixture, example, or scenario
+     to add or update first.
+   - `Expected red`: the command and failure expected before production edits.
+   - `Intended green change`: the smallest implementation expected to pass.
+   - `Refactor checkpoint`: the cleanup pass planned after green, or `none`.
+   - `Validation`: the focused and expanded commands intended after refactor.
+- Implement only the agreed feature with the smallest clear change that
+  preserves existing public behavior unless the human explicitly approved a
+  compatibility break.
+- Use `$change-safety` for public interfaces, compatibility, migration,
+  generated files, config, security-sensitive behavior, or dependencies.
+- Use `$testing-standards` for test design and pair with relevant language
+  standards for local idioms.
+- Use `$doc-standards` when the feature changes public commands, APIs, examples,
+  configuration, or documented workflows.
+- Use `$change-validation` when selecting validation commands.
+- Report the result for that feature with `Red`, `Green`, `Refactor`, and
+  `Validation` entries. Use `Refactor: none` when no cleanup was needed after
+  green. Then ask the human to verify and explicitly say `FEATURE-N is done`.
+- Do not move to the next proposal until the human says `FEATURE-N is done`.
+- After the human confirms a proposal is done, remove that proposal from scoped
+  `FEATURES.md`. If a proposal is deemed invalid or not actually a feature gap,
+  remove it only after explaining why and getting human agreement.
+- Once all proposals are resolved and confirmed done by the human, delete the
+  scoped `FEATURES.md`.
+
+## References
+
+- Read `references/plan.md` before starting Find mode or Implement mode.
+- Use `$project-workflow` for repository command discovery, documented
+  entrypoints, CI expectations, examples, and `./bin` wiring before review
+  planning or validation.
+- Use `$change-safety` when a proposed feature affects public contracts,
+  compatibility, migrations, config, generated files, dependencies, deployment,
+  security expectations, or documented operational behavior.
+- Use `$testing-standards` when deciding or reviewing tests for a feature.
+- Use `$doc-standards` when feature behavior needs README, docs, examples,
+  command help, package docs, comments, or docstrings.
+- Use `$naming-standards` when a feature creates or changes identifiers,
+  commands, flags, files, test fixtures, public terminology, or documentation
+  terms.
+- Use `$change-validation` when selecting validation commands for implemented
+  feature changes.
+- Use `$code-issues`, `$security-audit`, `$reliability-gaps`, `$test-gaps`, or
+  `$doc-gaps` when the confirmed concern belongs to those ledgers instead of
+  feature opportunities.

--- a/skills/feature-gaps/agents/openai.yaml
+++ b/skills/feature-gaps/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Feature Gaps"
+  short_description: "Find scoped feature opportunities"
+  default_prompt: "Use $feature-gaps to find scoped feature opportunities, store confirmed proposals in that scope's FEATURES.md, answer feature ID follow-ups such as FEATURE-1, or propose and implement explicitly agreed feature changes one at a time."

--- a/skills/feature-gaps/references/plan.md
+++ b/skills/feature-gaps/references/plan.md
@@ -1,0 +1,130 @@
+# Feature Gaps Plan
+
+Use this reference to instantiate the active execution plan for
+`$feature-gaps`. The active plan is runtime state. Do not write it into the
+repository unless the human explicitly asks for a durable plan file. In
+downstream repositories that vendor this project as `./bin`, instantiate the
+plan from the consuming repository root and keep `bin/` as shared guidance.
+
+## Plan State Rules
+
+- Keep exactly one active phase in progress at a time.
+- Preserve stop gates as plan boundaries; do not continue past a stop gate
+  based on silence or a broad request.
+- Update the active plan when scope, audience, product surface, validation,
+  delegation, external research, or ledger state changes.
+- Treat validation as stale when files change after a command ran.
+- Before checking, reading, creating, or updating the scoped `FEATURES.md`
+  ledger, ensure the consuming repository root `.gitignore` exists and contains
+  `FEATURES.md` as a standalone pattern. If the pattern is missing, add it.
+- Record durable feature proposals only in the scoped `FEATURES.md` ledger
+  defined by the skill.
+- Track broad-scope coverage explicitly as reviewed deeply, skimmed, excluded,
+  and deferred. Deferred entries must name runnable follow-up scopes.
+
+## Goal State Rules
+
+- Bind the active goal to the selected mode and requested scope.
+- In Find mode, the goal is complete when no confirmed feature gaps are found
+  and reported, or when the scoped `FEATURES.md` ledger is written and
+  presented.
+- For broad scopes, a no-gap result is complete only when the summary states
+  whether all high-value slices were deeply reviewed. If any relevant slice was
+  skimmed or deferred, completion requires coverage notes and runnable
+  follow-up scopes, not an unqualified all-scope no-gap claim.
+- In Implement mode, the goal is waiting while the human has not approved the
+  proposed feature solution, or after validation until the human confirms
+  `FEATURE-<number> is done`.
+- In Implement mode, the goal is complete for a proposal only after the human
+  confirms it is done and the scoped ledger is updated accordingly.
+- Record a blocked reason when a required scope is missing, the scoped ledger
+  required by the mode is absent or already exists in a conflicting state,
+  required permission is denied, or the selected feature cannot be re-checked
+  without human input. Follow runtime rules for when that reason changes goal
+  status.
+
+## Find Mode Plan
+
+1. Confirm the requested package or folder scope.
+2. Check whether scoped `FEATURES.md` already exists and stop if it does.
+3. Run `$project-workflow` discovery for entrypoints, CI, documented commands,
+   docs, examples, public APIs, developer workflows, and `./bin` wiring.
+4. Identify the feature surface in scope, including CLIs, APIs, libraries,
+   Make targets, scripts, examples, docs, integrations, extension points,
+   setup flows, validation flows, release flows, and maintainer workflows.
+5. Build a recursive scope inventory for the requested package or folder:
+   relevant file count, first-level subfolders, nested packages, dominant
+   languages, tests, public entrypoints, generated/vendor/build/cache
+   exclusions, user-facing surfaces, developer-facing surfaces, and likely
+   extension points.
+6. Split the inventory into bounded feature-surface, workflow-owned, or
+   audience-owned review slices. Use depth only as a discovery aid; do not
+   assign a broad recursive subtree merely because it is a first-level
+   subfolder.
+7. If the scope is too broad for a credible single pass, select the highest-
+   value slices first and initialize coverage entries for reviewed deeply,
+   skimmed, excluded, and deferred slices. Deferred entries must be exact
+   follow-up scopes such as `path/to/package` or `path/to/package/subpackage`.
+8. Decide whether comparable product, library, CLI, or system research is
+   needed. Use allowed research tools when they materially improve proposal
+   quality; ask permission before approval-gated network, auth, clone, or
+   remote-write commands.
+9. Launch the required review agents when available, or perform the local
+   fallback only when sub-agents are unavailable.
+10. Wait for all review work to finish.
+11. Update coverage state for every planned slice before judging the requested
+    scope.
+12. Deduplicate candidates and directly re-check conflicting or overlapping
+    conclusions against code, docs, tests, examples, command behavior, current
+    architecture, and comparable-tool evidence.
+13. Apply `SKILL.md#acceptance-gate` to each candidate and confirm the feature
+    gap names the audience, current limitation, repository-owned surface,
+    evidence of value, repository fit, smallest plausible implementation path,
+    compatibility and maintenance tradeoffs, validation path, and correct
+    workflow routing.
+14. Reject novelty, competitor checklists, trend-following, broad rewrites,
+    new-framework preferences, future-roadmap assumptions, optional polish, and
+    findings that belong in code, security, reliability, test, doc, or naming
+    workflows.
+15. If no confirmed feature gaps remain, report that result with the coverage
+    state, do not create `FEATURES.md`, and stop.
+16. If confirmed feature gaps remain, write the scoped `FEATURES.md` with
+    `FEATURE-<number>` IDs.
+17. Present the scoped ledger, proposed implementation plan, coverage state for
+    broad scopes, and runnable follow-up scopes for deferred slices.
+18. Stop before implementing features.
+
+## Implement Mode Plan
+
+1. Confirm the requested package or folder scope.
+2. Read scoped `FEATURES.md`, or stop and ask whether to run Find mode first.
+3. Run `$project-workflow` discovery for current entrypoints, CI, documented
+   commands, docs, examples, public APIs, developer workflows, and `./bin`
+   wiring.
+4. Select the next proposal by ID unless the human named a specific feature.
+5. Re-check the proposal against current code, docs, tests, examples, command
+   behavior, architecture, and comparable-tool evidence.
+6. If the proposal is already supported, no longer fits, duplicates another
+   proposal, or belongs in another workflow, explain that and propose removing
+   or reclassifying it.
+7. Present the feature evidence, audience, repository fit, proposed solution,
+   compatibility and maintenance tradeoffs, and intended validation.
+8. Stop until the human explicitly agrees to that feature's solution.
+9. After agreement, state the local code/config/docs pattern, dominant relevant
+   test harness, planned validation, and any needed deviation.
+10. If a deviation is needed, stop and ask before editing.
+11. For behavior-changing features, state the feature execution checklist:
+    TDD decision, first test/scenario, expected red, intended green change,
+    refactor checkpoint, and validation.
+12. Implement only the agreed feature with the smallest clear change.
+13. Use `$change-safety`, `$testing-standards`, `$doc-standards`,
+    `$naming-standards`, relevant language standards, and `$change-validation`
+    as required by the touched surface.
+14. Validate the feature change through repository Make targets or documented
+    entrypoints.
+15. Report `Red`, `Green`, `Refactor`, and `Validation`, then ask the human to
+    verify with `FEATURE-<number> is done`.
+16. Stop until that confirmation arrives.
+17. After confirmation, remove or revise the proposal in scoped `FEATURES.md`.
+18. Continue with the next proposal, or delete scoped `FEATURES.md` after all
+    feature gaps are confirmed resolved.

--- a/skills/reliability-gaps/SKILL.md
+++ b/skills/reliability-gaps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reliability-gaps
-description: Use when the user asks to find $reliability-gaps in a package or folder, find reliability gaps in a package or folder, review production readiness for a package or folder, implement $reliability-gaps in a package or folder, implement reliability gaps in a package or folder, asks about reliability gap IDs such as REL-1, asks what the fix is for REL-1, asks to fix or verify REL-1, or says REL-1 is done. Find verified reliability, operability, SLO, overload, observability, release-safety, recovery, data-integrity, disaster-readiness, or NALSD evidence gaps and implement agreed fixes gap by gap.
+description: Use when the user asks to find $reliability-gaps in a package or folder, find reliability gaps in a package or folder, review production readiness for a package or folder, implement $reliability-gaps in a package or folder, implement reliability gaps in a package or folder, asks about reliability gap IDs such as REL-1, asks what the fix is for REL-1, asks to fix or verify REL-1, or says REL-1 is done. Find verified reliability, operability, SLO, overload, observability, release-safety, recovery, data-integrity, disaster-readiness, or NALSD evidence gaps, record confirmed gaps in scoped RELIABILITY.md, and implement agreed fixes gap by gap.
 ---
 
 # Reliability Gaps
@@ -43,8 +43,11 @@ Follow `references/plan.md#find-mode-plan`.
 These rules remain mandatory:
 
 - If no scope is provided, stop and ask for the package or folder.
-- Use `ISSUES.md` in the requested package or folder as the review ledger, for example `PACKAGE_OR_FOLDER/ISSUES.md`.
-- If `ISSUES.md` already exists in the requested package or folder, stop. Tell the user the existing scoped ledger must be resolved first, or the human must delete that scoped `ISSUES.md` before a new find pass there.
+- Before checking, reading, creating, or updating the scoped `RELIABILITY.md`
+  ledger, ensure the consuming repository root `.gitignore` exists and contains
+  `RELIABILITY.md` as a standalone pattern. If the pattern is missing, add it.
+- Use `RELIABILITY.md` in the requested package or folder as the review ledger, for example `PACKAGE_OR_FOLDER/RELIABILITY.md`.
+- If `RELIABILITY.md` already exists in the requested package or folder, stop. Tell the user the existing scoped ledger must be resolved first, or the human must delete that scoped `RELIABILITY.md` before a new find pass there.
 - Treat `Find $reliability-gaps in PACKAGE_OR_FOLDER` or `Find reliability gaps in PACKAGE_OR_FOLDER` as the user's explicit request to delegate reliability review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
 - Use sub-agents for Find mode whenever the active runtime provides them and runtime policy/tooling permits delegation. Do not treat sub-agents as optional based on scope size, and do not perform the reliability-gap review locally first.
 - Do not claim that extra delegation wording is needed before launching review agents. The Find mode invocation is the explicit delegation request.
@@ -57,7 +60,7 @@ These rules remain mandatory:
 - If the requested scope is too broad to review credibly in one pass, review the highest-risk slices first and record explicit coverage: reviewed deeply, skimmed, excluded, and deferred.
 - Do not present a broad requested scope as fully reviewed when any relevant slice was only skimmed or deferred. Name those slices in the final coverage notes and provide runnable follow-up scopes for deferred review.
 - Each assigned agent owns recursive review only within its bounded slice. Each agent must perform a thorough `$reliability-standards` review for that slice, pairing with `$change-safety`, `$security-audit`, `$testing-standards`, and `$change-validation` as the surface requires.
-- Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
+- Require each agent to return findings in the same shape as the `RELIABILITY.md` format, without final IDs unless useful locally.
 - Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity and confidence.
 - Confirm each candidate gap against current evidence before recording it. Try to disprove the candidate by tracing the current code path, reading the documented workflow, checking the relevant config, inspecting existing tests, or running an allowed local command. A gap must name the affected reliability promise or operational expectation, the trigger condition, the failure mode, the missing or weak control, and the likely user or operator impact.
 - For candidates based on documentation or comments contradicting code, require non-prose proof that the implementation or repository-owned reliability control is wrong before recording a reliability gap. If current code, tests, runtime behavior, CI, or history support the implementation, treat the prose as a doc gap.
@@ -77,17 +80,17 @@ These rules remain mandatory:
 - Do not record standalone missing, weak, flaky, misleading, or wrong-layer tests as reliability gaps. Use `$test-gaps` when missing failure-path coverage is the finding.
 - Do not record standalone missing, weak, stale, misleading, or wrong-location operational docs as reliability gaps. Use `$doc-gaps` when documentation itself is the finding.
 - Do not report optional maturity improvements, cloud-architecture preferences, private implementation preferences, or "best practice" checkboxes as findings by themselves. List them only as optional follow-up notes when relevant.
-- If no confirmed reliability gaps are found, report that no reliability gaps were found and do not create `ISSUES.md`.
-- If confirmed reliability gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
+- If no confirmed reliability gaps are found, report that no reliability gaps were found and do not create `RELIABILITY.md`.
+- If confirmed reliability gaps are found, write all findings to the scoped `RELIABILITY.md` before making any fixes.
 - Assign every finding a unique ID for the session in the form `REL-N`.
 - Stop after presenting the ledger and plan. Do not fix findings in the same pass.
 
-## `ISSUES.md` Format
+## `RELIABILITY.md` Format
 
 Use this structure:
 
 ```markdown
-# Issues
+# Reliability
 
 ## REL-1: Short concrete title
 
@@ -116,12 +119,15 @@ Follow `references/plan.md#implement-mode-plan`.
 These rules remain mandatory:
 
 - If no scope is provided, stop and ask for the package or folder.
-- Read `ISSUES.md` in the requested package or folder first and treat it as the working reliability-gap ledger.
-- If scoped `ISSUES.md` does not exist, stop and ask whether to run Find mode first for that scope.
+- Before checking, reading, creating, or updating the scoped `RELIABILITY.md`
+  ledger, ensure the consuming repository root `.gitignore` exists and contains
+  `RELIABILITY.md` as a standalone pattern. If the pattern is missing, add it.
+- Read `RELIABILITY.md` in the requested package or folder first and treat it as the working reliability-gap ledger.
+- If scoped `RELIABILITY.md` does not exist, stop and ask whether to run Find mode first for that scope.
 - Work through findings sequentially by ID unless the human explicitly names a different finding.
 - Before proposing a fix for each finding, re-check the current code, config, tests, docs, and CI. Treat the ledger as something that can go stale: dismiss or revise findings that are already addressed, no longer have a concrete failure mode, duplicate another issue, or belong in `$code-issues`, `$security-audit`, `$test-gaps`, or `$doc-gaps`.
 - When re-checking a finding whose evidence depends on documentation or comments contradicting implementation, prove the implementation or reliability control is wrong with non-prose evidence before proposing a reliability change. If non-prose evidence supports the implementation, explain that the ledger item is invalid as a reliability gap and propose reclassifying or fixing documentation instead.
-- Stop after proposing the solution. Do not edit files, update `ISSUES.md`, or start validation until the human explicitly agrees to that finding's solution.
+- Stop after proposing the solution. Do not edit files, update `RELIABILITY.md`, or start validation until the human explicitly agrees to that finding's solution.
 - Ask questions when SLOs, expected failure behavior, operator workflow, compatibility, rollout, validation, or user intent is ambiguous. Treat silence or a broad "implement reliability gaps" request as permission to start the proposal workflow, not as permission to edit.
 - After the human agrees and before editing, state the selected local code/config/docs pattern, dominant relevant test harness, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
 - For behavior-changing fixes, state the reliability execution checklist before editing:
@@ -135,8 +141,8 @@ These rules remain mandatory:
 - Use `$reliability-standards` for reliability design, `$change-safety` for public or operational compatibility, `$testing-standards` for failure-path tests, and `$change-validation` for checks. Pair with `$security-audit` when the fix touches auth, secrets, privilege, DoS, logs, supply chain, or incident containment.
 - Report the result for that finding with `Red`, `Green`, `Refactor`, and `Validation` entries. Use `Refactor: none` when no cleanup was needed after green. Then ask the human to verify and explicitly say `REL-N is done`.
 - Do not move to the next finding until the human says `REL-N is done`.
-- After the human confirms a finding is done, remove that finding from scoped `ISSUES.md`. If a finding is deemed invalid or not actually a reliability gap, remove it only after explaining why and getting human agreement.
-- Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
+- After the human confirms a finding is done, remove that finding from scoped `RELIABILITY.md`. If a finding is deemed invalid or not actually a reliability gap, remove it only after explaining why and getting human agreement.
+- Once all findings are resolved and confirmed done by the human, delete the scoped `RELIABILITY.md`.
 
 ## References
 

--- a/skills/reliability-gaps/agents/openai.yaml
+++ b/skills/reliability-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Reliability Gaps"
   short_description: "Find scoped SRE readiness gaps"
-  default_prompt: "Use $reliability-gaps with its active goal and plan to find scoped reliability gaps, answer reliability gap ID follow-ups such as REL-1, and implement agreed fixes. For behavior-changing fixes, report the TDD decision plus Red, Green, Refactor, and Validation; otherwise use the appropriate docs/config validation path."
+  default_prompt: "Use $reliability-gaps with its active goal and plan to find scoped reliability gaps, store confirmed gaps in RELIABILITY.md, answer reliability gap ID follow-ups such as REL-1, and implement agreed fixes. For behavior-changing fixes, report the TDD decision plus Red, Green, Refactor, and Validation; otherwise use the appropriate docs/config validation path."

--- a/skills/reliability-gaps/references/plan.md
+++ b/skills/reliability-gaps/references/plan.md
@@ -14,8 +14,11 @@ plan from the consuming repository root and keep `bin/` as shared guidance.
 - Update the active plan when scope, reliability surface, validation,
   delegation, or ledger state changes.
 - Treat validation as stale when files change after a command ran.
-- Record durable findings only in the scoped `ISSUES.md` ledger defined by the
-  skill.
+- Before checking, reading, creating, or updating the scoped `RELIABILITY.md`
+  ledger, ensure the consuming repository root `.gitignore` exists and contains
+  `RELIABILITY.md` as a standalone pattern. If the pattern is missing, add it.
+- Record durable findings only in the scoped `RELIABILITY.md` ledger defined by
+  the skill.
 - Track broad-scope coverage explicitly as reviewed deeply, skimmed, excluded,
   and deferred. Deferred entries must name runnable follow-up scopes.
 
@@ -23,7 +26,7 @@ plan from the consuming repository root and keep `bin/` as shared guidance.
 
 - Bind the active goal to the selected mode and requested scope.
 - In Find mode, the goal is complete when no confirmed reliability gaps are
-  found and reported, or when the scoped `ISSUES.md` ledger is written and
+  found and reported, or when the scoped `RELIABILITY.md` ledger is written and
   presented.
 - For broad scopes, a no-gap result is complete only when the summary states
   whether all high-risk slices were deeply reviewed. If any relevant slice was
@@ -43,7 +46,7 @@ plan from the consuming repository root and keep `bin/` as shared guidance.
 ## Find Mode Plan
 
 1. Confirm the requested package or folder scope.
-2. Check whether scoped `ISSUES.md` already exists and stop if it does.
+2. Check whether scoped `RELIABILITY.md` already exists and stop if it does.
 3. Run `$project-workflow` discovery for entrypoints, CI, documented commands,
    operational docs, release/config surfaces, and `./bin` wiring.
 4. Identify the reliability surface in scope, including services, APIs, CLIs,
@@ -79,9 +82,9 @@ plan from the consuming repository root and keep `bin/` as shared guidance.
     preferences, and findings that belong in code, security, test, or doc
     ledgers.
 16. If no confirmed gaps remain, report that result with the coverage state, do
-    not create `ISSUES.md`, and stop.
-17. If confirmed gaps remain, write the scoped `ISSUES.md` with `REL-<number>`
-    IDs.
+    not create `RELIABILITY.md`, and stop.
+17. If confirmed gaps remain, write the scoped `RELIABILITY.md` with
+    `REL-<number>` IDs.
 18. Present the scoped ledger, proposed reliability-fix plan, coverage state for
     broad scopes, and runnable follow-up scopes for deferred slices.
 19. Stop before making fixes.
@@ -89,7 +92,7 @@ plan from the consuming repository root and keep `bin/` as shared guidance.
 ## Implement Mode Plan
 
 1. Confirm the requested package or folder scope.
-2. Read scoped `ISSUES.md`, or stop and ask whether to run Find mode first.
+2. Read scoped `RELIABILITY.md`, or stop and ask whether to run Find mode first.
 3. Run `$project-workflow` discovery for current entrypoints, CI, documented
    commands, operational docs, release/config surfaces, and `./bin` wiring.
 4. Select the next finding by ID unless the human named a specific finding.
@@ -116,6 +119,6 @@ plan from the consuming repository root and keep `bin/` as shared guidance.
 15. Report `Red`, `Green`, `Refactor`, and `Validation`, then ask the human to
     verify with `REL-<number> is done`.
 16. Stop until that confirmation arrives.
-17. After confirmation, remove or revise the finding in scoped `ISSUES.md`.
-18. Continue with the next finding, or delete scoped `ISSUES.md` after all gaps
-    are confirmed resolved.
+17. After confirmation, remove or revise the finding in scoped `RELIABILITY.md`.
+18. Continue with the next finding, or delete scoped `RELIABILITY.md` after all
+    gaps are confirmed resolved.

--- a/skills/reliability-standards/SKILL.md
+++ b/skills/reliability-standards/SKILL.md
@@ -94,7 +94,7 @@ without concrete evidence.
 ## Boundaries
 
 - Use `$reliability-gaps` when the user asks to find or implement scoped
-  reliability gaps through an `ISSUES.md` ledger.
+  reliability gaps through a `RELIABILITY.md` ledger.
 - Use `$code-review` or `$code-issues` when the finding is a concrete bug,
   violated contract, or broken behavior rather than a missing reliability
   control.

--- a/skills/test-gaps/SKILL.md
+++ b/skills/test-gaps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-gaps
-description: Use when the user asks to find $test-gaps in a package or folder, find test gaps in a package or folder, find flaky tests in a package or folder, find wrong-layer tests in a package or folder, implement $test-gaps in a package or folder, implement test gaps in a package or folder, asks about test gap IDs such as TEST-1, asks what the fix is for TEST-1, asks to fix or verify TEST-1, or says TEST-1 is done. Find concrete missing, weak, misleading, flaky, or wrong-layer test coverage, record confirmed gaps in scoped ISSUES.md, and later propose and implement agreed test fixes gap by gap.
+description: Use when the user asks to find $test-gaps in a package or folder, find test gaps in a package or folder, find flaky tests in a package or folder, find wrong-layer tests in a package or folder, implement $test-gaps in a package or folder, implement test gaps in a package or folder, asks about test gap IDs such as TEST-1, asks what the fix is for TEST-1, asks to fix or verify TEST-1, or says TEST-1 is done. Find concrete missing, weak, misleading, flaky, or wrong-layer test coverage, record confirmed gaps in scoped TESTS.md, and later propose and implement agreed test fixes gap by gap.
 ---
 
 # Test Gaps
@@ -44,8 +44,11 @@ Follow `references/plan.md#find-mode-plan`.
 These rules remain mandatory:
 
 - If no scope is provided, stop and ask for the package or folder.
-- Use `ISSUES.md` in the requested package or folder as the review ledger, for example `PACKAGE_OR_FOLDER/ISSUES.md`.
-- If `ISSUES.md` already exists in the requested package or folder, stop. Tell the user the existing scoped ledger must be resolved first, or the human must delete that scoped `ISSUES.md` before a new find pass there.
+- Before checking, reading, creating, or updating the scoped `TESTS.md` ledger,
+  ensure the consuming repository root `.gitignore` exists and contains
+  `TESTS.md` as a standalone pattern. If the pattern is missing, add it.
+- Use `TESTS.md` in the requested package or folder as the review ledger, for example `PACKAGE_OR_FOLDER/TESTS.md`.
+- If `TESTS.md` already exists in the requested package or folder, stop. Tell the user the existing scoped ledger must be resolved first, or the human must delete that scoped `TESTS.md` before a new find pass there.
 - Treat `Find $test-gaps in PACKAGE_OR_FOLDER` or `Find test gaps in PACKAGE_OR_FOLDER` as the user's explicit request to delegate test-gap review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
 - Use sub-agents for Find mode whenever the active runtime provides them and runtime policy/tooling permits delegation. Do not treat sub-agents as optional based on scope size, and do not perform the test-gap review locally first.
 - Do not claim that extra delegation wording is needed before launching review agents. The Find mode invocation is the explicit delegation request.
@@ -58,7 +61,7 @@ These rules remain mandatory:
 - If the requested scope is too broad to review credibly in one pass, review the highest-risk slices first and record explicit coverage: reviewed deeply, skimmed, excluded, and deferred.
 - Do not present a broad requested scope as fully reviewed when any relevant slice was only skimmed or deferred. Name those slices in the final coverage notes and provide runnable follow-up scopes for deferred review.
 - Each assigned agent owns recursive review only within its bounded slice. Each agent must perform a thorough and accurate `$testing-standards` review for that slice, pairing with relevant language standards and `$change-validation` for likely validation commands.
-- Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally. Each finding must name the repository-owned behavior being protected; reject findings that only test dependency semantics, aliases, or pass-through wrappers.
+- Require each agent to return findings in the same shape as the `TESTS.md` format, without final IDs unless useful locally. Each finding must name the repository-owned behavior being protected; reject findings that only test dependency semantics, aliases, or pass-through wrappers.
 - Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity and confidence.
 - Confirm each candidate gap against the code and existing tests before recording it. Gaps must be concrete missing, weak, misleading, flaky, or wrong-layer coverage with credible risk to changed behavior, public contracts, compatibility, release-sensitive workflows, or documented command/API behavior.
 - For each candidate, identify the real front door: the command, scenario,
@@ -80,17 +83,17 @@ These rules remain mandatory:
 - Do not record confirmed production bugs, security issues, compatibility breaks, or violated public contracts as test gaps. If such broken behavior is discovered during review, report it as out of scope for the test-gap ledger and recommend `$code-issues`; use this skill when the unprotected or poorly protected behavior is the finding.
 - Do not record standalone missing, weak, stale, misleading, or wrong-location documentation, README, example, comment, or docstring gaps as test gaps. Use `$doc-gaps` when documentation itself is the finding.
 - Do not report optional nice-to-have tests, private implementation coverage, arbitrary coverage percentage improvements, style preferences, or docs-only validation as findings by themselves. List them only as doc gaps or optional follow-up notes when relevant.
-- If no confirmed test gaps are found, report that no test gaps were found and do not create `ISSUES.md`.
-- If confirmed test gaps are found, write all findings to the scoped `ISSUES.md` before making any fixes.
+- If no confirmed test gaps are found, report that no test gaps were found and do not create `TESTS.md`.
+- If confirmed test gaps are found, write all findings to the scoped `TESTS.md` before making any fixes.
 - Assign every finding a unique ID for the session in the form `TEST-N`.
 - Stop after presenting the ledger and plan. Do not fix findings in the same pass.
 
-## `ISSUES.md` Format
+## `TESTS.md` Format
 
 Use this structure:
 
 ```markdown
-# Issues
+# Tests
 
 ## TEST-1: Short concrete title
 
@@ -119,19 +122,22 @@ Follow `references/plan.md#implement-mode-plan`.
 These rules remain mandatory:
 
 - If no scope is provided, stop and ask for the package or folder.
-- Read `ISSUES.md` in the requested package or folder first and treat it as the working test-gap ledger.
-- If scoped `ISSUES.md` does not exist, stop and ask whether to run Find mode first for that scope.
+- Before checking, reading, creating, or updating the scoped `TESTS.md` ledger,
+  ensure the consuming repository root `.gitignore` exists and contains
+  `TESTS.md` as a standalone pattern. If the pattern is missing, add it.
+- Read `TESTS.md` in the requested package or folder first and treat it as the working test-gap ledger.
+- If scoped `TESTS.md` does not exist, stop and ask whether to run Find mode first for that scope.
 - Work through findings sequentially by ID unless the human explicitly names a different finding.
 - Before proposing a fix for each finding, re-check the current code and nearby tests. Treat the ledger as something that can go stale: dismiss or revise findings that are already covered, would duplicate the local test shape, test only underlying libraries/frameworks, or require validation modes the repository does not run.
 - When re-checking a finding whose evidence depends on documentation or comments contradicting implementation, prove the expected behavior with non-prose evidence before proposing tests. If non-prose evidence supports the implementation, explain that the ledger item is invalid as a test gap and propose reclassifying or fixing documentation instead.
-- Stop after proposing the solution. Do not edit code, update `ISSUES.md`, or start validation until the human explicitly agrees to that finding's solution.
+- Stop after proposing the solution. Do not edit code, update `TESTS.md`, or start validation until the human explicitly agrees to that finding's solution.
 - Ask questions when behavior, compatibility, test layer, fixture strategy, validation, or user intent is ambiguous. Treat silence or a broad "implement test gaps" request as permission to start the proposal workflow, not as permission to code.
 - After the human agrees and before editing, state the selected local test pattern, dominant relevant test harness, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
 - Implement only the agreed finding with the smallest clear test change, preferring the existing local test shape over new standalone structure.
 - Use `$testing-standards` for test design and pair with the relevant language standard for local idioms. If implementing the test gap requires production behavior to change, prefer the test-first or scenario-first loop from `$testing-standards`.
 - Do not move to the next finding until the human says `TEST-N is done`.
-- After the human confirms a finding is done, remove that finding from scoped `ISSUES.md`. If a finding is deemed invalid or not actually a test gap, remove it only after explaining why and getting human agreement.
-- Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
+- After the human confirms a finding is done, remove that finding from scoped `TESTS.md`. If a finding is deemed invalid or not actually a test gap, remove it only after explaining why and getting human agreement.
+- Once all findings are resolved and confirmed done by the human, delete the scoped `TESTS.md`.
 
 ## References
 

--- a/skills/test-gaps/agents/openai.yaml
+++ b/skills/test-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Test Gaps"
   short_description: "Find scoped weak, flaky, or wrong-layer tests"
-  default_prompt: "Use $test-gaps with its active goal and plan to find scoped missing, weak, misleading, flaky, or wrong-layer test coverage; reject implementation-only or no-front-door candidates; store confirmed gaps in ISSUES.md; answer test gap ID follow-ups such as TEST-1; or implement agreed test fixes one gap at a time."
+  default_prompt: "Use $test-gaps with its active goal and plan to find scoped missing, weak, misleading, flaky, or wrong-layer test coverage; reject implementation-only or no-front-door candidates; store confirmed gaps in TESTS.md; answer test gap ID follow-ups such as TEST-1; or implement agreed test fixes one gap at a time."

--- a/skills/test-gaps/references/plan.md
+++ b/skills/test-gaps/references/plan.md
@@ -14,7 +14,10 @@ repository root and keep `bin/` as shared guidance.
 - Update the active plan when scope, dominant test harness, validation,
   delegation, or ledger state changes.
 - Treat validation as stale when files change after a command ran.
-- Record durable findings only in the scoped `ISSUES.md` ledger defined by the
+- Before checking, reading, creating, or updating the scoped `TESTS.md` ledger,
+  ensure the consuming repository root `.gitignore` exists and contains
+  `TESTS.md` as a standalone pattern. If the pattern is missing, add it.
+- Record durable findings only in the scoped `TESTS.md` ledger defined by the
   skill.
 - Track broad-scope coverage explicitly as reviewed deeply, skimmed, excluded,
   and deferred. Deferred entries must name runnable follow-up scopes.
@@ -23,7 +26,7 @@ repository root and keep `bin/` as shared guidance.
 
 - Bind the active goal to the selected mode and requested scope.
 - In Find mode, the goal is complete when no confirmed test gaps are found and
-  reported, or when the scoped `ISSUES.md` ledger is written and presented.
+  reported, or when the scoped `TESTS.md` ledger is written and presented.
 - For broad scopes, a no-gap result is complete only when the summary states
   whether all high-risk slices were deeply reviewed. If any relevant slice was
   skimmed or deferred, completion requires coverage notes and runnable
@@ -42,7 +45,7 @@ repository root and keep `bin/` as shared guidance.
 ## Find Mode Plan
 
 1. Confirm the requested package or folder scope.
-2. Check whether scoped `ISSUES.md` already exists and stop if it does.
+2. Check whether scoped `TESTS.md` already exists and stop if it does.
 3. Run `$project-workflow` discovery for entrypoints, CI, and `./bin` wiring.
 4. Identify the existing tests, fixtures, helpers, and dominant relevant harness
    for the requested scope.
@@ -72,8 +75,8 @@ repository root and keep `bin/` as shared guidance.
 14. Confirm each gap protects repository-owned behavior and is not duplicate,
     private-only, dependency-only, optional, or better handled by another skill.
 15. If no confirmed gaps remain, report that result with the coverage state, do
-    not create `ISSUES.md`, and stop.
-16. If confirmed gaps remain, write the scoped `ISSUES.md` with `TEST-<number>`
+    not create `TESTS.md`, and stop.
+16. If confirmed gaps remain, write the scoped `TESTS.md` with `TEST-<number>`
     IDs.
 17. Present the scoped ledger, proposed test-fix plan, coverage state for broad
     scopes, and runnable follow-up scopes for deferred slices.
@@ -82,7 +85,7 @@ repository root and keep `bin/` as shared guidance.
 ## Implement Mode Plan
 
 1. Confirm the requested package or folder scope.
-2. Read scoped `ISSUES.md`, or stop and ask whether to run Find mode first.
+2. Read scoped `TESTS.md`, or stop and ask whether to run Find mode first.
 3. Run `$project-workflow` discovery for current entrypoints, CI, and `./bin`
    wiring.
 4. Select the next finding by ID unless the human named a specific finding.
@@ -101,6 +104,6 @@ repository root and keep `bin/` as shared guidance.
 13. Validate the test change with commands appropriate to the changed tests.
 14. Report the result and ask the human to verify with `TEST-<number> is done`.
 15. Stop until that confirmation arrives.
-16. After confirmation, remove or revise the finding in scoped `ISSUES.md`.
-17. Continue with the next finding, or delete scoped `ISSUES.md` after all gaps
+16. After confirmation, remove or revise the finding in scoped `TESTS.md`.
+17. Continue with the next finding, or delete scoped `TESTS.md` after all gaps
     are confirmed resolved.


### PR DESCRIPTION
## What

- Add a `feature-gaps` workflow that records scoped product and developer-experience proposals in `FEATURES.md`.
- Add an explicit feature acceptance gate for audience, current limitation, repository ownership, evidence, fit, smallest useful version, compatibility and maintenance, validation, and correct workflow routing.
- Split non-code gap ledgers so test, doc, reliability, and feature workflows use `TESTS.md`, `DOCS.md`, `RELIABILITY.md`, and `FEATURES.md` while code issues continue to use `ISSUES.md`.
- Move skill metadata YAML validation out of the Bash lint wrapper into `quality/skills/metadata`, leaving policy-marker checks in `quality/skills/lint`.

## Why

- Keeps concurrent review workflows from blocking each other on a shared `ISSUES.md` file when they represent different kinds of work.
- Makes feature proposals harder to confuse with bugs, docs, tests, reliability findings, or optional polish by requiring concrete repository-fit evidence before writing a durable ledger.
- Keeps the skill lint entrypoint easier to maintain by moving Ruby metadata parsing into a Ruby file.

## Testing

- `quick_validate.py` for `feature-gaps`, `test-gaps`, `doc-gaps`, and `reliability-gaps` - passed
- `make dep` - passed
- `make skills-lint` - passed
- `make lint` - passed
- `make scripts-lint` - passed
- `make docker-lint` - passed
- `make sec` - passed
- `git diff --check` - passed
