### PR TITLE
feat(skills): respect downstream ledger boundaries

### DIFF
--- a/skills/code-issues/SKILL.md
+++ b/skills/code-issues/SKILL.md
@@ -52,6 +52,14 @@ These rules remain mandatory:
 - If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
 - Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, or other non-read-only validation.
 - Exclude generated files and folders, vendored dependencies, caches, build output, and generated lockfile churn unless the requested scope is explicitly about them.
+- In downstream repositories that vendor this project as `./bin`, treat
+  `bin/**` as vendored shared tooling unless the requested scope is explicitly
+  about shared `bin` tooling, Makefile includes, skills, or submodule wiring.
+  Exclude `bin/**` from recursive review and inventory by default; inspect only
+  included `bin/build/make/*.mak` fragments or selected `bin/skills/**`
+  guidance needed as evidence. Route upstream-only shared-tooling findings to a
+  separate `bin`-scoped run instead of writing them into the consuming
+  repository's `ISSUES.md`.
 - Before assigning review agents, build a recursive scope inventory for the requested package or folder: relevant file count, first-level subfolders, nested packages, dominant languages, tests, public entrypoints, generated/vendor/build/cache exclusions, and security-sensitive surfaces.
 - Do not assign broad recursive subtrees merely because they are first-level subfolders. When a subtree contains many independent nested packages, mixed responsibilities, or too many relevant files for a credible single pass, split it into smaller behavior-owned slices before delegation.
 - Prefer slices based on repository-owned behavior and risk: public commands/APIs, changed or recently touched areas, auth/network/filesystem/process boundaries, config/CI/release paths, documented workflows, and nearby tests. Use depth only as a discovery aid, not as the review boundary.

--- a/skills/code-issues/agents/openai.yaml
+++ b/skills/code-issues/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Code Issues"
   short_description: "Find scoped code defects and risks"
-  default_prompt: "Use $code-issues with its active goal and plan to delegate scoped code issue finding, store confirmed findings in that scope's ISSUES.md, answer issue ID follow-ups such as ISSUE-1, or propose and implement explicitly agreed fixes one code issue at a time."
+  default_prompt: "Use $code-issues with its active goal and plan to delegate scoped code issue finding, exclude downstream bin/** unless explicitly scoped to shared tooling, store confirmed findings in that scope's ISSUES.md, answer issue ID follow-ups such as ISSUE-1, or propose and implement explicitly agreed fixes one code issue at a time."

--- a/skills/code-issues/references/plan.md
+++ b/skills/code-issues/references/plan.md
@@ -19,6 +19,11 @@ repository root and keep `bin/` as shared guidance.
   `ISSUES.md` as a standalone pattern. If the pattern is missing, add it.
 - Record durable findings only in the scoped `ISSUES.md` ledger defined by the
   skill.
+- In downstream repositories that vendor this project as `./bin`, exclude
+  `bin/**` from recursive inventory, review slices, and durable findings unless
+  the requested scope is explicitly about shared `bin` tooling. Inspect only
+  included shared fragments or selected skill guidance needed as evidence, and
+  route upstream-only findings to a separate `bin`-scoped run.
 - Track broad-scope coverage explicitly as reviewed deeply, skimmed, excluded,
   and deferred. Deferred entries must name runnable follow-up scopes.
 

--- a/skills/doc-gaps/SKILL.md
+++ b/skills/doc-gaps/SKILL.md
@@ -50,6 +50,14 @@ These rules remain mandatory:
 - If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
 - Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, or other non-read-only validation.
 - Exclude generated files and folders, vendored dependencies, caches, build output, generated API docs, and generated lockfile churn unless the requested scope is explicitly about them.
