### PR TITLE
feat(skills): clarify ledger approval gates

### DIFF
--- a/skills/code-issues/SKILL.md
+++ b/skills/code-issues/SKILL.md
@@ -117,12 +117,22 @@ These rules remain mandatory:
 - Read `ISSUES.md` in the requested package or folder first and treat it as the working review ledger.
 - If scoped `ISSUES.md` does not exist, stop and ask whether to run Find mode first for that scope.
 - Work through code issues sequentially by ID unless the human explicitly names a different issue.
-- Stop after proposing the solution. Do not edit code, update `ISSUES.md`, or start validation until the human explicitly agrees to that issue's solution.
+- Stop after proposing the solution. Do not edit code, update `ISSUES.md`, or
+  start validation until the human explicitly agrees to that issue's solution.
+- Treat a request that names an issue and asks to fix, implement, or verify it
+  as permission to select that issue, re-check current evidence, and present or
+  refresh the proposal. It is not approval to edit unless the request also
+  explicitly agrees to the proposed solution. If the proposal was already
+  presented and remains unchanged after re-checking, state only the concise
+  approval gate instead of repeating the full proposal.
 - Ask questions when behavior, compatibility, security, validation, or user intent is ambiguous. Treat silence or a broad "implement code issues" request as permission to start the proposal workflow, not as permission to code.
 - When re-checking an issue whose evidence depends on documentation or comments contradicting implementation, prove the code is wrong before proposing a code change. If non-prose evidence supports the implementation, explain that the ledger item is invalid as a code issue and propose reclassifying or fixing the documentation instead.
 - After the human agrees and before editing, state the selected local code pattern, dominant relevant test harness, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
 - Implement only the agreed issue with the smallest safe change.
 - Use `$testing-standards` when deciding whether to add or update regression tests for the fix, and prefer its test-first or scenario-first loop when a behavior-changing fix has a credible test or BDD layer.
+- During automatic continuations while waiting for approval or `ISSUE-N is
+  done`, do not repeat the full proposal or result. State the current waiting
+  gate once, concisely.
 - Do not move to the next issue until the human says `ISSUE-N is done`.
 - After the human confirms an issue is done, remove that issue from scoped `ISSUES.md`. If an issue is deemed invalid or not actually a code issue, remove it only after explaining why and getting human agreement.
 - Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.

--- a/skills/code-issues/references/plan.md
+++ b/skills/code-issues/references/plan.md
@@ -39,6 +39,9 @@ repository root and keep `bin/` as shared guidance.
 - In Implement mode, the goal is waiting while the human has not approved the
   proposed issue solution, or after validation until the human confirms
   `ISSUE-<number> is done`.
+- During automatic continuations while waiting for approval or done
+  confirmation, state the waiting gate once and do not repeat the full
+  proposal or result.
 - In Implement mode, the goal is complete for an issue only after the human
   confirms it is done and the scoped ledger is updated accordingly.
 - Record a blocked reason when a required scope is missing, the scoped ledger
@@ -99,7 +102,12 @@ repository root and keep `bin/` as shared guidance.
    the documentation instead.
 7. Present the issue evidence, proposed solution, compatibility or behavior
    tradeoffs, and intended validation.
-8. Stop until the human explicitly agrees to that issue's solution.
+8. Stop until the human explicitly agrees to that issue's solution. A named
+   fix, implement, or verify request selects the issue and permits re-checking
+   evidence and refreshing the proposal, but it is not approval to edit unless
+   the request also explicitly agrees to the proposed solution. If the proposal
+   was already presented and remains unchanged after re-checking, state only
+   the concise approval gate instead of repeating the full proposal.
 9. After agreement, state the local code pattern, dominant relevant test
    harness, planned validation, and any needed deviation.
 10. If a deviation is needed, stop and ask before editing.

--- a/skills/feature-gaps/SKILL.md
+++ b/skills/feature-gaps/SKILL.md
@@ -315,6 +315,12 @@ These rules remain mandatory:
 - Stop after proposing the solution. Do not edit files, update `FEATURES.md`,
   or start validation until the human explicitly agrees to that feature's
   solution.
+- Treat a request that names a feature and asks to fix, implement, or verify it
+  as permission to select that feature, re-check current evidence, and present
+  or refresh the proposal. It is not approval to edit unless the request also
+  explicitly agrees to the proposed solution. If the proposal was already
+  presented and remains unchanged after re-checking, state only the concise
+  approval gate instead of repeating the full proposal.
 - Ask questions when audience, product direction, compatibility, dependency
   policy, UX/DX behavior, test layer, validation, or user intent is ambiguous.
   Treat silence or a broad "implement feature gaps" request as permission to
@@ -342,6 +348,9 @@ These rules remain mandatory:
 - Report the result for that feature with `Red`, `Green`, `Refactor`, and
   `Validation` entries. Use `Refactor: none` when no cleanup was needed after
   green. Then ask the human to verify and explicitly say `FEATURE-N is done`.
