### PR TITLE
feat(skills): tighten missing capability evidence checks

### DIFF
--- a/skills/feature-gaps/SKILL.md
+++ b/skills/feature-gaps/SKILL.md
@@ -66,6 +66,13 @@ candidate instead of recording it as low priority.
 - **Current limitation**: State the existing workflow limitation, missing
   capability, or friction. The limitation must exist today and must not already
   be solved by current code, docs, examples, or command behavior.
+- **Negative capability proof**: If the proposal depends on a capability being
+  absent, verify that absence across every layer that could already provide it:
+  local code, generated code, framework wrappers, shared helpers, vendored
+  dependencies, configuration defaults, command behavior, docs, examples, and
+  tests. If the behavior is delegated to a framework, shared helper, generated
+  surface, or vendored dependency, inspect that delegated implementation before
+  assigning 90% or higher confidence.
 - **Benefit**: Explain why this matters to the named audience and the concrete
   outcome they gain, such as saved time, fewer mistakes, clearer decisions,
   unlocked use cases, safer operation, or reduced support burden. Reject the
@@ -178,12 +185,14 @@ These rules remain mandatory:
   `FEATURES.md` before returning feature proposals.
 - Require each agent to return proposals in the same shape as the `FEATURES.md`
   format, without final IDs unless useful locally.
-- Confirm each candidate feature against the acceptance gate, code, docs,
-  tests, examples, command behavior, current architecture, and available
-  comparable-tool evidence before recording it. Try to disprove the candidate
-  by asking whether the workflow is already supported, whether the repository
-  owns the behavior, whether the likely audience exists, and whether the
-  feature can be added incrementally using local patterns.
+- Confirm each candidate feature against the acceptance gate, code, generated
+  surfaces, framework wrappers, shared helpers, vendored dependency behavior
+  when delegated, docs, tests, examples, command behavior, current
+  architecture, and available comparable-tool evidence before recording it. Try
+  to disprove the candidate by asking whether the workflow is already
+  supported, whether the repository owns the behavior, whether the likely
+  audience exists, and whether the feature can be added incrementally using
+  local patterns.
 - Record feature gaps only when the proposal names the audience, current
   product workflow limitation, practical audience benefit, repository-owned
   product surface, evidence of user, operator, service-author, package-consumer,
@@ -257,6 +266,12 @@ Confidence means the inspected evidence makes it very likely that the feature
 is repository-owned, not already supported, valuable to the named audience, and
 implementable without violating local patterns.
 
+Do not assign 90% or higher confidence to a missing-feature proposal when the
+current behavior may be provided by an included framework, shared helper,
+generated surface, vendored dependency, or default configuration that has not
+been inspected. Keep the candidate below threshold, gather that evidence, or
+discard it.
+
 Do not add a separate percentage for idea quality, strength, value, impact, or
 priority. Use `Priority` to express the strength of the audience benefit and
 use `Confidence` only for evidence-backed actionability.
@@ -292,10 +307,11 @@ These rules remain mandatory:
 - Work through feature proposals sequentially by ID unless the human explicitly
   names a different proposal.
 - Before proposing an implementation for each feature, re-check the current
-  code, docs, tests, examples, command behavior, and comparable-tool evidence.
-  Treat the ledger as something that can go stale: dismiss or revise proposals
-  that are already supported, duplicate another feature, no longer fit the
-  repository, or belong in another workflow.
+  code, generated surfaces, framework wrappers, shared helpers, vendored
+  dependency behavior when delegated, docs, tests, examples, command behavior,
+  and comparable-tool evidence. Treat the ledger as something that can go
+  stale: dismiss or revise proposals that are already supported, duplicate
+  another feature, no longer fit the repository, or belong in another workflow.
 - Stop after proposing the solution. Do not edit files, update `FEATURES.md`,
   or start validation until the human explicitly agrees to that feature's
   solution.

--- a/skills/feature-gaps/references/plan.md
+++ b/skills/feature-gaps/references/plan.md
@@ -84,8 +84,9 @@ plan from the consuming repository root and keep `bin/` as shared guidance.
 11. Update coverage state for every planned slice before judging the requested
     scope.
 12. Deduplicate candidates and directly re-check conflicting or overlapping
-    conclusions against code, docs, tests, examples, command behavior, current
-    architecture, and comparable-tool evidence.
+    conclusions against code, generated surfaces, framework wrappers, shared
+    helpers, vendored dependency behavior when delegated, docs, tests, examples,
+    command behavior, current architecture, and comparable-tool evidence.
 13. Apply `SKILL.md#acceptance-gate` to each candidate and confirm the feature
     gap names the audience, current product limitation, practical audience
     benefit, repository-owned product surface, evidence of value, repository
@@ -112,8 +113,10 @@ plan from the consuming repository root and keep `bin/` as shared guidance.
    commands, docs, examples, public APIs, developer workflows, and `./bin`
    wiring.
 4. Select the next proposal by ID unless the human named a specific feature.
-5. Re-check the proposal against current code, docs, tests, examples, command
-   behavior, architecture, and comparable-tool evidence.
+5. Re-check the proposal against current code, generated surfaces, framework
+   wrappers, shared helpers, vendored dependency behavior when delegated, docs,
+   tests, examples, command behavior, architecture, and comparable-tool
+   evidence.
 6. If the proposal is already supported, no longer fits, duplicates another
    proposal, or belongs in another workflow, explain that and propose removing
    or reclassifying it.


### PR DESCRIPTION
## What

- Tighten the feature-gap acceptance gate with a negative-capability proof requirement.
- Require feature-gap find and implement passes to inspect generated surfaces, framework wrappers, shared helpers, and delegated vendored behavior before accepting missing-feature claims.
- Keep the change scoped to feature-gap workflow instructions and the matching execution plan reference.

## Why

- A recent feature-gap pass accepted a missing-capability proposal without checking framework-owned behavior that already provided the workflow.
- This makes the evidence gate explicit so future proposals cannot reach 90%+ confidence when an included framework, shared helper, generated surface, vendored dependency, or default config may already support the behavior.

## Testing

- `zsh -lic 'make skills-lint'` - passed
- `zsh -lic 'make lint'` - passed
- `git diff --check` - passed
