### PR TITLE
feat(make): check protobuf formatting before buf lint

### DIFF
--- a/build/make/buf.mak
+++ b/build/make/buf.mak
@@ -1,8 +1,12 @@
 NAME:=$(shell basename $(shell dirname $(CURDIR)))
 
 # Lint protobuf definitions with buf.
-lint:
+lint: format-check
 	@buf lint
+
+# Check protobuf formatting without rewriting files.
+format-check:
+	@buf format --diff --exit-code
 
 # Fix protobuf formatting by rewriting files in place (buf format -w).
 fix-lint:


### PR DESCRIPTION
## What

- Add a read-only protobuf format check to the shared Buf lint target.
- Keep the existing mutating format and fix-lint targets unchanged.
- This makes downstream `make proto-lint` and other consumers of `build/make/buf.mak` fail when `.proto` files are not formatted.

## Why

- Protobuf formatting was only enforced by opt-in mutating commands, so unformatted `.proto` files could pass the normal lint path.
- Moving the check into the shared Buf fragment gives every downstream consumer the same validation behavior instead of requiring service-local overrides.

## Testing

- `gmake lint` in `/private/tmp/buf-mak-project` - failed as expected with an unformatted proto fixture at `format-check`
- `gmake format` in `/private/tmp/buf-mak-project` - passed
- `gmake lint` in `/private/tmp/buf-mak-project` - passed after formatting the fixture
- `gmake -f /Users/alejandro/code/bin/build/make/buf.mak -n lint` - passed, showing `buf format --diff --exit-code` before `buf lint`
- `gmake help` - passed
- `git diff --check` - passed
