### PR TITLE
feat(skills): require supported usage evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,15 @@ Agents MUST:
   tests, logs, scanner output, official documentation, runtime behavior, or
   repository history. Below the required threshold, gather more evidence or
   state the blocker instead of accepting completion.
+- Calibrate durable findings against supported usage evidence. In reusable
+  libraries, helpers, or shared tooling, package-local synthetic tests, fakes,
+  manual construction, and unsupported downstream patterns are leads, not enough
+  evidence for a >=90% finding by themselves. Before recording a high-confidence
+  issue, inspect a supported consumer, executable example, integration test,
+  module wiring path, documented contract, CI workflow, or comparable real usage
+  path that can trigger the candidate. If supported usage evidence cannot be
+  found, lower confidence below the recording threshold, route the concern to
+  the correct workflow, or state the evidence gap instead of recording it.
 - Follow existing repository patterns over personal judgment.
 - Treat skill workflow steps using "must", "do not", or "stop" language as
   blocking requirements.

--- a/skills/code-issues/SKILL.md
+++ b/skills/code-issues/SKILL.md
@@ -69,6 +69,12 @@ These rules remain mandatory:
 - Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
 - Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity and confidence.
 - Confirm each candidate finding against the code before recording it. Findings must be concrete bugs, security issues, compatibility breaks, or violated public contracts with user-visible impact.
+- For reusable library, helper, or shared-tooling scopes, inspect supported
+  usage evidence before recording a high-confidence issue: a real consumer,
+  executable example, integration test, module wiring path, documented
+  contract, CI workflow, or comparable usage path that can trigger the
+  candidate. Treat package-local fakes, synthetic tests, manual construction,
+  and unsupported downstream patterns as leads only.
 - For candidates based on documentation or comments contradicting code, require non-prose proof that the implementation is wrong before recording a code issue. Existing tests, helper names, runtime behavior, or commit history that support the implementation mean the candidate is a doc gap, not a code issue.
 - Do not record standalone missing, weak, flaky, misleading, or wrong-layer tests as code issues unless they are tied to a confirmed bug, security issue, compatibility break, or violated public contract. Use `$test-gaps` for standalone missing or weak test coverage passes.
 - Do not record standalone missing, weak, stale, misleading, or wrong-location documentation, README, example, comment, or docstring gaps as code issues unless they reveal a confirmed bug, security issue, compatibility break, or violated public contract. Use `$doc-gaps` for standalone documentation review passes.

--- a/skills/doc-gaps/SKILL.md
+++ b/skills/doc-gaps/SKILL.md
@@ -68,6 +68,12 @@ These rules remain mandatory:
 - Require each agent to return candidates in the candidate format below, without final IDs unless useful locally.
 - Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity and confidence.
 - Confirm each candidate gap against the code, current docs, examples, and documented interfaces before fixing it, using `$doc-standards` as the finding threshold. Do not confirm or dismiss a candidate merely because documentation exists; verify adequacy, ownership, discoverability, example coverage, and the relevant non-obvious contract.
+- For reusable library, helper, or shared-tooling scopes, inspect supported
+  usage evidence before treating a documentation gap as high confidence: a real
+  consumer, executable example, integration test, module wiring path,
+  documented contract, CI workflow, or comparable usage path showing the
+  audience and action at risk. Treat package-local fakes, synthetic tests,
+  manual construction, and unsupported downstream patterns as leads only.
 - When prose and implementation disagree, require non-prose evidence before treating the code as wrong or routing the candidate out to another workflow. If code, tests, runtime behavior, generated contracts, or history support the implementation, fix the stale prose as a doc gap.
 - Before fixing or dismissing a candidate, route it to the correct documentation surface: README, docs, examples, command help, package documentation, exported API comment, code comment, docstring, or no change. Do not treat package GoDoc or code-comment improvements as sufficient when first-use, setup, configuration, operational behavior, security expectations, or service-author workflows would reasonably be expected in README files, user-facing docs, examples, or command help. Do not treat README prose as sufficient when `$doc-standards` and the paired language standard route reusable API contracts to GoDoc, RDoc, docstrings, executable examples, specs, or features.
 - When dismissing a candidate because existing documentation is sufficient, identify the existing surface that covers the audience and action at risk in the final summary, and state why that surface is the authoritative owner under `$doc-standards`.

