### PR TITLE
feat(skills): clarify circleci report upload behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,6 +293,13 @@ Common shared targets include:
   HTML report path in `test/.config/cucumber.yml`. Treat JUnit XML reports and
   coverage files as the durable CI artifacts; do not flag the lack of separate
   feature and benchmark HTML report paths as a project workflow gap by default.
+- CircleCI `store_artifacts` and `store_test_results` are special steps that
+  already run after a previous step fails. Do not flag their placement after
+  feature, benchmark, coverage, or other validation commands, or the absence of
+  `when: always` around them, as a project workflow gap by default. Only raise a
+  report/artifact upload gap with concrete evidence that the repository's
+  configured upload steps, paths, job timeouts, cancellations, or documented CI
+  artifact contract fail to preserve required diagnostics.
 
 ### Shared service health defaults
 


### PR DESCRIPTION
## What

- Clarify shared downstream guidance for CircleCI report upload handling.
- Document that `store_artifacts` and `store_test_results` already run after failed validation steps, so agents should not raise missing `when: always` wrappers as project workflow gaps by default.
- Keep the valid exception cases scoped to wrong upload paths, job timeouts, cancellations, or a documented CI artifact contract that is not being met.

## Why

- Repeated project-gap audits were raising a false positive across downstream repositories.
- The shared guidance should match CircleCI special-step behavior so future audits focus on concrete diagnostic failures instead of adding redundant CI configuration.

## Testing

- `zsh -lic 'make skills-lint'` - passed
- `zsh -lic 'make lint'` - passed
- `git diff --check` - passed
- Official CircleCI configuration reference checked for `store_artifacts` / `store_test_results` failure behavior.
