### PR TITLE
feat(skills): document command environment prerequisite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,6 +248,10 @@ CI runs (CircleCI): `make dep`, `make clean-dep`, `make scripts-lint`, `make ski
 - Treat this repository's Makefile, reusable make fragments, and CI
   configuration as the source of truth for setup, lint, test, security,
   benchmark, and review commands.
+- Before any selected skill runs, retries, replaces, or recommends a command,
+  establish the repository command surface and execution environment. On
+  developer machines, especially macOS, assume required tools may come from
+  Homebrew or another user-shell setup rather than the OS defaults.
 - Prefer `make` targets and documented repository entry points over direct tool
   invocations, even when a direct command appears equivalent.
 - Run commands from the repository root unless the Makefile, script, or task
@@ -257,6 +261,9 @@ CI runs (CircleCI): `make dep`, `make clean-dep`, `make scripts-lint`, `make ski
   differs from the user's normal terminal, treat that as an environment
   mismatch or validation gap, not as evidence that the repository command is
   wrong.
+- Do not invent direct commands, bypass Make targets, install alternate tools,
+  or keep retrying variants merely to get something to run in the agent
+  environment.
 - In Codex/tool shells, verify `ruby` and `make` resolution against the
   initialized user shell before reporting repository command failures. Compare
   the default tool shell with `zsh -lic 'command -v ruby; command -v make'`; if

--- a/quality/skills/lint
+++ b/quality/skills/lint
@@ -28,18 +28,25 @@ fi
 require_pattern AGENTS.md "mandatory operating rules, not advisory guidance"
 require_pattern AGENTS.md "## Local pattern binding"
 require_pattern AGENTS.md "Re-read the selected skill and identify the governing instruction"
+require_pattern AGENTS.md "Before any selected skill runs, retries, replaces, or recommends a command"
 require_pattern AGENTS.md "rerun Make targets through the initialized"
 require_pattern AGENTS.md "complete only when confidence is at least 90%"
 
 require_pattern skills/README.md "Skills are mandatory operating rules, not advisory notes."
+require_pattern skills/README.md "## Command Environment Prerequisite"
+require_pattern skills/README.md "Do not invent direct commands"
 require_pattern skills/README.md "accept or mark work complete only when confidence is at least 90%"
 
 require_pattern skills/project-workflow/SKILL.md "Before editing code, tests, docs, config, scripts, or validation paths, identify the local pattern"
+require_pattern skills/project-workflow/SKILL.md "macOS/Homebrew tool-path assumptions"
 require_pattern skills/project-workflow/references/bin-submodule.md "Treat the consuming repository's \`AGENTS.md\` as binding local policy"
+require_pattern skills/project-workflow/references/bin-submodule.md "On developer machines, especially macOS"
 
 require_pattern skills/change-validation/references/check-selection.md "Before selecting tests, identify the dominant relevant test harness"
 require_pattern skills/change-validation/references/check-selection.md "Do not add or select an ad hoc language-native test command"
+require_pattern skills/change-validation/references/check-selection.md "Do not invent direct commands, replace a Makefile target, install alternate tools"
 require_pattern skills/change-validation/SKILL.md "Treat validation as valid only for the file state it tested"
+require_pattern skills/change-validation/SKILL.md "macOS/Homebrew tool-path assumptions"
 
 require_pattern skills/testing-standards/SKILL.md "## Mandatory Stop Gates"
 require_pattern skills/testing-standards/SKILL.md "MUST NOT add language-native tests"
@@ -69,6 +76,7 @@ require_pattern skills/reliability-gaps/SKILL.md "state the reliability executio
 require_pattern skills/reliability-gaps/SKILL.md "\`Red\`, \`Green\`, \`Refactor\`, and \`Validation\`"
 
 require_pattern skills/project-workflow/agents/openai.yaml "Treat AGENTS.md and selected skills as mandatory rules."
+require_pattern skills/project-workflow/agents/openai.yaml "initialized user-shell command environment"
 require_pattern skills/testing-standards/agents/openai.yaml "MUST identify the dominant relevant existing test harness before editing"
 require_pattern skills/testing-standards/agents/openai.yaml "stop on unexpected green tests"
 require_pattern skills/go-standards/agents/openai.yaml "MUST NOT invent import aliases for readability, caution, brevity, or personal clarity"