+- During automatic continuations while waiting for approval or `FEATURE-N is
+  done`, do not repeat the full proposal or result. State the current waiting
+  gate once, concisely.
 - Do not move to the next proposal until the human says `FEATURE-N is done`.
 - After the human confirms a proposal is done, remove that proposal from scoped
   `FEATURES.md`. If a proposal is deemed invalid or not actually a feature gap,

--- a/skills/feature-gaps/references/plan.md
+++ b/skills/feature-gaps/references/plan.md
@@ -40,6 +40,9 @@ plan from the consuming repository root and keep `bin/` as shared guidance.
 - In Implement mode, the goal is waiting while the human has not approved the
   proposed feature solution, or after validation until the human confirms
   `FEATURE-<number> is done`.
+- During automatic continuations while waiting for approval or done
+  confirmation, state the waiting gate once and do not repeat the full
+  proposal or result.
 - In Implement mode, the goal is complete for a proposal only after the human
   confirms it is done and the scoped ledger is updated accordingly.
 - Record a blocked reason when a required scope is missing, the scoped ledger
@@ -122,7 +125,12 @@ plan from the consuming repository root and keep `bin/` as shared guidance.
    or reclassifying it.
 7. Present the feature evidence, audience benefit, repository fit, proposed
    solution, compatibility and maintenance tradeoffs, and intended validation.
-8. Stop until the human explicitly agrees to that feature's solution.
+8. Stop until the human explicitly agrees to that feature's solution. A named
+   fix, implement, or verify request selects the feature and permits re-checking
+   evidence and refreshing the proposal, but it is not approval to edit unless
+   the request also explicitly agrees to the proposed solution. If the proposal
+   was already presented and remains unchanged after re-checking, state only
+   the concise approval gate instead of repeating the full proposal.
 9. After agreement, state the local code/config/docs pattern, dominant relevant
    test harness, planned validation, and any needed deviation.
 10. If a deviation is needed, stop and ask before editing.

--- a/skills/project-gaps/SKILL.md
+++ b/skills/project-gaps/SKILL.md
@@ -277,6 +277,12 @@ These rules remain mandatory:
 - Stop after proposing the solution. Do not edit files, update `PROJECTS.md`,
   or start validation until the human explicitly agrees to that project-gap
   solution.
+- Treat a request that names a project gap and asks to fix, implement, or verify
+  it as permission to select that project gap, re-check current evidence, and
+  present or refresh the proposal. It is not approval to edit unless the request
+  also explicitly agrees to the proposed solution. If the proposal was already
+  presented and remains unchanged after re-checking, state only the concise
+  approval gate instead of repeating the full proposal.
 - Ask questions when audience, workflow ownership, compatibility, dependency
   policy, validation, or user intent is ambiguous. Treat silence or a broad
   "implement project gaps" request as permission to start the proposal
@@ -306,6 +312,9 @@ These rules remain mandatory:
 - Report the result for that project gap with `Red`, `Green`, `Refactor`, and
   `Validation` entries. Use `Refactor: none` when no cleanup was needed after
   green. Then ask the human to verify and explicitly say `PROJECT-N is done`.
+- During automatic continuations while waiting for approval or `PROJECT-N is
+  done`, do not repeat the full proposal or result. State the current waiting
+  gate once, concisely.
 - Do not move to the next proposal until the human says `PROJECT-N is done`.
 - After the human confirms a proposal is done, remove that proposal from scoped
   `PROJECTS.md`. If a proposal is deemed invalid or not actually a project gap,

--- a/skills/project-gaps/references/plan.md
+++ b/skills/project-gaps/references/plan.md
@@ -40,6 +40,9 @@ plan from the consuming repository root and keep `bin/` as shared guidance.
 - In Implement mode, the goal is waiting while the human has not approved the
   proposed project-gap solution, or after validation until the human confirms
   `PROJECT-<number> is done`.
+- During automatic continuations while waiting for approval or done
+  confirmation, state the waiting gate once and do not repeat the full
+  proposal or result.
 - In Implement mode, the goal is complete for a proposal only after the human
   confirms it is done and the scoped ledger is updated accordingly.
 - Record a blocked reason when a required scope is missing, the scoped ledger
@@ -125,7 +128,12 @@ plan from the consuming repository root and keep `bin/` as shared guidance.
 7. Present the project workflow evidence, audience, implementation home,
    repository fit, proposed solution, compatibility and maintenance tradeoffs,
    and intended validation.
