### PR TITLE
feat(make): centralize report cleanup and cache key helpers

### DIFF
--- a/build/git/source-key
+++ b/build/git/source-key
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Generate a source cache key from tracked files, excluding the bin submodule.
+
+set -eo pipefail
+
+files="$(mktemp)"
+hashes="$(mktemp)"
+trap 'rm -f "$files" "$hashes"' EXIT
+
+if command -v sha256sum >/dev/null; then
+  hash_command=(sha256sum)
+elif command -v shasum >/dev/null; then
+  hash_command=(shasum -a 256)
+else
+  printf 'source-key: missing sha256sum or shasum\n' >&2
+  exit 1
+fi
+
+git ls-files -z . ':!:bin' ':!:bin/**' > "$files"
+xargs -0 "${hash_command[@]}" < "$files" > "$hashes"
+
+key="$(cut -d" " -f1 "$hashes" | "${hash_command[@]}")"
+printf '%s\n' "${key%% *}" > .source-key

--- a/build/make/_service.mak
+++ b/build/make/_service.mak
@@ -98,9 +98,9 @@ leave-coverage:
 codecov-upload:
 	@codecovcli --verbose upload-process --fail-on-error -F service -f test/reports/final.cov
 
-# Remove generated report artifacts under test/reports/.
+# Remove generated report artifacts while preserving report placeholders.
 clean-reports:
-	@rm -rf test/reports/*.*
+	@$(BIN_ROOT)/build/shell/clean-reports test/reports
 
 # Run cucumber features in test/ (builds the test binary first).
 features: build-test

--- a/build/make/git.mak
+++ b/build/make/git.mak
@@ -159,7 +159,7 @@ unstash:
 
 # Generate a repo source key (sha256 of tracked files excluding bin/) into .source-key.
 source-key:
-	@git ls-files | grep -v '^bin/' | xargs sha256sum | cut -d" " -f1 | sha256sum | cut -d" " -f1 > .source-key
+	@$(BIN_ROOT)/build/git/source-key
 
 # Purge local branches (except master).
 purge-local:

--- a/build/make/go.mak
+++ b/build/make/go.mak
@@ -113,9 +113,9 @@ coverage: html-coverage func-coverage
 codecov-upload:
 	@codecovcli --verbose upload-process --fail-on-error -F service -f test/reports/final.cov
 
-# Remove generated report artifacts under test/reports/.
+# Remove generated report artifacts while preserving report placeholders.
 clean-reports:
-	@rm -rf test/reports/*.*
+	@$(BIN_ROOT)/build/shell/clean-reports test/reports
 
 # Run govulncheck on the module (including tests).
 govulncheck:

--- a/build/make/ruby.mak
+++ b/build/make/ruby.mak
@@ -49,9 +49,9 @@ features:
 benchmarks:
 	@$(BIN_ROOT)/quality/ruby/benchmark $(feature)
 
-# Remove generated report artifacts under test/reports/.
+# Remove generated report artifacts while preserving report placeholders.
 clean-reports:
-	@rm -rf test/reports/*.*
+	@$(BIN_ROOT)/build/shell/clean-reports "$(if $(wildcard reports/.),reports,test/reports)"
 
 # Upload test/reports/coverage.xml to Codecov (codecovcli upload-process).
 codecov-upload:

--- a/build/shell/clean-reports
+++ b/build/shell/clean-reports
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Remove generated report artifacts while preserving placeholder files.
+
+set -eo pipefail
+
+readonly reports="${1:?usage: clean-reports REPORTS_PATH}"
+
+if [[ $(basename "$reports") != "reports" ]]; then
+  printf 'clean-reports: path must end with reports: %s\n' "$reports" >&2
+  exit 1
+fi
+
+if [[ ! -d $reports ]]; then
+  exit 0
+fi
+
+find "$reports" -mindepth 1 -maxdepth 1 ! -name .keep -exec rm -rf {} +


### PR DESCRIPTION
## What

- Add shared helper scripts for source cache-key generation and report cleanup.
- Route the git, Go, Ruby, and service Make fragments through those helpers instead of duplicating inline shell.
- Keep report cleanup recursive and placeholder-preserving, with a guard that only accepts paths ending in `reports`.

## Why

- The shared Make fragments had duplicated report cleanup behavior and inline cache-key shell that was hard to reuse safely.
- Centralizing the behavior keeps downstream `./bin` consumers consistent, removes the `bin` submodule hash noise, and keeps `clean-reports` cwd-safe for root and `test/` includes.

## Testing

- `bash -n build/git/source-key build/shell/clean-reports` - passed
- `gmake scripts-lint` - passed
- `gmake source-key` - passed
- `gmake -f /Users/alejandro/code/bin/build/make/git.mak source-key` from `/Users/alejandro/code/migrieren` - passed
- cleanup fixture checks for direct script use and Ruby `test/` include layout - passed
- `gmake help | rg -n "clean-reports|source-key"` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
