### PR TITLE
feat(docker): centralize build context exclusions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
 .bundle/
+.crush/
+.ruby-lsp/
+.source-key
 ISSUES.md
 TESTS.md
 DOCS.md
 RELIABILITY.md
 FEATURES.md
-vendor
+test/reports/*
+!test/reports/.keep
+vendor/

--- a/README.md
+++ b/README.md
@@ -85,16 +85,21 @@ repository Make targets.
 
 Some helpers intentionally depend on tools or services outside this repository:
 Docker helpers assume the consuming project supplies image names and release
-version files; security helpers assume Trivy is available; shell and Dockerfile
-lint targets depend on `shellcheck` and `hadolint`; `build/docker/env` pulls,
-rebases, and updates submodules in an existing sibling `../docker` checkout, or
-uses SSH to clone `git@github.com:alexfalkowski/docker.git` there when missing.
+version files; the shared Go Dockerfile uses `Dockerfile.dockerignore` next to
+the Dockerfile, which takes precedence over a consuming repository's root
+`.dockerignore`; security helpers assume Trivy is available; shell and
+Dockerfile lint targets depend on `shellcheck` and `hadolint`;
+`build/docker/env` pulls, rebases, and updates submodules in an existing sibling
+`../docker` checkout, or uses SSH to clone
+`git@github.com:alexfalkowski/docker.git` there when missing.
 
 ## 🔗 References
 
 - `make` or `make help`: current command catalog for this repository.
 - `build/make/*.mak`: reusable Makefile fragments for downstream projects.
 - `build/docker/go/Dockerfile`: shared Go service Dockerfile template.
+- `build/docker/go/Dockerfile.dockerignore`: shared Docker build-context
+  exclusions for the Go service Dockerfile.
 - `quality/`: shared lint, feature, benchmark, and coverage helpers.
 - `skills/README.md`: shared skill composition and lifecycle guidance.
 - `AGENTS.md`: repository instructions and shared agent operating rules.

--- a/build/docker/go/Dockerfile.dockerignore
+++ b/build/docker/go/Dockerfile.dockerignore
@@ -1,0 +1,33 @@
+# Shared context exclusions for services built with this Dockerfile.
+#
+# Keep files required by:
+# - COPY go.mod go.sum ./
+# - RUN go mod download
+# - COPY . ./
+# - RUN go build -buildvcs=false -tags netgo -a -o service .
+
+# Version control, CI, and local tool state.
+.git
+.git/**
+.github/**
+.circleci/**
+.bundle/**
+.crush/**
+.ruby-lsp/**
+
+# Shared tooling, local test harnesses, and dependency mirrors not used by the
+# Dockerfile's module-download build path.
+bin/**
+test/**
+vendor/**
+
+# Local build, report, and profiling outputs.
+dist/**
+reports/**
+tmp/**
+*.cov
+*.out
+*.prof
+*.test
+coverage.*
+.source-key


### PR DESCRIPTION
## What

- Add a Dockerfile-specific ignore file for the shared Go service Dockerfile so downstream builds can reuse one context policy.
- Exclude shared tooling, local test harnesses, vendor mirrors, CI metadata, and generated build/report artifacts from shared Go service build contexts.
- Document the Dockerfile-specific ignore precedence in the README and align the root ignore file with this repository’s generated local state.

## Why

- Reduces repeated per-service Docker ignore setup while keeping the shared Dockerfile on its existing `go mod download` build path.
- Avoids sending large downstream `test/`, `vendor/`, and `bin/` payloads into BuildKit contexts for services that use the shared Dockerfile.
- Makes local generated files and tool caches explicit in this repository before downstream `.gitignore` cleanup happens separately.

## Testing

- `make dep` - passed
- `make clean-dep` - passed
- `make scripts-lint` - passed
- `make skills-lint` - passed
- `make docker-lint` - passed
- `make lint` - passed
- `make sec` - passed
- `docker build --check --progress=plain -f /Users/alejandro/code/bin/build/docker/go/Dockerfile .` from each listed downstream consumer root - passed
- Temporary build-context proof with 40M under ignored `test/` and `vendor/` transferred 221B and completed the shared Dockerfile build.

AI-assisted-by: [Codex](https://openai.com/codex/)