--- a/skills/feature-gaps/SKILL.md
+++ b/skills/feature-gaps/SKILL.md
@@ -193,6 +193,12 @@ These rules remain mandatory:
   supported, whether the repository owns the behavior, whether the likely
   audience exists, and whether the feature can be added incrementally using
   local patterns.
+- For reusable library, helper, or shared-tooling scopes, inspect supported
+  usage evidence before recording a high-confidence feature gap: a real
+  consumer, executable example, integration test, module wiring path,
+  documented contract, CI workflow, or comparable usage path that shows the
+  current limitation and audience benefit. Treat package-local fakes, synthetic
+  tests, manual construction, and unsupported downstream patterns as leads only.
 - Record feature gaps only when the proposal names the audience, current
   product workflow limitation, practical audience benefit, repository-owned
   product surface, evidence of user, operator, service-author, package-consumer,
@@ -271,6 +277,11 @@ current behavior may be provided by an included framework, shared helper,
 generated surface, vendored dependency, or default configuration that has not
 been inspected. Keep the candidate below threshold, gather that evidence, or
 discard it.
+
+Do not assign 90% or higher confidence to a reusable-library or shared-tooling
+proposal whose support is limited to package-local possibility, synthetic
+fakes, manual construction, or unsupported downstream usage. Inspect supported
+usage evidence first.
 
 Do not add a separate percentage for idea quality, strength, value, impact, or
 priority. Use `Priority` to express the strength of the audience benefit and

--- a/skills/project-gaps/SKILL.md
+++ b/skills/project-gaps/SKILL.md
@@ -165,6 +165,12 @@ These rules remain mandatory:
   whether the workflow is already supported, whether the repository owns the
   surface, whether the likely audience exists, and whether the project change
   can be added incrementally using local patterns.
+- For reusable library, helper, or shared-tooling scopes, inspect supported
+  usage evidence before recording a high-confidence project gap: a real
+  consumer, executable example, integration test, module wiring path,
+  documented contract, CI workflow, or comparable usage path that shows the
+  workflow friction. Treat package-local fakes, synthetic tests, manual
+  construction, and unsupported downstream patterns as leads only.
 - Do not record confirmed bugs, security issues, compatibility breaks,
   reliability gaps, missing tests, stale docs, unclear naming, or main product
   feature ideas as project gaps. Route them to `$code-issues`,
@@ -237,6 +243,11 @@ confidence or higher. Below 90%, gather more evidence or discard the candidate.
 Confidence means the inspected evidence makes it very likely that the project
 workflow is repository-owned, not already supported, valuable to the named
 audience, and implementable without violating local patterns.
+
+Do not assign 90% or higher confidence to a reusable-library or shared-tooling
+proposal whose support is limited to package-local possibility, synthetic
+fakes, manual construction, or unsupported downstream usage. Inspect supported
+usage evidence first.
 
 Assign priority by workflow value and fit, not implementation ease:
 

--- a/skills/references/finding-severity.md
+++ b/skills/references/finding-severity.md
@@ -31,6 +31,17 @@ the workflow's data-gap, open-question, or optional follow-up section only when
 that section is explicitly meant for unresolved evidence; otherwise discard the
 candidate.
 
+For reusable libraries, helpers, and shared tooling, calibrate confidence
+against supported usage evidence, not package-local possibility alone. Synthetic
+tests, fakes, manual construction, unsupported downstream patterns, or private
+implementation reachability are useful leads, but they do not justify a >=90%
+durable finding unless a supported consumer, executable example, integration
+test, module wiring path, documented contract, CI workflow, or comparable real
+usage path can trigger the candidate. If that evidence is missing, gather it,
+lower confidence below the recording threshold, route the concern to a better
+workflow, or record only the evidence gap when the selected workflow has a
+place for unresolved questions.
+
 When a candidate depends on comments, GoDoc, README text, examples, or other
 prose contradicting implementation, do not treat the prose as source of truth.
 First prove the implementation is wrong with non-prose evidence such as

--- a/skills/reliability-gaps/SKILL.md
+++ b/skills/reliability-gaps/SKILL.md
@@ -71,6 +71,12 @@ These rules remain mandatory:
 - Require each agent to return findings in the same shape as the `RELIABILITY.md` format, without final IDs unless useful locally.
 - Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity and confidence.
 - Confirm each candidate gap against current evidence before recording it. Try to disprove the candidate by tracing the current code path, reading the documented workflow, checking the relevant config, inspecting existing tests, or running an allowed local command. A gap must name the affected reliability promise or operational expectation, the trigger condition, the failure mode, the missing or weak control, and the likely user or operator impact.
