### PR TITLE
build(ci): reuse pipeline setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,32 @@
 version: 2.1
 
-jobs:
-  build:
-    docker:
-      - image: alexfalkowski/ruby:3.17
+commands:
+  sync-submodules:
+    steps:
+      - run: git submodule sync
+      - run: git submodule update --init
+  checkout-submodules:
     steps:
       - checkout:
           method: blobless
-      - run: git submodule sync
-      - run: git submodule update --init
+      - sync-submodules
+
+executors:
+  ruby:
+    docker:
+      - image: alexfalkowski/ruby:3.17
+  release:
+    docker:
+      - image: alexfalkowski/release:8.18
+  alpine:
+    docker:
+      - image: alpine:latest
+
+jobs:
+  build:
+    executor: ruby
+    steps:
+      - checkout-submodules
       - run: make source-key
       - restore_cache:
           name: restore deps
@@ -29,29 +47,20 @@ jobs:
       - run: make sec
     resource_class: arm.large
   sync:
-    docker:
-      - image: alexfalkowski/release:8.18
+    executor: release
     steps:
-      - checkout:
-          method: blobless
-      - run: git submodule sync
-      - run: git submodule update --init
+      - checkout-submodules
       - run: make sync push
     resource_class: arm.large
   version:
-    docker:
-      - image: alexfalkowski/release:8.18
+    executor: release
     steps:
-      - checkout:
-          method: blobless
-      - run: git submodule sync
-      - run: git submodule update --init
+      - checkout-submodules
       - run: version
       - run: package
     resource_class: arm.large
   wait-all:
-    docker:
-      - image: alpine:latest
+    executor: alpine
     resource_class: small
     steps:
       - run: echo "all applicable jobs finished"


### PR DESCRIPTION
## What

- Added reusable CircleCI commands for checkout and submodule setup.
- Added reusable CircleCI executors for the existing job images.
- Kept the existing job names, workflow dependencies, contexts, filters, resource classes, and command invocations unchanged.

## Why

- This reduces repeated CircleCI image and bootstrap configuration so cross-repo CI image updates are easier to review and less error-prone.

## Testing

- `circleci config validate` - passed for changed CircleCI config files.
- `git diff --check -- .circleci` - passed.