+- In downstream repositories that vendor this project as `./bin`, treat
+  `bin/**` as vendored shared tooling unless the requested scope is explicitly
+  about shared `bin` tooling, Makefile includes, skills, or submodule wiring.
+  Exclude `bin/**` from recursive review and inventory by default; inspect only
+  included `bin/build/make/*.mak` fragments or selected `bin/skills/**`
+  guidance needed as evidence. Route upstream-only shared-tooling findings to a
+  separate `bin`-scoped run instead of writing them into the consuming
+  repository's `DOCS.md`.
 - Before assigning review agents, build a recursive documentation inventory for the requested package or folder: README files, docs, examples, command help surfaces, package docs, public API comments, code-comment/docstring surfaces, first-level subfolders, nested packages, generated/vendor/build/cache exclusions, and relevant validation entrypoints.
 - Do not assign broad recursive subtrees merely because they are first-level subfolders. When a subtree contains many independent documentation owners, mixed audiences, or too many relevant files for a credible single pass, split it into smaller documentation-surface or behavior-owned slices before delegation.
 - Prefer slices based on authoritative documentation owner and user risk: README or user docs, command help, examples, public API/package docs, documented workflows, changed or recently touched areas, and code areas with public interfaces. Use depth only as a discovery aid, not as the review boundary.

--- a/skills/doc-gaps/agents/openai.yaml
+++ b/skills/doc-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Doc Gaps"
   short_description: "Find and fix scoped doc adequacy gaps"
-  default_prompt: "Use $doc-gaps with its active goal and plan plus $doc-standards to run a one-pass scoped documentation gap workflow, answer doc gap ID follow-ups such as DOC-1, apply confirmed doc fixes, validate, and write DOCS.md only for audit-only requests or unresolved gaps."
+  default_prompt: "Use $doc-gaps with its active goal and plan plus $doc-standards to run a one-pass scoped documentation gap workflow, exclude downstream bin/** unless explicitly scoped to shared tooling, answer doc gap ID follow-ups such as DOC-1, apply confirmed doc fixes, validate, and write DOCS.md only for audit-only requests or unresolved gaps."

--- a/skills/doc-gaps/references/plan.md
+++ b/skills/doc-gaps/references/plan.md
@@ -19,6 +19,11 @@ repository root and keep `bin/` as shared guidance.
   `DOCS.md` as a standalone pattern. If the pattern is missing, add it.
 - Use a scoped `DOCS.md` ledger only for audit-only mode, unresolved confirmed
   gaps, or an existing doc-gap ledger being completed.
+- In downstream repositories that vendor this project as `./bin`, exclude
+  `bin/**` from recursive inventory, review slices, edits, and durable findings
+  unless the requested scope is explicitly about shared `bin` tooling. Inspect
+  only included shared fragments or selected skill guidance needed as evidence,
+  and route upstream-only findings to a separate `bin`-scoped run.
 - Track broad-scope coverage explicitly as reviewed deeply, skimmed, excluded,
   and deferred. Deferred entries must name runnable follow-up scopes.
 

--- a/skills/feature-gaps/SKILL.md
+++ b/skills/feature-gaps/SKILL.md
@@ -138,6 +138,14 @@ These rules remain mandatory:
 - Exclude generated files and folders, vendored dependencies, caches, build
   output, generated API docs, and generated lockfile churn unless the requested
   scope is explicitly about them.
+- In downstream repositories that vendor this project as `./bin`, treat
+  `bin/**` as vendored shared tooling unless the requested scope is explicitly
+  about shared `bin` tooling, Makefile includes, skills, or submodule wiring.
+  Exclude `bin/**` from recursive review and inventory by default; inspect only
+  included `bin/build/make/*.mak` fragments or selected `bin/skills/**`
+  guidance needed as evidence. Route upstream-only shared-tooling findings to a
+  separate `bin`-scoped run instead of writing them into the consuming
+  repository's `FEATURES.md`.
 - Before assigning review agents, build a recursive scope inventory for the
   requested package or folder: relevant file count, first-level subfolders,
   nested packages, dominant languages, tests, public entrypoints, generated,

--- a/skills/feature-gaps/agents/openai.yaml
+++ b/skills/feature-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Feature Gaps"
   short_description: "Find product feature opportunities"
