### PR TITLE
feat(skills): classify project workflow ownership

### DIFF
--- a/quality/skills/lint
+++ b/quality/skills/lint
@@ -63,6 +63,8 @@ require_pattern skills/test-gaps/SKILL.md "After the human agrees and before edi
 require_pattern skills/doc-gaps/SKILL.md "After the human agrees and before editing, state the selected local documentation pattern"
 require_pattern skills/feature-gaps/SKILL.md "After the human agrees and before editing, state the selected local code/config/docs pattern"
 require_pattern skills/project-gaps/SKILL.md "After the human agrees and before editing, state the selected local project workflow pattern"
+require_pattern skills/project-gaps/SKILL.md "Implementation home: current repo|shared bin|external repo|mixed"
+require_pattern skills/project-gaps/SKILL.md "If a candidate's implementation home is outside the requested scope"
 require_pattern skills/reliability-gaps/SKILL.md "After the human agrees and before editing, state the selected local code/config/docs pattern"
 require_pattern skills/code-issues/SKILL.md "asks about issue IDs such as ISSUE-1"
 require_pattern skills/test-gaps/SKILL.md "asks about test gap IDs such as TEST-1"
@@ -86,6 +88,7 @@ require_pattern skills/test-gaps/agents/openai.yaml "answer test gap ID follow-u
 require_pattern skills/doc-gaps/agents/openai.yaml "answer doc gap ID follow-ups such as DOC-1"
 require_pattern skills/feature-gaps/agents/openai.yaml "answer feature ID follow-ups such as FEATURE-1"
 require_pattern skills/project-gaps/agents/openai.yaml "answer project gap ID follow-ups such as PROJECT-1"
+require_pattern skills/project-gaps/agents/openai.yaml "implementation home as current repo, shared bin, external repo, or mixed"
 require_pattern skills/change-validation/agents/openai.yaml "file changes make prior validation stale"
 require_pattern skills/change-validation/agents/openai.yaml "initialized user shell"
 

--- a/skills/project-gaps/SKILL.md
+++ b/skills/project-gaps/SKILL.md
@@ -56,6 +56,9 @@ candidate instead of recording it as low priority.
   Make target or fragment, CI job, setup path, release/versioning flow,
   validation/preflight entrypoint, script, generated-artifact check, local
   developer command, or shared `./bin` wiring.
+- **Implementation home**: Identify where the smallest useful fix should live:
+  current repo, shared `bin`, external repo, or mixed. Confirm the requested
+  scope owns that home before recording a normal project gap.
 - **Evidence**: Cite concrete local evidence such as Makefiles, CI config,
   scripts, docs, command behavior, recurring maintainer workflow, or comparable
   mature project workflow behavior. Comparable evidence is supporting evidence,
@@ -122,6 +125,12 @@ These rules remain mandatory:
   guidance needed as evidence. Route upstream-only shared-tooling findings to a
   separate `bin`-scoped run instead of writing them into the consuming
   repository's `PROJECTS.md`.
+- Classify every candidate's implementation home before recording it. Use:
+  `current repo` when the requested scope owns the fix; `shared bin` when
+  reusable `bin` tooling owns the fix; `external repo` when another repository
+  or image owns the invoked command, script, CI job, or release behavior; and
+  `mixed` only when a small local adapter plus an owning upstream change are
+  both necessary.
 - Before assigning review agents, build a recursive scope inventory for the
   requested package or folder: relevant file count, first-level subfolders,
   nested packages, dominant languages, Makefiles, CI config, scripts,
@@ -169,6 +178,11 @@ These rules remain mandatory:
   package consumers, service authors, or operators, route it to
   `$feature-gaps`.
 - If a candidate mostly documents existing behavior, route it to `$doc-gaps`.
+- If a candidate's implementation home is outside the requested scope, do not
+  record it as a normal `PROJECT-N` for that scope. Record it under
+  `Routed Project Follow-Ups` with the owning home and local evidence, or route
+  it to a separate project-gaps run in the owning repository or shared tooling
+  scope.
 - If no confirmed project gaps are found, report that no project gaps were
   found and do not create `PROJECTS.md`.
 - If confirmed project gaps are found, write all proposals to the scoped
@@ -191,6 +205,7 @@ Use this structure:
 - Confidence: 93%
 - Scope: path/to/file-or-folder
 - Audience: Developer|Maintainer|Operator|Package consumer|Service author
+- Implementation home: current repo|shared bin|external repo|mixed
 - Current limitation: The project workflow friction or missing project capability.
 - Project surface: Make target|CI job|script|setup flow|validation flow|release flow|command discovery|shared ./bin wiring.
 - Evidence: Concrete file and line references, command behavior, CI config, docs, examples, comparable workflow evidence, or maintainer workflow evidence.
