### PR TITLE
feat(skills): tighten reliability finding calibration

### DIFF
--- a/skills/references/finding-severity.md
+++ b/skills/references/finding-severity.md
@@ -16,6 +16,12 @@ a problem is definitely fixed. Treat this percentage as an evidence-calibration
 threshold, not a statistical claim: after trying to disprove the candidate, the
 inspected evidence should make it at least roughly as likely as the required
 threshold that the finding is real, repository-owned, and actionable.
+Confidence must account for both the concrete failure path and the likelihood
+that supported current operation admits the trigger. A technically real failure
+path that depends on an unusual future bad commit, missed review, deliberately
+invalid fixture, or unsupported manual construction is a lead, not a >=90%
+finding, unless repository evidence shows that path is plausibly exercised
+today.
 
 Discard candidates that are likely false positives, vague suggestions,
 unsupported guesses, style-only preferences, nitpicks, or comments whose impact

--- a/skills/reliability-gaps/SKILL.md
+++ b/skills/reliability-gaps/SKILL.md
@@ -28,6 +28,13 @@ Treat a candidate as unconfirmed until the current code, config, docs, tests, or
 command behavior show how a repository-owned reliability control can fail.
 Reject speculative scalability advice, generic SRE checklists, environment
 preferences, and findings that depend on undocumented future requirements.
+Do not record a reliability gap whose trigger is primarily a future bad code,
+config, data, or asset change that would need to be committed, reviewed, and
+deployed first, unless current repository evidence shows that such changes are
+automated, frequent, externally supplied, weakly reviewed, already failing, or
+otherwise reasonably admitted by a supported workflow. Treat normal code review,
+CI, typed or generated contracts, and documented manual update procedures as
+real controls when calibrating likelihood.
 
 Comments, GoDoc, README prose, examples, and operational docs can reveal leads,
 but they are not source of truth when they contradict implementation. Before
@@ -90,6 +97,10 @@ These rules remain mandatory:
 - Do not record findings whose evidence is only a repository preference, transport choice, hosting choice, cloud architecture preference, or environment setup assumption. For example, an SSH Git remote or submodule URL is not a reliability gap unless a documented repository-owned workflow currently fails for intended operators and the repository owns the fix.
 - For release or supply-chain findings involving Docker/image scans, first trace the exact artifacts through CI, Make targets, scripts, Dockerfiles, tags, build arguments, and push commands. Do not record a pre-publish scan or release-gate gap merely because CI scans a test image or runs scan jobs on non-release branches. Record the gap only when the scanned artifact and published artifact can materially differ, the release build bypasses a repository-owned required scan, or a documented release contract is violated.
 - Do not record reliability gaps whose only support is an undocumented future scale target, hypothetical product direction, architecture preference, or a conclusion reached from briefly noticing a pattern without verifying a concrete failure path.
+- Do not record future bad commits, invalid future fixtures, or missed-review
+  scenarios as reliability gaps unless the repository currently admits that
+  trigger through automation, external input, frequent operational data changes,
+  or another supported path that existing controls do not cover.
 - Do not record confirmed production bugs, security issues, compatibility breaks, or violated public contracts as reliability gaps. If broken behavior is discovered during review, report it as out of scope for the reliability-gap ledger and recommend `$code-issues`, `$security-audit`, or `$change-safety` as appropriate.
 - Do not record standalone missing, weak, flaky, misleading, or wrong-layer tests as reliability gaps. Use `$test-gaps` when missing failure-path coverage is the finding.
 - Do not record standalone missing, weak, stale, misleading, or wrong-location operational docs as reliability gaps. Use `$doc-gaps` when documentation itself is the finding.

--- a/skills/reliability-gaps/references/plan.md
+++ b/skills/reliability-gaps/references/plan.md
@@ -86,16 +86,24 @@ plan from the consuming repository root and keep `bin/` as shared guidance.
 14. Confirm each gap names a current reliability promise or operational
     expectation, trigger, failure mode, missing or weak control, and user or
     operator impact.
-15. Reject generic maturity advice, future-scale assumptions, private
+15. Run a final finding calibration pass:
+    - Does the trigger exist in current supported operation?
+    - Is the missing control repository-owned rather than normal review, CI, or
+      deployment discipline?
+    - Are existing controls insufficient for this repository's workflow?
+    - Would a skeptical maintainer likely agree this is more than optional
+      hardening?
+    If any answer is no, discard the candidate or move it to optional follow-up.
+16. Reject generic maturity advice, future-scale assumptions, private
     preferences, and findings that belong in code, security, test, or doc
     ledgers.
-16. If no confirmed gaps remain, report that result with the coverage state, do
+17. If no confirmed gaps remain, report that result with the coverage state, do
     not create `RELIABILITY.md`, and stop.
-17. If confirmed gaps remain, write the scoped `RELIABILITY.md` with
+18. If confirmed gaps remain, write the scoped `RELIABILITY.md` with
     `REL-<number>` IDs.
-18. Present the scoped ledger, proposed reliability-fix plan, coverage state for
+19. Present the scoped ledger, proposed reliability-fix plan, coverage state for
     broad scopes, and runnable follow-up scopes for deferred slices.
-19. Stop before making fixes.
+20. Stop before making fixes.
 
 ## Implement Mode Plan
 


### PR DESCRIPTION
## What

- Tighten reliability-gap guidance so future bad commits, fixtures, data, or asset changes are treated as leads unless the repository currently admits that trigger through a supported workflow.
- Clarify shared confidence calibration so technically possible failure paths still need current supported usage likelihood before becoming high-confidence findings.
- Add a final pre-ledger calibration checkpoint to the reliability-gaps find-mode plan.

## Why

- Prevent optional hardening leads from being recorded as confirmed reliability gaps when normal review, CI, generated contracts, or documented manual update procedures are already meaningful controls.
- Make reliability review output more defensible for maintainers by forcing agents to separate plausible future-change scenarios from current operational failure modes.

## Testing

- `zsh -lic 'gmake skills-lint'` - passed
- `git diff --check` - passed
- `gmake skills-lint` - failed in the non-login shell because it resolved macOS Ruby 2.6/Psych 3.1, where `Psych.safe_load_file` is unavailable; the initialized user shell resolved Ruby 4.0/Psych 5.3 and passed.
