### PR TITLE
feat(skills): align downstream guidance snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,9 @@ repositories should point agents at the shared instructions instead of copying
 the skill list:
 
 ```markdown
-## Shared skills
+## Shared guidance
 
-This repository uses the shared skills from `bin/skills/`. Read
-`bin/AGENTS.md` for the canonical shared skill list and use the smallest
-matching skill for the task.
+Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
 ```
 
 Update `AGENTS.md` when the shared skill set, composition rules, or repository


### PR DESCRIPTION
## What

- Update the downstream `AGENTS.md` example in `README.md` to use the new `## Shared guidance` heading.
- Replace the old shared-skill boilerplate with the concise `bin/AGENTS.md` pointer used by consuming repositories.

## Why

- Keeps the published integration guidance aligned with the repository updates that now centralize shared defaults in `bin/AGENTS.md`.
- Prevents new consumers from copying the stale `## Shared skills` snippet.

## Testing

- `git diff --check -- README.md` - passed
- `zsh -lic 'make lint'` - passed
- Full CI was not run locally; this is a README-only documentation change.

AI-assisted-by: [Codex](https://openai.com/codex/)