-8. Stop until the human explicitly agrees to that project-gap solution.
+8. Stop until the human explicitly agrees to that project-gap solution. A named
+   fix, implement, or verify request selects the project gap and permits
+   re-checking evidence and refreshing the proposal, but it is not approval to
+   edit unless the request also explicitly agrees to the proposed solution. If
+   the proposal was already presented and remains unchanged after re-checking,
+   state only the concise approval gate instead of repeating the full proposal.
 9. After agreement, state the local project workflow pattern, dominant relevant
    validation path, planned validation, and any needed deviation.
 10. If a deviation is needed, stop and ask before editing.

--- a/skills/reliability-gaps/SKILL.md
+++ b/skills/reliability-gaps/SKILL.md
@@ -135,7 +135,15 @@ These rules remain mandatory:
 - Work through findings sequentially by ID unless the human explicitly names a different finding.
 - Before proposing a fix for each finding, re-check the current code, config, tests, docs, and CI. Treat the ledger as something that can go stale: dismiss or revise findings that are already addressed, no longer have a concrete failure mode, duplicate another issue, or belong in `$code-issues`, `$security-audit`, `$test-gaps`, or `$doc-gaps`.
 - When re-checking a finding whose evidence depends on documentation or comments contradicting implementation, prove the implementation or reliability control is wrong with non-prose evidence before proposing a reliability change. If non-prose evidence supports the implementation, explain that the ledger item is invalid as a reliability gap and propose reclassifying or fixing documentation instead.
-- Stop after proposing the solution. Do not edit files, update `RELIABILITY.md`, or start validation until the human explicitly agrees to that finding's solution.
+- Stop after proposing the solution. Do not edit files, update
+  `RELIABILITY.md`, or start validation until the human explicitly agrees to
+  that finding's solution.
+- Treat a request that names a finding and asks to fix, implement, or verify it
+  as permission to select that finding, re-check current evidence, and present
+  or refresh the proposal. It is not approval to edit unless the request also
+  explicitly agrees to the proposed solution. If the proposal was already
+  presented and remains unchanged after re-checking, state only the concise
+  approval gate instead of repeating the full proposal.
 - Ask questions when SLOs, expected failure behavior, operator workflow, compatibility, rollout, validation, or user intent is ambiguous. Treat silence or a broad "implement reliability gaps" request as permission to start the proposal workflow, not as permission to edit.
 - After the human agrees and before editing, state the selected local code/config/docs pattern, dominant relevant test harness, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
 - For behavior-changing fixes, state the reliability execution checklist before editing:
@@ -148,6 +156,9 @@ These rules remain mandatory:
 - Implement only the agreed finding with the smallest clear reliability change.
 - Use `$reliability-standards` for reliability design, `$change-safety` for public or operational compatibility, `$testing-standards` for failure-path tests, and `$change-validation` for checks. Pair with `$security-audit` when the fix touches auth, secrets, privilege, DoS, logs, supply chain, or incident containment.
 - Report the result for that finding with `Red`, `Green`, `Refactor`, and `Validation` entries. Use `Refactor: none` when no cleanup was needed after green. Then ask the human to verify and explicitly say `REL-N is done`.
+- During automatic continuations while waiting for approval or `REL-N is done`,
+  do not repeat the full proposal or result. State the current waiting gate
+  once, concisely.
 - Do not move to the next finding until the human says `REL-N is done`.
 - After the human confirms a finding is done, remove that finding from scoped `RELIABILITY.md`. If a finding is deemed invalid or not actually a reliability gap, remove it only after explaining why and getting human agreement.
 - Once all findings are resolved and confirmed done by the human, delete the scoped `RELIABILITY.md`.

--- a/skills/reliability-gaps/references/plan.md
+++ b/skills/reliability-gaps/references/plan.md
@@ -40,6 +40,9 @@ plan from the consuming repository root and keep `bin/` as shared guidance.
 - In Implement mode, the goal is waiting while the human has not approved the
   proposed reliability-gap solution, or after validation until the human
   confirms `REL-<number> is done`.
+- During automatic continuations while waiting for approval or done
+  confirmation, state the waiting gate once and do not repeat the full
+  proposal or result.
 - In Implement mode, the goal is complete for a finding only after the human
   confirms it is done and the scoped ledger is updated accordingly.
 - Record a blocked reason when a required scope is missing, the scoped ledger
@@ -108,7 +111,12 @@ plan from the consuming repository root and keep `bin/` as shared guidance.
    a documentation gap.
 7. Present the finding evidence, affected reliability promise or operational
    expectation, proposed solution, tradeoffs, and intended validation.
-8. Stop until the human explicitly agrees to that finding's solution.
+8. Stop until the human explicitly agrees to that finding's solution. A named
+   fix, implement, or verify request selects the finding and permits re-checking
+   evidence and refreshing the proposal, but it is not approval to edit unless
+   the request also explicitly agrees to the proposed solution. If the proposal
+   was already presented and remains unchanged after re-checking, state only
+   the concise approval gate instead of repeating the full proposal.
 9. After agreement, state the local code/config/docs pattern, dominant relevant
    test harness, planned validation, and any needed deviation.
 10. If a deviation is needed, stop and ask before editing.