-  default_prompt: "Use $feature-gaps to find scoped main product capability gaps with explicit audience benefit, store confirmed proposals in FEATURES.md, answer feature ID follow-ups such as FEATURE-1, or propose and implement explicitly agreed product feature changes one at a time; route test and project workflow gaps to their own skills."
+  default_prompt: "Use $feature-gaps to find scoped main product capability gaps with explicit audience benefit, exclude downstream bin/** unless explicitly scoped to shared tooling, store confirmed proposals in FEATURES.md, answer feature ID follow-ups such as FEATURE-1, or propose and implement explicitly agreed product feature changes one at a time; route test and project workflow gaps to their own skills."

--- a/skills/feature-gaps/references/plan.md
+++ b/skills/feature-gaps/references/plan.md
@@ -19,6 +19,11 @@ plan from the consuming repository root and keep `bin/` as shared guidance.
   `FEATURES.md` as a standalone pattern. If the pattern is missing, add it.
 - Record durable feature proposals only in the scoped `FEATURES.md` ledger
   defined by the skill.
+- In downstream repositories that vendor this project as `./bin`, exclude
+  `bin/**` from recursive inventory, review slices, and durable proposals unless
+  the requested scope is explicitly about shared `bin` tooling. Inspect only
+  included shared fragments or selected skill guidance needed as evidence, and
+  route upstream-only proposals to a separate `bin`-scoped run.
 - Track broad-scope coverage explicitly as reviewed deeply, skimmed, excluded,
   and deferred. Deferred entries must name runnable follow-up scopes.
 

--- a/skills/project-gaps/SKILL.md
+++ b/skills/project-gaps/SKILL.md
@@ -114,6 +114,14 @@ These rules remain mandatory:
 - Exclude generated files and folders, vendored dependencies, caches, build
   output, generated API docs, and generated lockfile churn unless the requested
   scope is explicitly about them.
+- In downstream repositories that vendor this project as `./bin`, treat
+  `bin/**` as vendored shared tooling unless the requested scope is explicitly
+  about shared `bin` tooling, Makefile includes, skills, or submodule wiring.
+  Exclude `bin/**` from recursive review and inventory by default; inspect only
+  included `bin/build/make/*.mak` fragments or selected `bin/skills/**`
+  guidance needed as evidence. Route upstream-only shared-tooling findings to a
+  separate `bin`-scoped run instead of writing them into the consuming
+  repository's `PROJECTS.md`.
 - Before assigning review agents, build a recursive scope inventory for the
   requested package or folder: relevant file count, first-level subfolders,
   nested packages, dominant languages, Makefiles, CI config, scripts,

--- a/skills/project-gaps/agents/openai.yaml
+++ b/skills/project-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Project Gaps"
   short_description: "Find scoped project workflow gaps"
-  default_prompt: "Use $project-gaps to find scoped build, CI, Makefile, release, setup, validation, command discovery, and repository workflow gaps; store confirmed proposals in PROJECTS.md; answer project gap ID follow-ups such as PROJECT-1; or implement agreed project workflow fixes one gap at a time."
+  default_prompt: "Use $project-gaps to find scoped build, CI, Makefile, release, setup, validation, command discovery, and repository workflow gaps; exclude downstream bin/** unless explicitly scoped to shared tooling; store confirmed proposals in PROJECTS.md; answer project gap ID follow-ups such as PROJECT-1; or implement agreed project workflow fixes one gap at a time."

--- a/skills/project-gaps/references/plan.md
+++ b/skills/project-gaps/references/plan.md
@@ -19,6 +19,11 @@ plan from the consuming repository root and keep `bin/` as shared guidance.
   `PROJECTS.md` as a standalone pattern. If the pattern is missing, add it.
 - Record durable project proposals only in the scoped `PROJECTS.md` ledger
   defined by the skill.
+- In downstream repositories that vendor this project as `./bin`, exclude
+  `bin/**` from recursive inventory, review slices, and durable proposals unless
+  the requested scope is explicitly about shared `bin` tooling. Inspect only
+  included shared fragments or selected skill guidance needed as evidence, and
+  route upstream-only proposals to a separate `bin`-scoped run.
 - Track broad-scope coverage explicitly as reviewed deeply, skimmed, excluded,
   and deferred. Deferred entries must name runnable follow-up scopes.
 