@@ -79,5 +87,6 @@ require_pattern skills/doc-gaps/agents/openai.yaml "answer doc gap ID follow-ups
 require_pattern skills/feature-gaps/agents/openai.yaml "answer feature ID follow-ups such as FEATURE-1"
 require_pattern skills/project-gaps/agents/openai.yaml "answer project gap ID follow-ups such as PROJECT-1"
 require_pattern skills/change-validation/agents/openai.yaml "file changes make prior validation stale"
+require_pattern skills/change-validation/agents/openai.yaml "initialized user shell"
 
 exit "$missing"

--- a/skills/README.md
+++ b/skills/README.md
@@ -29,6 +29,23 @@ accept or mark work complete only when confidence is at least 90%; below 90%,
 they must gather more evidence or state the blocker instead of accepting
 completion.
 
+## Command Environment Prerequisite
+
+Before any skill runs, retries, replaces, or recommends a command, establish the
+repository command surface and execution environment. Treat the repository
+Makefile, documented entrypoints, and CI configuration as the source of truth;
+on developer machines, especially macOS, assume required tools may come from
+Homebrew or another user-shell setup rather than the OS defaults.
+
+Run repository commands through the user's initialized shell when tool
+resolution matters, for example `zsh -lic 'make lint'`, and compare `make`,
+`ruby`, or other required tool paths against the initialized shell before
+calling a tool failure real. Do not invent direct commands, bypass Make targets,
+install alternate tools, or keep retrying variants merely to get something to
+run in the agent environment. Report shell, `PATH`, Homebrew, missing-tool, and
+version mismatches as environment or validation gaps while preserving the
+repository-defined command as the intended path.
+
 ## Common Composition
 
 - `review-pr` orchestrates PR preparation with `project-workflow`,

--- a/skills/change-validation/SKILL.md
+++ b/skills/change-validation/SKILL.md
@@ -9,13 +9,14 @@ description: Use when running or selecting validation after code, docs, Makefile
 
 1. Discover the repository's validation entrypoints before running checks.
 2. Read `references/check-selection.md` when choosing between targeted tests, lint commands, make targets, CI mirrors, benchmarks, or security checks.
-3. Run the repository's setup or dependency target first when validation depends on installed dependencies or generated/vendor state.
-4. Ask for user permission before running validation commands that require SSH credentials, GitHub auth, registry auth, cloning, pushing, publishing, opening PRs, or updating remote state.
-5. Run the narrowest check that credibly exercises the changed behavior, then expand only when risk justifies it.
-6. Treat validation as valid only for the file state it tested. If files change while a validation command is still running or after it completes, report that result as stale and rerun the relevant checks after final edits.
-7. Notice wrappers that no-op because optional tools are missing, and do not report them as full validation.
-8. Use `$testing-standards` when the task needs decisions about what tests to add or whether coverage is credible; keep this skill focused on selecting and reporting commands.
-9. When reporting standalone validation, use the exact structure in `references/check-selection.md`; when another skill embeds validation, preserve the command, result, coverage, and gap details.
+3. Before running, retrying, replacing, or recommending validation commands, establish the execution environment: repository root, documented entrypoint, CI analogue, initialized user shell, and any macOS/Homebrew tool-path assumptions. Do not invent direct commands or bypass Make targets just because the agent shell cannot find the right tool.
+4. Run the repository's setup or dependency target first when validation depends on installed dependencies or generated/vendor state.
+5. Ask for user permission before running validation commands that require SSH credentials, GitHub auth, registry auth, cloning, pushing, publishing, opening PRs, or updating remote state.
+6. Run the narrowest check that credibly exercises the changed behavior, then expand only when risk justifies it.
+7. Treat validation as valid only for the file state it tested. If files change while a validation command is still running or after it completes, report that result as stale and rerun the relevant checks after final edits.
+8. Notice wrappers that no-op because optional tools are missing, and do not report them as full validation.
+9. Use `$testing-standards` when the task needs decisions about what tests to add or whether coverage is credible; keep this skill focused on selecting and reporting commands.
+10. When reporting standalone validation, use the exact structure in `references/check-selection.md`; when another skill embeds validation, preserve the command, result, coverage, and gap details.
 
 ## References
 

--- a/skills/change-validation/agents/openai.yaml
+++ b/skills/change-validation/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Change Validation"
   short_description: "Choose tests, lint, and CI checks"