--- a/skills/test-gaps/SKILL.md
+++ b/skills/test-gaps/SKILL.md
@@ -156,11 +156,21 @@ These rules remain mandatory:
 - Work through findings sequentially by ID unless the human explicitly names a different finding.
 - Before proposing a fix for each finding, re-check the current code and nearby tests. Treat the ledger as something that can go stale: dismiss or revise findings that are already covered, would duplicate the local test shape, test only underlying libraries/frameworks, or require validation modes the repository does not run.
 - When re-checking a finding whose evidence depends on documentation or comments contradicting implementation, prove the expected behavior with non-prose evidence before proposing tests. If non-prose evidence supports the implementation, explain that the ledger item is invalid as a test gap and propose reclassifying or fixing documentation instead.
-- Stop after proposing the solution. Do not edit code, update `TESTS.md`, or start validation until the human explicitly agrees to that finding's solution.
+- Stop after proposing the solution. Do not edit code, update `TESTS.md`, or
+  start validation until the human explicitly agrees to that finding's solution.
+- Treat a request that names a finding and asks to fix, implement, or verify it
+  as permission to select that finding, re-check current evidence, and present
+  or refresh the proposal. It is not approval to edit unless the request also
+  explicitly agrees to the proposed solution. If the proposal was already
+  presented and remains unchanged after re-checking, state only the concise
+  approval gate instead of repeating the full proposal.
 - Ask questions when behavior, compatibility, test layer, fixture strategy, validation, or user intent is ambiguous. Treat silence or a broad "implement test gaps" request as permission to start the proposal workflow, not as permission to code.
 - After the human agrees and before editing, state the selected local test pattern, dominant relevant test harness, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
 - Implement only the agreed finding with the smallest clear test change, preferring the existing local test shape over new standalone structure.
 - Use `$testing-standards` for test design and pair with the relevant language standard for local idioms. If implementing the test gap requires production behavior to change, prefer the test-first or scenario-first loop from `$testing-standards`.
+- During automatic continuations while waiting for approval or `TEST-N is done`,
+  do not repeat the full proposal or result. State the current waiting gate
+  once, concisely.
 - Do not move to the next finding until the human says `TEST-N is done`.
 - After the human confirms a finding is done, remove that finding from scoped `TESTS.md`. If a finding is deemed invalid or not actually a test gap, remove it only after explaining why and getting human agreement.
 - Once all findings are resolved and confirmed done by the human, delete the scoped `TESTS.md`.

--- a/skills/test-gaps/references/plan.md
+++ b/skills/test-gaps/references/plan.md
@@ -39,6 +39,9 @@ repository root and keep `bin/` as shared guidance.
 - In Implement mode, the goal is waiting while the human has not approved the
   proposed test-gap solution, or after validation until the human confirms
   `TEST-<number> is done`.
+- During automatic continuations while waiting for approval or done
+  confirmation, state the waiting gate once and do not repeat the full
+  proposal or result.
 - In Implement mode, the goal is complete for a finding only after the human
   confirms it is done and the scoped ledger is updated accordingly.
 - Record a blocked reason when a required scope is missing, the scoped ledger
@@ -105,7 +108,12 @@ repository root and keep `bin/` as shared guidance.
    propose reclassification as a documentation gap.
 7. Present the finding evidence, proposed test solution, repository-owned
    behavior, existing coverage gap, tradeoffs, and intended validation.
-8. Stop until the human explicitly agrees to that finding's solution.
+8. Stop until the human explicitly agrees to that finding's solution. A named
+   fix, implement, or verify request selects the finding and permits re-checking
+   evidence and refreshing the proposal, but it is not approval to edit unless
+   the request also explicitly agrees to the proposed solution. If the proposal
+   was already presented and remains unchanged after re-checking, state only
+   the concise approval gate instead of repeating the full proposal.
 9. After agreement, state the local test pattern, dominant relevant test
    harness, planned validation, and any needed deviation.
 10. If a deviation is needed, stop and ask before editing.


### PR DESCRIPTION
## What

- Clarify ledger implement-mode approval gates for code issues, test gaps, reliability gaps, feature gaps, and project gaps.
- Keep named fix, implement, or verify requests as item-selection and proposal-refresh signals, not edit approval.
- Add matching plan guidance so unchanged proposals and automatic continuations report a concise waiting gate instead of repeating the full proposal or result.

## Why

- This preserves explicit human approval before edits while removing duplicate proposal output during ledger-driven fix workflows.
- It keeps the shared ledger skills consistent across issue and gap families.

## Testing

- `git diff --check` - passed
- `env PATH=/usr/local/opt/ruby@4/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin gmake skills-lint` - passed
