### PR TITLE
feat(skills): tighten data-backed triage routing

### DIFF
--- a/skills/code-issues/SKILL.md
+++ b/skills/code-issues/SKILL.md
@@ -75,6 +75,16 @@ These rules remain mandatory:
   contract, CI workflow, or comparable usage path that can trigger the
   candidate. Treat package-local fakes, synthetic tests, manual construction,
   and unsupported downstream patterns as leads only.
+- Treat provider-to-public-contract adapters, lookup tables, data enrichment,
+  normalization maps, embedded assets, vendored static data, and generated
+  schema/value translations as high-risk review slices when they affect API
+  output, routing, auth, billing, persistence, or user-visible behavior.
+- When reviewing code that maps provider, asset, generated, embedded, or
+  vendored data values into repository-owned public values, inspect the actual
+  emitted data set or representative fixtures. Do not assume names in a mapping
+  table match provider output. Check for unmapped provider values, stale
+  fixtures, fallback-to-empty behavior, and public contract violations caused
+  by normalization drift.
 - For candidates based on documentation or comments contradicting code, require non-prose proof that the implementation is wrong before recording a code issue. Existing tests, helper names, runtime behavior, or commit history that support the implementation mean the candidate is a doc gap, not a code issue.
 - Do not record standalone missing, weak, flaky, misleading, or wrong-layer tests as code issues unless they are tied to a confirmed bug, security issue, compatibility break, or violated public contract. Use `$test-gaps` for standalone missing or weak test coverage passes.
 - Do not record standalone missing, weak, stale, misleading, or wrong-location documentation, README, example, comment, or docstring gaps as code issues unless they reveal a confirmed bug, security issue, compatibility break, or violated public contract. Use `$doc-gaps` for standalone documentation review passes.

--- a/skills/reliability-gaps/SKILL.md
+++ b/skills/reliability-gaps/SKILL.md
@@ -102,6 +102,11 @@ These rules remain mandatory:
   trigger through automation, external input, frequent operational data changes,
   or another supported path that existing controls do not cover.
 - Do not record confirmed production bugs, security issues, compatibility breaks, or violated public contracts as reliability gaps. If broken behavior is discovered during review, report it as out of scope for the reliability-gap ledger and recommend `$code-issues`, `$security-audit`, or `$change-safety` as appropriate.
+- If investigation finds current valid user input producing the wrong API
+  response, error, status code, persisted value, generated artifact, or public
+  contract output, stop treating it as a reliability gap. Route it to
+  `$code-issues` unless the primary missing control is operational rather than
+  behavioral.
 - Do not record standalone missing, weak, flaky, misleading, or wrong-layer tests as reliability gaps. Use `$test-gaps` when missing failure-path coverage is the finding.
 - Do not record standalone missing, weak, stale, misleading, or wrong-location operational docs as reliability gaps. Use `$doc-gaps` when documentation itself is the finding.
 - Do not report optional maturity improvements, cloud-architecture preferences, private implementation preferences, or "best practice" checkboxes as findings by themselves. List them only as optional follow-up notes when relevant.


### PR DESCRIPTION
## What

- Tighten code-issue triage for provider-to-public-contract adapters, lookup tables, normalization maps, embedded assets, vendored data, and generated value translations.
- Require code-issue reviews to inspect actual emitted provider/data values or representative fixtures before trusting mapping tables.
- Clarify that reliability-gap reviews should route current wrong API/status/output/public-contract behavior to `$code-issues` unless the primary missing control is operational.

## Why

- Data-backed normalization bugs can be missed when review only checks the mapping code and assumes provider labels match expected public terminology.
- Current valid-input behavior bugs should land in the code-issue ledger, while reliability-gap ledgers should stay focused on operational controls and production-readiness gaps.

## Testing

- `zsh -lic 'gmake skills-lint'` - passed
- `zsh -lic 'gmake lint'` - passed
- `git diff --check` - passed