-  default_prompt: "Use $change-validation to choose and report validation for this change. Prefer repository-defined commands, run narrow checks before broad ones, detect no-op wrappers, and rerun checks when file changes make prior validation stale."
+  default_prompt: "Use $change-validation to choose and report validation for this change. Prefer repository-defined commands through the initialized user shell, run narrow checks before broad ones, detect no-op wrappers, report tool/PATH mismatches as gaps, and rerun checks when file changes make prior validation stale."

--- a/skills/change-validation/references/check-selection.md
+++ b/skills/change-validation/references/check-selection.md
@@ -8,6 +8,7 @@ Use this reference when choosing which checks to run.
 - Run the narrowest check that gives credible confidence for the change.
 - Prefer repository-defined commands because they encode project conventions.
 - Use direct commands when they are clearly narrower or better aligned with the task than a broader repo wrapper.
+- Before running, retrying, replacing, or recommending commands, establish the repository root, documented entrypoint, CI analogue, initialized user shell, and any macOS/Homebrew tool-path assumptions.
 - Before selecting tests, identify the dominant relevant test harness and repository-defined entry point for the affected behavior.
 - Do not add or select an ad hoc language-native test command when the repository's established harness owns the behavior, unless the user explicitly asked for that layer or the behavior cannot be covered through the established harness.
 - If bypassing the dominant harness is necessary, stop before editing or validating and state why the established harness cannot cover the behavior.
@@ -22,10 +23,12 @@ Use this reference when choosing which checks to run.
 ## Command Execution Environment
 
 - Treat the repository Makefile and CI configuration as the source of truth for setup, lint, test, security, benchmark, and review commands.
+- On developer machines, especially macOS, assume required tools may come from Homebrew or another user-shell setup rather than the OS defaults.
 - Prefer `make` targets and documented repository entry points over direct tool invocations, even when a direct command appears equivalent.
 - Run commands from the repository root unless the Makefile, script, or task explicitly requires another working directory.
 - Use the user's configured shell environment for command execution. If a command fails because a tool is missing, an old version is found, or `PATH` differs from the user's normal terminal, treat that as an environment mismatch or validation gap, not as evidence that the repository command is wrong.
-- Do not replace a Makefile target with guessed direct commands just because the agent environment cannot find the same tools as the user's shell.
+- Run repository commands through the user's initialized shell when tool resolution matters, for example `zsh -lic 'make lint'`.
+- Do not invent direct commands, replace a Makefile target, install alternate tools, or keep retrying variants merely to get something to run in the agent environment.
 - When diagnosing command-environment mismatches, check the command surface first, then inspect `command -v <tool>`, `<tool> --version`, `SHELL`, and `PATH` as diagnostics only.
 - In this shared `bin` repo and downstream repos that vendor it as `./bin`, `make` targets are the preferred validation interface. If `make` reports an unexpected tool or version problem in the agent environment but works in the user's shell, report the mismatch and keep the Makefile target as the intended command.
 

--- a/skills/project-workflow/SKILL.md
+++ b/skills/project-workflow/SKILL.md
@@ -9,14 +9,15 @@ description: Use when starting in a project, inspecting how to run tasks, decidi
 
 1. Read project-local instructions first, such as `AGENTS.md`, `README.md`, the root `Makefile`, and CI configuration.
 2. Identify the project's real command surface before choosing tools. Prefer exposed entrypoints over guessed direct invocations.