@@ -203,6 +218,13 @@ Use this structure:
 Keep optional follow-up notes separate from proposals:
 
 ```markdown
+## Routed Project Follow-Ups
+
+- Owning home: shared bin|external repo|mixed
+  Evidence: Local evidence that exposed the gap.
+  Follow-up scope: The repository, package, or shared tooling scope where the
+  project-gaps run or implementation belongs.
+
 ## Optional Project Follow-Ups
 
 - Optional or non-blocking idea.
@@ -248,8 +270,10 @@ These rules remain mandatory:
   Makefiles, CI config, scripts, docs, tests, examples, command behavior, and
   comparable workflow evidence. Treat the ledger as something that can go
   stale: dismiss or revise proposals that are already supported, duplicate
-  another project workflow, no longer fit the repository, or belong in another
-  workflow.
+  another project workflow, no longer fit the repository, belong in another
+  workflow, or have an implementation home outside the requested scope.
+- If the proposal's implementation home is outside the requested scope, stop
+  and propose moving or reclassifying it instead of implementing it locally.
 - Stop after proposing the solution. Do not edit files, update `PROJECTS.md`,
   or start validation until the human explicitly agrees to that project-gap
   solution.

--- a/skills/project-gaps/agents/openai.yaml
+++ b/skills/project-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Project Gaps"
   short_description: "Find scoped project workflow gaps"
-  default_prompt: "Use $project-gaps to find scoped build, CI, Makefile, release, setup, validation, command discovery, and repository workflow gaps; exclude downstream bin/** unless explicitly scoped to shared tooling; store confirmed proposals in PROJECTS.md; answer project gap ID follow-ups such as PROJECT-1; or implement agreed project workflow fixes one gap at a time."
+  default_prompt: "Use $project-gaps to find scoped build, CI, Makefile, release, setup, validation, command discovery, and repository workflow gaps; classify each proposal's implementation home as current repo, shared bin, external repo, or mixed; exclude downstream bin/** unless explicitly scoped to shared tooling; store confirmed in-scope proposals in PROJECTS.md; answer project gap ID follow-ups such as PROJECT-1; or implement agreed project workflow fixes one gap at a time."

--- a/skills/project-gaps/references/plan.md
+++ b/skills/project-gaps/references/plan.md
@@ -12,7 +12,7 @@ plan from the consuming repository root and keep `bin/` as shared guidance.
 - Preserve stop gates as plan boundaries; do not continue past a stop gate
   based on silence or a broad request.
 - Update the active plan when scope, audience, project workflow surface,
-  validation, delegation, or ledger state changes.
+  implementation home, validation, delegation, or ledger state changes.
 - Treat validation as stale when files change after a command ran.
 - Before checking, reading, creating, or updating the scoped `PROJECTS.md`
   ledger, ensure the consuming repository root `.gitignore` exists and contains
@@ -87,20 +87,24 @@ plan from the consuming repository root and keep `bin/` as shared guidance.
     command behavior, and current architecture.
 13. Apply `SKILL.md#acceptance-gate` to each candidate and confirm the project
     gap names the audience, current limitation, repository-owned project
-    surface, evidence of value, repository fit, smallest plausible
-    implementation path, compatibility and maintenance tradeoffs, validation
-    path, and correct workflow routing.
+    surface, implementation home, evidence of value, repository fit, smallest
+    plausible implementation path, compatibility and maintenance tradeoffs,
+    validation path, and correct workflow routing.
 14. Reject novelty, competitor checklists, trend-following, broad rewrites,
     new-framework preferences, future-roadmap assumptions, optional polish, and
     findings that belong in feature, code, security, reliability, test, doc, or
     naming workflows.
-15. If no confirmed project gaps remain, report that result with the coverage
+15. Route candidates whose implementation home is outside the requested scope to
+    `Routed Project Follow-Ups` or to a separate project-gaps run in the owning
+    repository or shared tooling scope; do not record them as normal
+    `PROJECT-<number>` entries for the current scope.
+16. If no confirmed project gaps remain, report that result with the coverage
     state, do not create `PROJECTS.md`, and stop.
-16. If confirmed project gaps remain, write the scoped `PROJECTS.md` with
+17. If confirmed project gaps remain, write the scoped `PROJECTS.md` with
     `PROJECT-<number>` IDs.
-17. Present the scoped ledger, proposed implementation plan, coverage state for
+18. Present the scoped ledger, proposed implementation plan, coverage state for
     broad scopes, and runnable follow-up scopes for deferred slices.
-18. Stop before implementing project changes.
+19. Stop before implementing project changes.
 
 ## Implement Mode Plan
 
@@ -115,10 +119,12 @@ plan from the consuming repository root and keep `bin/` as shared guidance.
    tests, examples, command behavior, architecture, and comparable workflow
    evidence.
 6. If the proposal is already supported, no longer fits, duplicates another
-   proposal, or belongs in another workflow, explain that and propose removing
-   or reclassifying it.
-7. Present the project workflow evidence, audience, repository fit, proposed
-   solution, compatibility and maintenance tradeoffs, and intended validation.
+   proposal, belongs in another workflow, or has an implementation home outside
+   the requested scope, explain that and propose removing, moving, or
+   reclassifying it before any local implementation.
+7. Present the project workflow evidence, audience, implementation home,
+   repository fit, proposed solution, compatibility and maintenance tradeoffs,
+   and intended validation.
 8. Stop until the human explicitly agrees to that project-gap solution.
 9. After agreement, state the local project workflow pattern, dominant relevant
    validation path, planned validation, and any needed deviation.


### PR DESCRIPTION
## What

- Require project-gap proposals to classify the implementation home as current repo, shared bin, external repo, or mixed before being recorded.
- Add routed follow-up guidance for findings that are discovered in one repository but belong in shared tooling or another owning repository.
- Update the project-gaps execution plan, OpenAI metadata, and skill lint markers so implementation-home routing is enforced in find and implement modes.

## Why

- Prevent scoped PROJECTS.md ledgers from collecting fixes that should live closer to their owning Make fragment, release image, CI job, or external repository.
- Preserve useful downstream evidence while steering implementation to the place with enough context to make the correct change.

## Testing

- `make dep` - passed
- `make clean-dep` - passed
- `make lint` - passed
- `make scripts-lint` - passed
- `make skills-lint` - passed
- `make docker-lint` - passed
- `make sec` - passed
- `git diff --check` - passed
