### PR TITLE
feat(codecov): avoid release blocking coverage uploads

### DIFF
--- a/build/make/_service.mak
+++ b/build/make/_service.mak
@@ -96,7 +96,7 @@ leave-coverage:
 
 # Upload test/reports/final.cov to Codecov (codecovcli upload-process).
 codecov-upload:
-	@codecovcli --verbose upload-process --fail-on-error -F service -f test/reports/final.cov
+	@codecovcli --verbose upload-process -F service -f test/reports/final.cov
 
 # Remove generated report artifacts while preserving report placeholders.
 clean-reports:

--- a/build/make/go.mak
+++ b/build/make/go.mak
@@ -111,7 +111,7 @@ coverage: html-coverage func-coverage
 
 # Upload test/reports/final.cov to Codecov (codecovcli upload-process).
 codecov-upload:
-	@codecovcli --verbose upload-process --fail-on-error -F service -f test/reports/final.cov
+	@codecovcli --verbose upload-process -F service -f test/reports/final.cov
 
 # Remove generated report artifacts while preserving report placeholders.
 clean-reports:

--- a/build/make/ruby.mak
+++ b/build/make/ruby.mak
@@ -55,7 +55,7 @@ clean-reports:
 
 # Upload test/reports/coverage.xml to Codecov (codecovcli upload-process).
 codecov-upload:
-	@codecovcli --verbose upload-process --fail-on-error -F service -f test/reports/coverage.xml
+	@codecovcli --verbose upload-process -F service -f test/reports/coverage.xml
 
 # Scan the repository with Trivy, excluding .ruby-lsp, bin, vendor, and test/vendor.
 trivy-repo:


### PR DESCRIPTION
## What

- Make shared service, Go, and Ruby coverage upload targets stop asking codecovcli to fail the command when upload processing has an external error.
- Keep the existing upload commands, flags, and coverage file paths otherwise unchanged.

## Why

- Coverage generation remains the validation gate, but coverage reporting should not block downstream release workflows when the external reporting service has an outage or token-side issue.
- This keeps shared Make consumers from coupling release readiness to a best-effort coverage upload.

## Testing

- `gmake -n codecov-upload` - passed
- `gmake -n -f build/make/go.mak codecov-upload` - passed
- `gmake -n -f build/make/http.mak codecov-upload` - passed
- `gmake -n -f /Users/alejandro/code/bin/build/make/http.mak codecov-upload` from `/Users/alejandro/code/status` - passed
- `git diff --check` - passed
- `zsh -lic 'gmake lint'` - passed
- `zsh -lic 'gmake scripts-lint'` - passed
- `zsh -lic 'gmake skills-lint'` - passed
- `zsh -lic 'gmake docker-lint'` - passed