+- For reusable library, helper, or shared-tooling scopes, inspect supported
+  usage evidence before recording a high-confidence reliability gap: a real
+  consumer, executable example, integration test, module wiring path,
+  documented contract, CI workflow, or comparable usage path that can trigger
+  the failure mode. Treat package-local fakes, synthetic tests, manual
+  construction, and unsupported downstream patterns as leads only.
 - For candidates based on documentation or comments contradicting code, require non-prose proof that the implementation or repository-owned reliability control is wrong before recording a reliability gap. If current code, tests, runtime behavior, CI, or history support the implementation, treat the prose as a doc gap.
 - Record reliability gaps only when they involve repository-owned behavior or documented/implicit operational contracts, such as:
    - missing or weak SLO, SLI, alertability, dashboard, runbook, or operator diagnostic coverage for behavior the repository claims or owns.

--- a/skills/reliability-standards/SKILL.md
+++ b/skills/reliability-standards/SKILL.md
@@ -51,11 +51,17 @@ documented promise, code path, or operational risk.
    the documented workflow, check the relevant config, inspect tests, or run an
    allowed local command so the concern is based on verified current behavior
    instead of a brief observation.
-9. Prefer small, locally consistent fixes: bounded retries before new
+9. For reusable libraries, helpers, and shared tooling, calibrate reliability
+   confidence against supported usage evidence. Synthetic tests, fakes, manual
+   construction, and unsupported downstream patterns are leads, not enough for
+   high-confidence reliability concerns unless a supported consumer, executable
+   example, integration test, module wiring path, documented contract, CI
+   workflow, or comparable real usage path can trigger the failure mode.
+10. Prefer small, locally consistent fixes: bounded retries before new
    infrastructure, useful logs before broad telemetry redesigns, rollback-safe
    migrations before process-only mitigations, and documented runbook steps
    before vague operational advice.
-10. Report uncertainty explicitly. When scale, SLO, traffic, durability, or
+11. Report uncertainty explicitly. When scale, SLO, traffic, durability, or
    recovery targets are unknown, ask for the missing assumption or record the
    need for a concrete assumption only when the code or docs already imply one.
 

--- a/skills/test-gaps/SKILL.md
+++ b/skills/test-gaps/SKILL.md
@@ -81,6 +81,12 @@ These rules remain mandatory:
 - Require each agent to return findings in the same shape as the `TESTS.md` format, without final IDs unless useful locally. Each finding must name the repository-owned behavior being protected; reject findings that only test dependency semantics, aliases, or pass-through wrappers.
 - Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity and confidence.
 - Confirm each candidate gap against the code and existing tests before recording it. Gaps must be concrete missing, weak, misleading, flaky, or wrong-layer coverage with credible risk to changed behavior, public contracts, compatibility, release-sensitive workflows, or documented command/API behavior.
+- For reusable library, helper, or shared-tooling scopes, inspect supported
+  usage evidence before recording a high-confidence test gap: a real consumer,
+  executable example, integration test, module wiring path, documented
+  contract, CI workflow, or comparable usage path that can observe the
+  unprotected behavior. Treat package-local fakes, synthetic tests, manual
+  construction, and unsupported downstream patterns as leads only.
 - For each candidate, identify the real front door: the command, scenario,
   package/API consumer, service boundary, workflow, or documented entrypoint
   that would observe the behavior. Do not record a gap merely because an


### PR DESCRIPTION
## What

- Add shared confidence guidance requiring durable findings in reusable libraries, helpers, and shared tooling to be backed by supported usage evidence.
- Apply the guard to code, test, doc, feature, project, and reliability gap workflows, plus reliability standards.
- Keep existing skill triggers and OpenAI UI metadata unchanged because the user-facing skill surfaces remain accurate.

## Why

- Prevent package-local fakes, synthetic tests, manual construction, or unsupported downstream patterns from becoming high-confidence ledger findings without verifying a supported usage path.
- Make the confidence rule reusable across all durable ledger workflows instead of relying on package-specific AGENTS notes after a false positive.

## Testing

- `zsh -lic 'make dep'` - passed
- `zsh -lic 'make skills-lint'` - passed
- `zsh -lic 'make lint'` - passed
- `zsh -lic 'make sec'` - passed
- `zsh -lic 'make scripts-lint'` - passed
- `zsh -lic 'make docker-lint'` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