-3. If the repository uses this shared project as `./bin`, read `references/bin-submodule.md` before reasoning about path-sensitive behavior.
-4. Inspect only the files, scripts, and make fragments relevant to the user's task.
-5. Read `references/make-fragments.md` when you need to interpret included `bin/build/make/*.mak` fragments, edit reusable make fragments, or reason about likely target behavior.
-6. Identify commands that require network, SSH, GitHub auth, registry auth, cloning, pushing, publishing, opening PRs, or updating remote state before running or recommending them.
-7. Before editing code, tests, docs, config, scripts, or validation paths, identify the local pattern for the changed surface: import style, naming style, file layout, dominant test harness, documented config keys, and repository validation target. Agents MUST preserve those patterns unless the user explicitly asks to change them.
-8. If an edit would deviate from the discovered local pattern, stop and ask before editing. State the exact pattern, why it cannot work, and the proposed deviation.
-9. When workflow discovery is the final response, use the exact structure in `references/bin-submodule.md`; do not add, remove, rename, or reorder sections.
-10. When another skill embeds this discovery, preserve the discovered commands, CI expectations, bin wiring, constraints, and local-pattern facts in the caller's output format.
+3. Before running, retrying, replacing, or recommending commands, establish the execution environment: repository root, documented entrypoint, CI analogue, initialized user shell, and any macOS/Homebrew tool-path assumptions. Do not invent direct commands or bypass Make targets just because the agent shell cannot find the right tool.
+4. If the repository uses this shared project as `./bin`, read `references/bin-submodule.md` before reasoning about path-sensitive behavior.
+5. Inspect only the files, scripts, and make fragments relevant to the user's task.
+6. Read `references/make-fragments.md` when you need to interpret included `bin/build/make/*.mak` fragments, edit reusable make fragments, or reason about likely target behavior.
+7. Identify commands that require network, SSH, GitHub auth, registry auth, cloning, pushing, publishing, opening PRs, or updating remote state before running or recommending them.
+8. Before editing code, tests, docs, config, scripts, or validation paths, identify the local pattern for the changed surface: import style, naming style, file layout, dominant test harness, documented config keys, and repository validation target. Agents MUST preserve those patterns unless the user explicitly asks to change them.
+9. If an edit would deviate from the discovered local pattern, stop and ask before editing. State the exact pattern, why it cannot work, and the proposed deviation.
+10. When workflow discovery is the final response, use the exact structure in `references/bin-submodule.md`; do not add, remove, rename, or reorder sections.
+11. When another skill embeds this discovery, preserve the discovered commands, CI expectations, bin wiring, constraints, and local-pattern facts in the caller's output format.
 
 ## References
 

--- a/skills/project-workflow/agents/openai.yaml
+++ b/skills/project-workflow/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Project Workflow"
   short_description: "Discover commands, CI, bin wiring, and local patterns"
-  default_prompt: "Use $project-workflow to discover project entrypoints, CI expectations, ./bin wiring, shared Makefile fragment behavior, and local code/test/config/validation patterns before work begins. Treat AGENTS.md and selected skills as mandatory rules."
+  default_prompt: "Use $project-workflow to discover project entrypoints, CI expectations, ./bin wiring, shared Makefile fragment behavior, local code/test/config/validation patterns, and the initialized user-shell command environment before work begins. Treat AGENTS.md and selected skills as mandatory rules."

--- a/skills/project-workflow/references/bin-submodule.md
+++ b/skills/project-workflow/references/bin-submodule.md
@@ -26,10 +26,12 @@ Use this reference when you need to establish context quickly and discover how a
 ## Command Execution Environment
 
 - Treat the repository Makefile and CI configuration as the source of truth for setup, lint, test, security, benchmark, and review commands.
+- On developer machines, especially macOS, assume required tools may come from Homebrew or another user-shell setup rather than the OS defaults.
 - Prefer `make` targets and documented repository entry points over direct tool invocations, even when a direct command appears equivalent.
 - Run commands from the repository root unless the Makefile, script, or task explicitly requires another working directory.
 - Use the user's configured shell environment for command execution. If a command fails because a tool is missing, an old version is found, or `PATH` differs from the user's normal terminal, treat that as an environment mismatch or validation gap, not as evidence that the repository command is wrong.
-- Do not replace a Makefile target with guessed direct commands just because the agent environment cannot find the same tools as the user's shell.
+- Run repository commands through the user's initialized shell when tool resolution matters, for example `zsh -lic 'make lint'`.
+- Do not invent direct commands, replace a Makefile target, install alternate tools, or keep retrying variants merely to get something to run in the agent environment.
 - When diagnosing command-environment mismatches, check the command surface first, then inspect `command -v <tool>`, `<tool> --version`, `SHELL`, and `PATH` as diagnostics only.
 
 ## Output Format


### PR DESCRIPTION
## What

- Add a shared command-environment prerequisite that requires agents to discover repository entrypoints, CI analogues, and initialized user-shell tooling before running or replacing commands.
- Thread the prerequisite through project workflow and change validation guidance, including macOS/Homebrew tool-path handling.
- Update skill metadata and lint markers so the policy stays discoverable and enforced.

## Why

- Prevent agents from bypassing Make targets or retrying direct tool commands when local macOS shells differ from CI Linux setup.
- Keep downstream repositories on the supported validation path and make shell/PATH/tool-version mismatches explicit validation gaps.

## Testing

- `make dep` - passed
- `make clean-dep` - passed
- `make lint` - passed
- `make scripts-lint` - passed
- `make skills-lint` - passed
- `make docker-lint` - passed
- `make sec` - passed
- `git diff --check` - passed