--- a/skills/reliability-gaps/SKILL.md
+++ b/skills/reliability-gaps/SKILL.md
@@ -54,6 +54,14 @@ These rules remain mandatory:
 - If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
 - Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, destructive operations, or non-read-only validation.
 - Exclude generated files and folders, vendored dependencies, caches, build output, generated API docs, and generated lockfile churn unless the requested scope is explicitly about them.
+- In downstream repositories that vendor this project as `./bin`, treat
+  `bin/**` as vendored shared tooling unless the requested scope is explicitly
+  about shared `bin` tooling, Makefile includes, skills, or submodule wiring.
+  Exclude `bin/**` from recursive review and inventory by default; inspect only
+  included `bin/build/make/*.mak` fragments or selected `bin/skills/**`
+  guidance needed as evidence. Route upstream-only shared-tooling findings to a
+  separate `bin`-scoped run instead of writing them into the consuming
+  repository's `RELIABILITY.md`.
 - Before assigning review agents, build a recursive scope inventory for the requested package or folder: relevant file count, first-level subfolders, nested packages, dominant languages, tests, public entrypoints, generated/vendor/build/cache exclusions, and reliability-sensitive surfaces.
 - Do not assign broad recursive subtrees merely because they are first-level subfolders. When a subtree contains many independent nested packages, mixed operational responsibilities, or too many relevant files for a credible single pass, split it into smaller behavior-owned slices before delegation.
 - Prefer slices based on repository-owned reliability and operational risk: public commands/APIs, changed or recently touched areas, retries/timeouts/backpressure, config/CI/release paths, observability/runbook surfaces, documented workflows, and nearby tests. Use depth only as a discovery aid, not as the review boundary.

--- a/skills/reliability-gaps/agents/openai.yaml
+++ b/skills/reliability-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Reliability Gaps"
   short_description: "Find scoped SRE readiness gaps"
-  default_prompt: "Use $reliability-gaps with its active goal and plan to find scoped reliability gaps, store confirmed gaps in RELIABILITY.md, answer reliability gap ID follow-ups such as REL-1, and implement agreed fixes. For behavior-changing fixes, report the TDD decision plus Red, Green, Refactor, and Validation; otherwise use the appropriate docs/config validation path."
+  default_prompt: "Use $reliability-gaps with its active goal and plan to find scoped reliability gaps, exclude downstream bin/** unless explicitly scoped to shared tooling, store confirmed gaps in RELIABILITY.md, answer reliability gap ID follow-ups such as REL-1, and implement agreed fixes. For behavior-changing fixes, report the TDD decision plus Red, Green, Refactor, and Validation; otherwise use the appropriate docs/config validation path."

--- a/skills/reliability-gaps/references/plan.md
+++ b/skills/reliability-gaps/references/plan.md
@@ -19,6 +19,11 @@ plan from the consuming repository root and keep `bin/` as shared guidance.
   `RELIABILITY.md` as a standalone pattern. If the pattern is missing, add it.
 - Record durable findings only in the scoped `RELIABILITY.md` ledger defined by
   the skill.
+- In downstream repositories that vendor this project as `./bin`, exclude
+  `bin/**` from recursive inventory, review slices, and durable findings unless
+  the requested scope is explicitly about shared `bin` tooling. Inspect only
+  included shared fragments or selected skill guidance needed as evidence, and
+  route upstream-only findings to a separate `bin`-scoped run.
 - Track broad-scope coverage explicitly as reviewed deeply, skimmed, excluded,
   and deferred. Deferred entries must name runnable follow-up scopes.
 

--- a/skills/test-gaps/SKILL.md
+++ b/skills/test-gaps/SKILL.md
@@ -64,6 +64,14 @@ These rules remain mandatory:
 - If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
 - Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, or other non-read-only validation.
 - Exclude generated files and folders, vendored dependencies, caches, build output, and generated lockfile churn unless the requested scope is explicitly about them.
