### PR TITLE
feat(make): centralize cert generation and run services from test

### DIFF
--- a/build/go/dev
+++ b/build/go/dev
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Run a service in dev mode with air using the test config as the working context.
+
+set -eo pipefail
+
+name="${1:?name is required}"
+
+air -c /dev/null --build.cmd "make dep build" --build.full_bin "cd test && ../$name server -config file:.config/server.yml" --build.exclude_dir "assets,bin,vendor,test"

--- a/build/make/_service.mak
+++ b/build/make/_service.mak
@@ -216,9 +216,7 @@ encode-config:
 
 # Create server and client TLS certs under test/certs/ using mkcert.
 create-certs:
-	@mkcert -key-file test/certs/key.pem -cert-file test/certs/cert.pem localhost
-	@mkcert -client -key-file test/certs/client-key.pem -cert-file test/certs/client-cert.pem localhost
-	@cp "$$(mkcert -CAROOT)/rootCA.pem" test/certs/rootCA.pem
+	@$(BIN_ROOT)/build/sec/certs
 
 # Generate assets/<package>.png with goda+dot; package=internal/foo, default assets/diagram.png.
 create-diagram:

--- a/build/make/go.mak
+++ b/build/make/go.mak
@@ -134,9 +134,7 @@ encode-config:
 
 # Create server and client TLS certs under test/certs/ using mkcert.
 create-certs:
-	@mkcert -key-file test/certs/key.pem -cert-file test/certs/cert.pem localhost
-	@mkcert -client -key-file test/certs/client-key.pem -cert-file test/certs/client-cert.pem localhost
-	@cp "$$(mkcert -CAROOT)/rootCA.pem" test/certs/rootCA.pem
+	@$(BIN_ROOT)/build/sec/certs
 
 # Generate assets/<package>.png with goda+dot; package=internal/foo, default assets/diagram.png.
 create-diagram:

--- a/build/make/grpc.mak
+++ b/build/make/grpc.mak
@@ -50,4 +50,4 @@ update-all-dep: go-update-all-dep go-dep ruby-update-all-dep ruby-dep proto-upda
 
 # Run in dev mode with air; builds and runs "$(NAME) server" using test config.
 dev:
-	@air -c /dev/null --build.cmd "make dep build" --build.entrypoint "$(CURDIR)/$(NAME)" --build.args_bin "server,-config,file:test/.config/server.yml" --build.exclude_dir "assets,bin,vendor,test"
+	@$(BIN_ROOT)/build/go/dev "$${NAME}"

--- a/build/make/http.mak
+++ b/build/make/http.mak
@@ -18,4 +18,4 @@ update-all-dep: go-update-all-dep go-dep ruby-update-all-dep ruby-dep
 
 # Run in dev mode with air; builds and runs "$(NAME) server" using test config.
 dev:
-	@air -c /dev/null --build.cmd "make dep build" --build.entrypoint "$(CURDIR)/$(NAME)" --build.args_bin "server,-config,file:test/.config/server.yml" --build.exclude_dir "assets,bin,vendor,test"
+	@$(BIN_ROOT)/build/go/dev "$${NAME}"

--- a/build/sec/certs
+++ b/build/sec/certs
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Create server and client TLS certs under test/certs/ using mkcert.
+
+set -eo pipefail
+
+mkcert -key-file test/certs/key.pem -cert-file test/certs/cert.pem localhost
+mkcert -client -key-file test/certs/client-key.pem -cert-file test/certs/client-cert.pem localhost
+cp "$(mkcert -CAROOT)/rootCA.pem" test/certs/rootCA.pem


### PR DESCRIPTION
## What

- Centralize the shared `create-certs` implementation in `build/sec/certs` while preserving the existing `make create-certs` targets.
- Run HTTP and gRPC dev services through Air from the `test/` directory with `file:.config/server.yml`, so test-relative paths in the server config resolve from the harness directory.
- Keep `analyse` advisory with `gsa "$${NAME}" || true`.

## Why

- Certificate generation belongs with the shared security helpers and no longer needs to be duplicated across Go and service Make fragments.
- The dev server command now matches the test harness layout, avoiding config references that are interpreted from the repository root when they are authored relative to `test/`.

## Testing

- `make dep` - passed
- `make clean-dep` - passed
- `make scripts-lint` - passed
- `make skills-lint` - passed
- `make docker-lint` - passed
- `make lint` - passed
- `make sec` - passed
- `make -f build/make/http.mak -n dev` - passed
- `make -f build/make/grpc.mak -n dev` - passed
- `make -f build/make/go.mak -n create-certs analyse` - passed
- `make -f build/make/_service.mak -n create-certs analyse` - passed
- `git diff --check` - passed
- Downstream runtime execution was not run from this shared tooling repository.