+- In downstream repositories that vendor this project as `./bin`, treat
+  `bin/**` as vendored shared tooling unless the requested scope is explicitly
+  about shared `bin` tooling, Makefile includes, skills, or submodule wiring.
+  Exclude `bin/**` from recursive review and inventory by default; inspect only
+  included `bin/build/make/*.mak` fragments or selected `bin/skills/**`
+  guidance needed as evidence. Route upstream-only shared-tooling findings to a
+  separate `bin`-scoped run instead of writing them into the consuming
+  repository's `TESTS.md`.
 - Before assigning review agents, build a recursive scope inventory for the requested package or folder: relevant file count, first-level subfolders, nested packages, dominant languages, tests, public entrypoints, generated/vendor/build/cache exclusions, and existing test harnesses.
 - Do not assign broad recursive subtrees merely because they are first-level subfolders. When a subtree contains many independent nested packages, mixed responsibilities, or too many relevant files for a credible single pass, split it into smaller behavior-owned slices before delegation.
 - Prefer slices based on repository-owned behavior and test risk: public commands/APIs, changed or recently touched areas, documented workflows, compatibility-sensitive behavior, release paths, and nearby existing tests. Use depth only as a discovery aid, not as the review boundary.

--- a/skills/test-gaps/agents/openai.yaml
+++ b/skills/test-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Test Gaps"
   short_description: "Find weak tests and harness gaps"
-  default_prompt: "Use $test-gaps with its active goal and plan to find scoped missing, weak, misleading, flaky, wrong-layer, or test-harness coverage gaps; reject implementation-only or no-front-door candidates; store confirmed gaps in TESTS.md; answer test gap ID follow-ups such as TEST-1; or implement agreed test fixes one gap at a time."
+  default_prompt: "Use $test-gaps with its active goal and plan to find scoped missing, weak, misleading, flaky, wrong-layer, or test-harness coverage gaps; exclude downstream bin/** unless explicitly scoped to shared tooling; reject implementation-only or no-front-door candidates; store confirmed gaps in TESTS.md; answer test gap ID follow-ups such as TEST-1; or implement agreed test fixes one gap at a time."

--- a/skills/test-gaps/references/plan.md
+++ b/skills/test-gaps/references/plan.md
@@ -19,6 +19,11 @@ repository root and keep `bin/` as shared guidance.
   `TESTS.md` as a standalone pattern. If the pattern is missing, add it.
 - Record durable findings only in the scoped `TESTS.md` ledger defined by the
   skill.
+- In downstream repositories that vendor this project as `./bin`, exclude
+  `bin/**` from recursive inventory, review slices, and durable findings unless
+  the requested scope is explicitly about shared `bin` tooling. Inspect only
+  included shared fragments or selected skill guidance needed as evidence, and
+  route upstream-only findings to a separate `bin`-scoped run.
 - Track broad-scope coverage explicitly as reviewed deeply, skimmed, excluded,
   and deferred. Deferred entries must name runnable follow-up scopes.
 


### PR DESCRIPTION
## What

- Added explicit downstream `bin/**` exclusion guidance to the scoped ledger skills for code issues, test gaps, doc gaps, feature gaps, project gaps, and reliability gaps.
- Mirrored the same scope-routing rule in each ledger skill plan so execution checklists exclude vendored shared tooling by default.
- Updated each matching `agents/openai.yaml` default prompt so UI-triggered runs preserve the same downstream `bin/**` boundary.

## Why

- Prevents scoped gap and issue workflows in consuming repositories from recording upstream shared-tooling findings in the wrong repository ledger.
- Keeps downstream reviews focused on the consuming repository while still allowing explicit `bin`-scoped runs for shared Makefile includes, skills, or submodule wiring.

## Testing

- `make dep` - passed
- `make clean-dep` - passed
- `make lint` - passed
- `make skills-lint` - passed
- `make scripts-lint` - passed
- `make docker-lint` - passed
- `make sec` - passed
- `git diff --check` - passed
