### PR TITLE
feat(skills): share scoped gap workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,9 @@
 ISSUES.md
 TESTS.md
 DOCS.md
-RELIABILITY.md
 FEATURES.md
+PROJECTS.md
+RELIABILITY.md
 test/reports/*
 !test/reports/.keep
 vendor/

--- a/quality/skills/lint
+++ b/quality/skills/lint
@@ -21,9 +21,31 @@ require_pattern() {
   fi
 }
 
+require_gitignore_pattern() {
+  local pattern="$1"
+
+  if [[ ! -f .gitignore ]]; then
+    printf 'missing file: .gitignore\n' >&2
+    missing=1
+    return
+  fi
+
+  if ! grep -Fxq -- "$pattern" .gitignore; then
+    printf 'missing .gitignore pattern: %s\n' "$pattern" >&2
+    missing=1
+  fi
+}
+
 if ! ruby quality/skills/metadata; then
   missing=1
 fi
+
+require_gitignore_pattern "ISSUES.md"
+require_gitignore_pattern "TESTS.md"
+require_gitignore_pattern "DOCS.md"
+require_gitignore_pattern "FEATURES.md"
+require_gitignore_pattern "PROJECTS.md"
+require_gitignore_pattern "RELIABILITY.md"
 
 require_pattern AGENTS.md "mandatory operating rules, not advisory guidance"
 require_pattern AGENTS.md "## Local pattern binding"

--- a/quality/skills/metadata
+++ b/quality/skills/metadata
@@ -3,6 +3,16 @@
 
 require 'yaml'
 
+GAP_CONTRACTS = {
+  'code-issues' => { ledger: 'ISSUES.md', id: 'ISSUE' },
+  'test-gaps' => { ledger: 'TESTS.md', id: 'TEST' },
+  'doc-gaps' => { ledger: 'DOCS.md', id: 'DOC' },
+  'feature-gaps' => { ledger: 'FEATURES.md', id: 'FEATURE' },
+  'project-gaps' => { ledger: 'PROJECTS.md', id: 'PROJECT' },
+  'reliability-gaps' => { ledger: 'RELIABILITY.md', id: 'REL' }
+}.freeze
+REFERENCE_PATTERN = %r{(?<!/)(?:\.\./)*references/[A-Za-z0-9._/-]+\.md}
+
 def present_string?(value)
   value.is_a?(String) && !value.strip.empty?
 end
@@ -69,7 +79,11 @@ def valid_skill?(path)
   data = safe_load_frontmatter(path)
   return false unless mapping?(data, path, 'frontmatter must be a mapping')
 
-  [valid_skill_keys?(data, path), valid_required_strings?(data, %w[name description], path)].all?
+  [
+    valid_skill_keys?(data, path),
+    valid_required_strings?(data, %w[name description], path),
+    valid_skill_name?(data, path)
+  ].all?
 end
 
 def agent_interface(path)
@@ -93,8 +107,130 @@ def valid_agent?(path)
   ].all?
 end
 
+def valid_skill_name?(data, path)
+  skill_name = path.split('/')[1]
+  return true if data['name'] == skill_name
+
+  report_failure("frontmatter name must match directory in #{path}: #{data['name'].inspect}")
+end
+
+def valid_markdown_references?(path)
+  text = File.read(path)
+  references = text.scan(REFERENCE_PATTERN).uniq.select do |reference|
+    checkable_reference?(path, reference)
+  end
+
+  references.map do |reference|
+    reference_candidates(path, reference).any? { |candidate| File.file?(candidate) } ||
+      report_failure("missing referenced file in #{path}: #{reference}")
+  end.all?
+end
+
+def checkable_reference?(path, reference)
+  return false if path == 'skills/README.md'
+  return reference.start_with?('../') if path.start_with?('skills/references/')
+
+  true
+end
+
+def reference_candidates(path, reference)
+  candidates = [File.expand_path(reference, File.dirname(path))]
+  parts = path.split('/')
+
+  if reference.start_with?('references/') && parts[0] == 'skills' && parts[1] && parts[1] != 'references'
+    candidates << File.expand_path(reference, File.join(parts[0], parts[1]))
+  end
+
+  candidates.uniq
+end
+
+def valid_skill_agent_pairs?
+  skills = Dir['skills/*/SKILL.md'].map { |path| path.split('/')[1] }
+  agents = Dir['skills/*/agents/openai.yaml'].map { |path| path.split('/')[1] }
+
+  missing_agents = skills - agents
+  orphan_agents = agents - skills
+
+  [
+    valid_pairs?(missing_agents, 'missing agent metadata for skill'),
+    valid_pairs?(orphan_agents, 'orphan agent metadata without skill')
+  ].all?
+end
+
+def valid_pairs?(names, message)
+  return true if names.empty?
+
+  names.each { |name| report_failure("#{message}: #{name}") }
+  false
+end
+
+def valid_gap_contract?(skill_name, contract)
+  skill_path = "skills/#{skill_name}/SKILL.md"
+  plan_path = "skills/#{skill_name}/references/plan.md"
+  agent_path = "skills/#{skill_name}/agents/openai.yaml"
+
+  [
+    valid_gap_file?(skill_path, skill_name),
+    valid_gap_file?(plan_path, skill_name),
+    valid_gap_file?(agent_path, skill_name),
+    valid_gap_text?(skill_path, plan_path, agent_path, contract)
+  ].all?
+end
+
+def valid_gap_file?(path, skill_name)
+  return true if File.file?(path)
+
+  report_failure("missing gap workflow file for #{skill_name}: #{path}")
+end
+
+def valid_gap_text?(skill_path, plan_path, agent_path, contract)
+  return false unless [skill_path, plan_path, agent_path].all? { |path| File.file?(path) }
+
+  skill_text = File.read(skill_path)
+  plan_text = File.read(plan_path)
+  agent_text = File.read(agent_path)
+  combined_text = [skill_text, plan_text, agent_text].join("\n")
+
+  valid_gap_skill_text?(skill_text, skill_path) &&
+    valid_gap_plan_text?(plan_text, plan_path) &&
+    valid_gap_contract_text?(combined_text, skill_path, contract)
+end
+
+def valid_gap_skill_text?(skill_text, skill_path)
+  [
+    required_text?(skill_text, skill_path, 'references/plan.md'),
+    required_text?(skill_text, skill_path, '../references/gap-workflow.md')
+  ].all?
+end
+
+def valid_gap_plan_text?(plan_text, plan_path)
+  required_text?(plan_text, plan_path, 'shared gap workflow')
+end
+
+def valid_gap_contract_text?(combined_text, skill_path, contract)
+  [
+    required_text?(combined_text, skill_path, contract.fetch(:ledger)),
+    required_gap_id?(combined_text, skill_path, contract.fetch(:id))
+  ].all?
+end
+
+def required_text?(text, path, expected)
+  return true if text.include?(expected)
+
+  report_failure("missing required text in #{path}: #{expected}")
+end
+
+def required_gap_id?(text, path, id)
+  return true if text.match?(/\b#{Regexp.escape(id)}-(?:1|N|<number>)/)
+
+  report_failure("missing gap ID pattern in #{path}: #{id}-1, #{id}-N, or #{id}-<number>")
+end
+
 ok = true
 Dir['skills/*/SKILL.md'].each { |path| ok = false unless valid_skill?(path) }
 Dir['skills/*/agents/openai.yaml'].each { |path| ok = false unless valid_agent?(path) }
+Dir['skills/**/*.md'].each { |path| ok = false unless valid_markdown_references?(path) }
+ok = false unless valid_skill_agent_pairs?
+GAP_CONTRACTS.each { |skill_name, contract| ok = false unless valid_gap_contract?(skill_name, contract) }
 
 exit(ok ? 0 : 1)

--- a/skills/code-issues/SKILL.md
+++ b/skills/code-issues/SKILL.md
@@ -12,13 +12,10 @@ Use this skill in two distinct modes:
 
 Do not combine the two modes in one pass.
 
-Before starting Find mode or Implement mode, read `references/plan.md` and use
-it to maintain the active execution plan. The active plan is runtime state; do
-not write it into the repository unless the human explicitly asks for a durable
-plan file.
-When the runtime supports goals, bind the selected mode and requested scope to
-one active goal and update that goal as ledger, proposal, approval, validation,
-or human-confirmation state changes.
+Before starting Find mode or Implement mode, read `references/plan.md` and
+`../references/gap-workflow.md`. The plan owns active runtime state; the shared
+gap workflow owns ledger, delegation, scope, coverage, confidence, and approval
+gates.
 
 ## Operating Stance
 
@@ -36,45 +33,16 @@ while prose disagrees, treat it as a documentation gap and update the docs.
 
 ## Find Mode
 
-Follow `references/plan.md#find-mode-plan`.
+Follow `references/plan.md#find-mode-plan` and the find/audit rules in
+`../references/gap-workflow.md`.
 
-These rules remain mandatory:
+These code-issue rules remain mandatory:
 
-- If no scope is provided, stop and ask for the package or folder.
-- Before checking, reading, creating, or updating the scoped `ISSUES.md`
-  ledger, ensure the consuming repository root `.gitignore` exists and contains
-  `ISSUES.md` as a standalone pattern. If the pattern is missing, add it.
-- Use `ISSUES.md` in the requested package or folder as the review ledger, for example `PACKAGE_OR_FOLDER/ISSUES.md`.
-- If `ISSUES.md` already exists in the requested package or folder, stop. Tell the user the existing scoped ledger must be resolved first, or the human must delete that scoped `ISSUES.md` before a new find pass there.
-- Treat `Find $code-issues in PACKAGE_OR_FOLDER` or `Find code issues in PACKAGE_OR_FOLDER` as the user's explicit request to delegate review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
-- Use sub-agents for Find mode whenever the active runtime provides them and runtime policy/tooling permits delegation. Do not treat sub-agents as optional based on scope size, and do not perform the find review locally first.
-- Do not claim that extra delegation wording is needed before launching review agents. The Find mode invocation is the explicit delegation request.
-- If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
-- Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, or other non-read-only validation.
-- Exclude generated files and folders, vendored dependencies, caches, build output, and generated lockfile churn unless the requested scope is explicitly about them.
-- In downstream repositories that vendor this project as `./bin`, treat
-  `bin/**` as vendored shared tooling unless the requested scope is explicitly
-  about shared `bin` tooling, Makefile includes, skills, or submodule wiring.
-  Exclude `bin/**` from recursive review and inventory by default; inspect only
-  included `bin/build/make/*.mak` fragments or selected `bin/skills/**`
-  guidance needed as evidence. Route upstream-only shared-tooling findings to a
-  separate `bin`-scoped run instead of writing them into the consuming
-  repository's `ISSUES.md`.
-- Before assigning review agents, build a recursive scope inventory for the requested package or folder: relevant file count, first-level subfolders, nested packages, dominant languages, tests, public entrypoints, generated/vendor/build/cache exclusions, and security-sensitive surfaces.
-- Do not assign broad recursive subtrees merely because they are first-level subfolders. When a subtree contains many independent nested packages, mixed responsibilities, or too many relevant files for a credible single pass, split it into smaller behavior-owned slices before delegation.
+- Use `ISSUES.md` in the requested package or folder as the review ledger, for
+  example `PACKAGE_OR_FOLDER/ISSUES.md`.
 - Prefer slices based on repository-owned behavior and risk: public commands/APIs, changed or recently touched areas, auth/network/filesystem/process boundaries, config/CI/release paths, documented workflows, and nearby tests. Use depth only as a discovery aid, not as the review boundary.
-- If the requested scope is too broad to review credibly in one pass, review the highest-risk slices first and record explicit coverage: reviewed deeply, skimmed, excluded, and deferred.
-- Do not present a broad requested scope as fully reviewed when any relevant slice was only skimmed or deferred. Name those slices in the final coverage notes and provide runnable follow-up scopes for deferred review.
 - Each assigned agent owns recursive review only within its bounded slice. Each agent must perform a thorough and accurate `$code-review` and `$security-audit` for that slice, using `$testing-standards` for concrete missing-coverage or weak-test analysis and `$change-validation` for likely validation commands.
-- Require each agent to return findings in the same shape as the `ISSUES.md` format, without final IDs unless useful locally.
-- Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity and confidence.
 - Confirm each candidate finding against the code before recording it. Findings must be concrete bugs, security issues, compatibility breaks, or violated public contracts with user-visible impact.
-- For reusable library, helper, or shared-tooling scopes, inspect supported
-  usage evidence before recording a high-confidence issue: a real consumer,
-  executable example, integration test, module wiring path, documented
-  contract, CI workflow, or comparable usage path that can trigger the
-  candidate. Treat package-local fakes, synthetic tests, manual construction,
-  and unsupported downstream patterns as leads only.
 - Treat provider-to-public-contract adapters, lookup tables, data enrichment,
   normalization maps, embedded assets, vendored static data, and generated
   schema/value translations as high-risk review slices when they affect API
@@ -89,10 +57,6 @@ These rules remain mandatory:
 - Do not record standalone missing, weak, flaky, misleading, or wrong-layer tests as code issues unless they are tied to a confirmed bug, security issue, compatibility break, or violated public contract. Use `$test-gaps` for standalone missing or weak test coverage passes.
 - Do not record standalone missing, weak, stale, misleading, or wrong-location documentation, README, example, comment, or docstring gaps as code issues unless they reveal a confirmed bug, security issue, compatibility break, or violated public contract. Use `$doc-gaps` for standalone documentation review passes.
 - Do not report optional regression tests, unused convenience aliases, API symmetry, or documentation polish as findings by themselves. List them only as testing gaps, doc gaps, or optional follow-up notes when relevant.
-- If no confirmed code issues are found, report that no code issues were found and do not create `ISSUES.md`.
-- If confirmed code issues are found, write all findings to the scoped `ISSUES.md` before making any fixes.
-- Assign every finding a unique ID for the session in the form `ISSUE-N`.
-- Stop after presenting the ledger and plan. Do not fix findings in the same pass.
 
 ## `ISSUES.md` Format
 
@@ -122,40 +86,20 @@ Keep optional follow-up notes separate from findings:
 
 ## Implement Mode
 
-Follow `references/plan.md#implement-mode-plan`.
+Follow `references/plan.md#implement-mode-plan` and the implementation rules in
+`../references/gap-workflow.md`.
 
-These rules remain mandatory:
+These code-issue implementation rules remain mandatory:
 
-- If no scope is provided, stop and ask for the package or folder.
-- Before checking, reading, creating, or updating the scoped `ISSUES.md`
-  ledger, ensure the consuming repository root `.gitignore` exists and contains
-  `ISSUES.md` as a standalone pattern. If the pattern is missing, add it.
-- Read `ISSUES.md` in the requested package or folder first and treat it as the working review ledger.
-- If scoped `ISSUES.md` does not exist, stop and ask whether to run Find mode first for that scope.
-- Work through code issues sequentially by ID unless the human explicitly names a different issue.
-- Stop after proposing the solution. Do not edit code, update `ISSUES.md`, or
-  start validation until the human explicitly agrees to that issue's solution.
-- Treat a request that names an issue and asks to fix, implement, or verify it
-  as permission to select that issue, re-check current evidence, and present or
-  refresh the proposal. It is not approval to edit unless the request also
-  explicitly agrees to the proposed solution. If the proposal was already
-  presented and remains unchanged after re-checking, state only the concise
-  approval gate instead of repeating the full proposal.
 - Ask questions when behavior, compatibility, security, validation, or user intent is ambiguous. Treat silence or a broad "implement code issues" request as permission to start the proposal workflow, not as permission to code.
 - When re-checking an issue whose evidence depends on documentation or comments contradicting implementation, prove the code is wrong before proposing a code change. If non-prose evidence supports the implementation, explain that the ledger item is invalid as a code issue and propose reclassifying or fixing the documentation instead.
 - After the human agrees and before editing, state the selected local code pattern, dominant relevant test harness, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
-- Implement only the agreed issue with the smallest safe change.
 - Use `$testing-standards` when deciding whether to add or update regression tests for the fix, and prefer its test-first or scenario-first loop when a behavior-changing fix has a credible test or BDD layer.
-- During automatic continuations while waiting for approval or `ISSUE-N is
-  done`, do not repeat the full proposal or result. State the current waiting
-  gate once, concisely.
-- Do not move to the next issue until the human says `ISSUE-N is done`.
-- After the human confirms an issue is done, remove that issue from scoped `ISSUES.md`. If an issue is deemed invalid or not actually a code issue, remove it only after explaining why and getting human agreement.
-- Once all findings are resolved and confirmed done by the human, delete the scoped `ISSUES.md`.
 
 ## References
 
 - Read `references/plan.md` before starting Find mode or Implement mode.
+- Read `../references/gap-workflow.md` for shared scoped-ledger, delegation, coverage, confidence, and approval gates.
 - Use `../references/finding-severity.md` for confidence filtering, confidence labels, and severity.
 - Use `$code-review` for review rigor and finding quality.
 - Use `$security-audit` for security-sensitive review scope.

--- a/skills/code-issues/agents/openai.yaml
+++ b/skills/code-issues/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Code Issues"
   short_description: "Find scoped code defects and risks"
-  default_prompt: "Use $code-issues with its active goal and plan to delegate scoped code issue finding, exclude downstream bin/** unless explicitly scoped to shared tooling, store confirmed findings in that scope's ISSUES.md, answer issue ID follow-ups such as ISSUE-1, or propose and implement explicitly agreed fixes one code issue at a time."
+  default_prompt: "Use $code-issues with its active goal, plan, and shared gap workflow to delegate scoped code issue finding, exclude downstream bin/** unless explicitly scoped to shared tooling, store confirmed findings in that scope's ISSUES.md, answer issue ID follow-ups such as ISSUE-1, or propose and implement explicitly agreed fixes one code issue at a time."

--- a/skills/code-issues/references/plan.md
+++ b/skills/code-issues/references/plan.md
@@ -1,54 +1,12 @@
 # Code Issues Plan
 
-Use this reference to instantiate the active execution plan for `$code-issues`.
-The active plan is runtime state. Do not write it into the repository unless the
-human explicitly asks for a durable plan file. In downstream repositories that
-vendor this project as `./bin`, instantiate the plan from the consuming
-repository root and keep `bin/` as shared guidance.
+Use this reference to instantiate the code-issue-specific active plan for
+`$code-issues`. Read it with the shared gap workflow named in `SKILL.md`; that
+workflow owns common plan state, goal state, scoped-ledger, delegation,
+coverage, and implementation gates.
 
-## Plan State Rules
-
-- Keep exactly one active phase in progress at a time.
-- Preserve stop gates as plan boundaries; do not continue past a stop gate based
-  on silence or a broad request.
-- Update the active plan when scope, validation, delegation, or ledger state
-  changes.
-- Treat validation as stale when files change after a command ran.
-- Before checking, reading, creating, or updating the scoped `ISSUES.md`
-  ledger, ensure the consuming repository root `.gitignore` exists and contains
-  `ISSUES.md` as a standalone pattern. If the pattern is missing, add it.
-- Record durable findings only in the scoped `ISSUES.md` ledger defined by the
-  skill.
-- In downstream repositories that vendor this project as `./bin`, exclude
-  `bin/**` from recursive inventory, review slices, and durable findings unless
-  the requested scope is explicitly about shared `bin` tooling. Inspect only
-  included shared fragments or selected skill guidance needed as evidence, and
-  route upstream-only findings to a separate `bin`-scoped run.
-- Track broad-scope coverage explicitly as reviewed deeply, skimmed, excluded,
-  and deferred. Deferred entries must name runnable follow-up scopes.
-
-## Goal State Rules
-
-- Bind the active goal to the selected mode and requested scope.
-- In Find mode, the goal is complete when no confirmed code issues are found and
-  reported, or when the scoped `ISSUES.md` ledger is written and presented.
-- For broad scopes, a no-issue result is complete only when the summary states
-  whether all high-risk slices were deeply reviewed. If any relevant slice was
-  skimmed or deferred, completion requires coverage notes and runnable
-  follow-up scopes, not an unqualified all-scope no-issue claim.
-- In Implement mode, the goal is waiting while the human has not approved the
-  proposed issue solution, or after validation until the human confirms
-  `ISSUE-<number> is done`.
-- During automatic continuations while waiting for approval or done
-  confirmation, state the waiting gate once and do not repeat the full
-  proposal or result.
-- In Implement mode, the goal is complete for an issue only after the human
-  confirms it is done and the scoped ledger is updated accordingly.
-- Record a blocked reason when a required scope is missing, the scoped ledger
-  required by the mode is absent or already exists in a conflicting state,
-  required permission is denied, or the selected issue cannot be re-checked
-  without human input. Follow runtime rules for when that reason changes goal
-  status.
+Track code-issue-specific state for scope, validation, delegation, ledger
+state, code/security/compatibility evidence, and public contract evidence.
 
 ## Find Mode Plan
 

--- a/skills/doc-gaps/SKILL.md
+++ b/skills/doc-gaps/SKILL.md
@@ -11,12 +11,9 @@ Use this skill in one-pass mode by default:
 - **Audit-only mode**: `Audit-only $doc-gaps in PACKAGE_OR_FOLDER` or `Find doc gaps in PACKAGE_OR_FOLDER without editing`.
 
 Before starting one-pass mode or audit-only mode, read `references/plan.md` and
-use it to maintain the active execution plan. The active plan is runtime state;
-do not write it into the repository unless the human explicitly asks for a
-durable plan file.
-When the runtime supports goals, bind the selected mode and requested scope to
-one active goal and update that goal as delegation, edit, validation, summary,
-or unresolved-ledger state changes.
+`../references/gap-workflow.md`. The plan owns active runtime state; the shared
+gap workflow owns ledger, delegation, scope, coverage, confidence, and approval
+gates.
 
 ## Operating Stance
 
@@ -34,47 +31,22 @@ the repository implements.
 
 ## One-Pass Mode
 
-Follow `references/plan.md#one-pass-mode-plan`.
+Follow `references/plan.md#one-pass-mode-plan` and the find/audit rules in
+`../references/gap-workflow.md`.
 
-These rules remain mandatory:
+These doc-gap rules remain mandatory:
 
-- If no scope is provided, stop and ask for the package or folder.
 - Treat `Run $doc-gaps in PACKAGE_OR_FOLDER`, `Find doc gaps in PACKAGE_OR_FOLDER`, or `Fix doc gaps in PACKAGE_OR_FOLDER` as permission to delegate review, edit documentation in scope, run appropriate validation, and summarize the result in one pass.
 - Use audit-only mode only when the user explicitly asks not to edit or asks only for an audit or ledger. When a stop gate prevents a correct documentation fix during one-pass mode, record unresolved confirmed findings instead of switching modes.
-- Before checking, reading, creating, or updating the scoped `DOCS.md` ledger,
-  ensure the consuming repository root `.gitignore` exists and contains
-  `DOCS.md` as a standalone pattern. If the pattern is missing, add it.
+- Use `DOCS.md` in the requested package or folder as the scoped ledger.
 - If scoped `DOCS.md` already exists, read it before reviewing. If it is a doc-gap ledger, include unresolved findings in the candidate set and update or delete the ledger after fixing them. If it is unrelated or ambiguous active work, stop and ask before editing it.
 - Use as many independent review agents as the runtime can safely run when the active runtime provides sub-agents and runtime policy/tooling permits delegation. Do not perform the doc-gap review locally first when delegation is available.
-- Treat the doc-gap invocation as the user's explicit request to delegate documentation review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
-- If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
-- Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, or other non-read-only validation.
-- Exclude generated files and folders, vendored dependencies, caches, build output, generated API docs, and generated lockfile churn unless the requested scope is explicitly about them.
-- In downstream repositories that vendor this project as `./bin`, treat
-  `bin/**` as vendored shared tooling unless the requested scope is explicitly
-  about shared `bin` tooling, Makefile includes, skills, or submodule wiring.
-  Exclude `bin/**` from recursive review and inventory by default; inspect only
-  included `bin/build/make/*.mak` fragments or selected `bin/skills/**`
-  guidance needed as evidence. Route upstream-only shared-tooling findings to a
-  separate `bin`-scoped run instead of writing them into the consuming
-  repository's `DOCS.md`.
 - Before assigning review agents, build a recursive documentation inventory for the requested package or folder: README files, docs, examples, command help surfaces, package docs, public API comments, code-comment/docstring surfaces, first-level subfolders, nested packages, generated/vendor/build/cache exclusions, and relevant validation entrypoints.
-- Do not assign broad recursive subtrees merely because they are first-level subfolders. When a subtree contains many independent documentation owners, mixed audiences, or too many relevant files for a credible single pass, split it into smaller documentation-surface or behavior-owned slices before delegation.
 - Prefer slices based on authoritative documentation owner and user risk: README or user docs, command help, examples, public API/package docs, documented workflows, changed or recently touched areas, and code areas with public interfaces. Use depth only as a discovery aid, not as the review boundary.
-- If the requested scope is too broad to review credibly in one pass, review the highest-risk slices first and record explicit coverage: reviewed deeply, skimmed, excluded, and deferred.
-- Do not present a broad requested scope as fully reviewed when any relevant slice was only skimmed or deferred. Name those slices in the final coverage notes and provide runnable follow-up scopes for deferred review.
 - Each assigned agent owns recursive review only within its bounded slice. Each agent must perform a thorough documentation review for that slice, pairing with `$doc-standards`, relevant language standards, `$naming-standards` when terminology is unclear or inconsistent, and `$change-validation` for likely validation commands.
 - Each agent must audit the relevant documentation surfaces before returning candidates: README files, docs, examples, command help, package documentation, exported API comments, code comments, and docstrings. For each candidate, apply `$doc-standards`' adequacy gate by identifying the public surface, intended audience, user action or maintenance decision at risk, existing documentation surface, correct target surface, minimum successful example or command, and missing non-obvious contract.
 - Require each agent to return candidates in the candidate format below, without final IDs unless useful locally.
-- Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity and confidence.
 - Confirm each candidate gap against the code, current docs, examples, and documented interfaces before fixing it, using `$doc-standards` as the finding threshold. Do not confirm or dismiss a candidate merely because documentation exists; verify adequacy, ownership, discoverability, example coverage, and the relevant non-obvious contract.
-- For reusable library, helper, or shared-tooling scopes, inspect supported
-  usage evidence before treating a documentation gap as high confidence: a real
-  consumer, executable example, integration test, module wiring path,
-  documented contract, CI workflow, or comparable usage path showing the
-  audience and action at risk. Treat package-local fakes, synthetic tests,
-  manual construction, and unsupported downstream patterns as leads only.
-- When prose and implementation disagree, require non-prose evidence before treating the code as wrong or routing the candidate out to another workflow. If code, tests, runtime behavior, generated contracts, or history support the implementation, fix the stale prose as a doc gap.
 - Before fixing or dismissing a candidate, route it to the correct documentation surface: README, docs, examples, command help, package documentation, exported API comment, code comment, docstring, or no change. Do not treat package GoDoc or code-comment improvements as sufficient when first-use, setup, configuration, operational behavior, security expectations, or service-author workflows would reasonably be expected in README files, user-facing docs, examples, or command help. Do not treat README prose as sufficient when `$doc-standards` and the paired language standard route reusable API contracts to GoDoc, RDoc, docstrings, executable examples, specs, or features.
 - When dismissing a candidate because existing documentation is sufficient, identify the existing surface that covers the audience and action at risk in the final summary, and state why that surface is the authoritative owner under `$doc-standards`.
 - Do not fix candidates that `$doc-standards` routes to `$code-review`, `$code-issues`, `$security-audit`, `$testing-standards`, or `$test-gaps`. Report those as out of scope when relevant.
@@ -84,25 +56,19 @@ These rules remain mandatory:
 - Stop and ask before editing when behavior, audience, documentation location, public-contract wording, examples, validation, or user intent is ambiguous enough that a correct documentation change cannot be inferred from local context.
 - Write unresolved confirmed findings to the scoped `DOCS.md` only when they cannot be fixed in the same pass, the user requested audit-only mode, validation or permission is blocked, or the scope is too large to complete.
 - Validate documentation changes with commands appropriate to the changed files.
-- If no confirmed doc gaps are found, report that no doc gaps were found and do not create `DOCS.md`.
 - If all confirmed doc gaps are fixed, do not leave a new `DOCS.md` behind. If an existing doc-gap ledger is fully resolved, delete it.
 - Final output must summarize fixed gaps, dismissed or out-of-scope candidates when relevant, broad-scope coverage notes when the requested scope was too broad for complete deep review, unresolved findings written to `DOCS.md` if any, and validation results.
 
 ## Audit-Only Mode
 
-Follow `references/plan.md#audit-only-mode-plan`.
+Follow `references/plan.md#audit-only-mode-plan` and the find/audit rules in
+`../references/gap-workflow.md`.
 
 These rules remain mandatory:
 
-- If no scope is provided, stop and ask for the package or folder.
-- Before checking, reading, creating, or updating the scoped `DOCS.md` ledger,
-  ensure the consuming repository root `.gitignore` exists and contains
-  `DOCS.md` as a standalone pattern. If the pattern is missing, add it.
 - Use `DOCS.md` in the requested package or folder as the audit ledger, for example `PACKAGE_OR_FOLDER/DOCS.md`.
 - If `DOCS.md` already exists in the requested package or folder, stop unless the human explicitly asked to refresh or overwrite that scoped ledger.
 - Use the same delegation, surface-routing, candidate confirmation, severity, and out-of-scope rules as one-pass mode.
-- If no confirmed doc gaps are found, report that no doc gaps were found and do not create `DOCS.md`.
-- If confirmed doc gaps are found, write all findings to the scoped `DOCS.md` with `DOC-N` IDs.
 - Stop after presenting the audit ledger. Do not make fixes in audit-only mode.
 
 ## Documentation Review Standards
@@ -153,6 +119,7 @@ Keep optional follow-up notes separate from findings:
 ## References
 
 - Read `references/plan.md` before starting one-pass mode or audit-only mode.
+- Read `../references/gap-workflow.md` for shared scoped-ledger, delegation, coverage, confidence, and approval gates.
 - Use `$doc-standards` as the documentation quality bar and routing threshold.
 - Use `../references/finding-severity.md` for confidence filtering, confidence labels, and severity.
 - Use `$project-workflow` for repository command discovery, documented entrypoints, CI expectations, examples, and `./bin` wiring before review planning or validation.

--- a/skills/doc-gaps/agents/openai.yaml
+++ b/skills/doc-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Doc Gaps"
   short_description: "Find and fix scoped doc adequacy gaps"
-  default_prompt: "Use $doc-gaps with its active goal and plan plus $doc-standards to run a one-pass scoped documentation gap workflow, exclude downstream bin/** unless explicitly scoped to shared tooling, answer doc gap ID follow-ups such as DOC-1, apply confirmed doc fixes, validate, and write DOCS.md only for audit-only requests or unresolved gaps."
+  default_prompt: "Use $doc-gaps with its active goal, plan, shared gap workflow, and $doc-standards to run a one-pass scoped documentation gap workflow, exclude downstream bin/** unless explicitly scoped to shared tooling, answer doc gap ID follow-ups such as DOC-1, apply confirmed doc fixes, validate, and write DOCS.md only for audit-only requests or unresolved gaps."

--- a/skills/doc-gaps/references/plan.md
+++ b/skills/doc-gaps/references/plan.md
@@ -1,48 +1,13 @@
 # Doc Gaps Plan
 
-Use this reference to instantiate the active execution plan for `$doc-gaps`.
-The active plan is runtime state. Do not write it into the repository unless the
-human explicitly asks for a durable plan file. In downstream repositories that
-vendor this project as `./bin`, instantiate the plan from the consuming
-repository root and keep `bin/` as shared guidance.
+Use this reference to instantiate the doc-gap-specific active plan for
+`$doc-gaps`. Read it with the shared gap workflow named in `SKILL.md`; that
+workflow owns common plan state, goal state, scoped-ledger, delegation,
+coverage, and implementation gates.
 
-## Plan State Rules
-
-- Keep exactly one active phase in progress at a time.
-- Preserve stop gates as plan boundaries; do not continue past a stop gate based
-  on silence or a broad request.
-- Update the active plan when scope, documentation location, validation,
-  delegation, edits, summary, or unresolved ledger state changes.
-- Treat validation as stale when files change after a command ran.
-- Before checking, reading, creating, or updating the scoped `DOCS.md` ledger,
-  ensure the consuming repository root `.gitignore` exists and contains
-  `DOCS.md` as a standalone pattern. If the pattern is missing, add it.
-- Use a scoped `DOCS.md` ledger only for audit-only mode, unresolved confirmed
-  gaps, or an existing doc-gap ledger being completed.
-- In downstream repositories that vendor this project as `./bin`, exclude
-  `bin/**` from recursive inventory, review slices, edits, and durable findings
-  unless the requested scope is explicitly about shared `bin` tooling. Inspect
-  only included shared fragments or selected skill guidance needed as evidence,
-  and route upstream-only findings to a separate `bin`-scoped run.
-- Track broad-scope coverage explicitly as reviewed deeply, skimmed, excluded,
-  and deferred. Deferred entries must name runnable follow-up scopes.
-
-## Goal State Rules
-
-- Bind the active goal to the selected mode and requested scope.
-- In one-pass mode, the goal is complete when confirmed gaps are fixed and
-  validated, no confirmed gaps are found and reported, or unresolved findings
-  are recorded because a stop gate prevents a correct fix.
-- In audit-only mode, the goal is complete when no confirmed doc gaps are found
-  and reported, or when the scoped `DOCS.md` ledger is written and presented.
-- For broad scopes, a no-gap result is complete only when the summary states
-  whether all high-risk slices were deeply reviewed. If any relevant slice was
-  skimmed or deferred, completion requires coverage notes and runnable
-  follow-up scopes, not an unqualified all-scope no-gap claim.
-- Record a blocked reason when a required scope is missing, required permission
-  is denied, an existing scoped ledger is unrelated or ambiguous, or a selected
-  finding cannot be fixed or recorded without human input. Follow runtime rules
-  for when that reason changes goal status.
+Track doc-gap-specific state for scope, documentation location, validation,
+delegation, edits, summary, unresolved ledger state, audience, and public
+documentation surface.
 
 ## One-Pass Mode Plan
 

--- a/skills/feature-gaps/SKILL.md
+++ b/skills/feature-gaps/SKILL.md
@@ -12,13 +12,10 @@ Use this skill in two distinct modes:
 
 Do not combine the two modes in one pass.
 
-Before starting Find mode or Implement mode, read `references/plan.md` and use
-it to maintain the active execution plan. The active plan is runtime state; do
-not write it into the repository unless the human explicitly asks for a durable
-plan file.
-When the runtime supports goals, bind the selected mode and requested scope to
-one active goal and update that goal as ledger, proposal, approval, validation,
-or human-confirmation state changes.
+Before starting Find mode or Implement mode, read `references/plan.md` and
+`../references/gap-workflow.md`. The plan owns active runtime state; the shared
+gap workflow owns ledger, delegation, scope, coverage, confidence, and approval
+gates.
 
 ## Operating Stance
 
@@ -113,68 +110,25 @@ outcome.
 
 ## Find Mode
 
-Follow `references/plan.md#find-mode-plan`.
+Follow `references/plan.md#find-mode-plan` and the find/audit rules in
+`../references/gap-workflow.md`.
 
-These rules remain mandatory:
+These feature-gap rules remain mandatory:
 
-- If no scope is provided, stop and ask for the package or folder.
-- Before checking, reading, creating, or updating the scoped `FEATURES.md`
-  ledger, ensure the consuming repository root `.gitignore` exists and contains
-  `FEATURES.md` as a standalone pattern. If the pattern is missing, add it.
 - Use `FEATURES.md` in the requested package or folder as the proposal ledger,
   for example `PACKAGE_OR_FOLDER/FEATURES.md`.
-- If `FEATURES.md` already exists in the requested package or folder, stop.
-  Tell the user the existing scoped feature ledger must be resolved first, or
-  the human must delete that scoped `FEATURES.md` before a new find pass there.
-- Treat `Find $feature-gaps in PACKAGE_OR_FOLDER` or `Find feature gaps in
-  PACKAGE_OR_FOLDER` as the user's explicit request to delegate feature-gap
-  discovery for that scope. Do not require the user to separately say "use
-  sub-agents", "spawn agents", or "delegate".
-- Use sub-agents for Find mode whenever the active runtime provides them and
-  runtime policy/tooling permits delegation. Do not treat sub-agents as
-  optional based on scope size, and do not perform the feature-gap review
-  locally first.
-- Do not claim that extra delegation wording is needed before launching review
-  agents. The Find mode invocation is the explicit delegation request.
-- If delegation is denied, stop instead of falling back to a local review. If
-  sub-agents are unavailable, say so briefly and perform the review locally for
-  the requested scope.
-- Ask for human permission before agents run commands that require approval,
-  such as network, SSH, GitHub auth, registry auth, remote writes, cloning,
-  destructive operations, or non-read-only validation.
-- Exclude generated files and folders, vendored dependencies, caches, build
-  output, generated API docs, and generated lockfile churn unless the requested
-  scope is explicitly about them.
-- In downstream repositories that vendor this project as `./bin`, treat
-  `bin/**` as vendored shared tooling unless the requested scope is explicitly
-  about shared `bin` tooling, Makefile includes, skills, or submodule wiring.
-  Exclude `bin/**` from recursive review and inventory by default; inspect only
-  included `bin/build/make/*.mak` fragments or selected `bin/skills/**`
-  guidance needed as evidence. Route upstream-only shared-tooling findings to a
-  separate `bin`-scoped run instead of writing them into the consuming
-  repository's `FEATURES.md`.
 - Before assigning review agents, build a recursive scope inventory for the
   requested package or folder: relevant file count, first-level subfolders,
   nested packages, dominant languages, tests, public entrypoints, generated,
   vendor, build, and cache exclusions, user-facing product surfaces,
   package-consumer or service-author surfaces, operator-facing surfaces, docs,
   examples, command help, and likely product extension points.
-- Do not assign broad recursive subtrees merely because they are first-level
-  subfolders. When a subtree contains many independent products, packages,
-  workflows, or audiences, split it into smaller behavior-owned or
-  audience-owned slices before delegation.
 - Prefer slices based on repository-owned feature surface and user value:
   public commands/APIs, library or service behavior, package-consumer and
   service-author workflows, documented product examples, product onboarding
   paths, integrations, extension points, changed or recently touched product
   areas, and nearby tests. Use depth only as a discovery aid, not as the review
   boundary.
-- If the requested scope is too broad to review credibly in one pass, review
-  the highest-value slices first and record explicit coverage: reviewed deeply,
-  skimmed, excluded, and deferred.
-- Do not present a broad requested scope as fully reviewed when any relevant
-  slice was only skimmed or deferred. Name those slices in the final coverage
-  notes and provide runnable follow-up scopes for deferred review.
 - Each assigned agent owns recursive review only within its bounded slice. Each
   agent must perform feature-gap discovery for that slice, pairing with
   `$project-workflow`, `$doc-standards`, `$naming-standards`, relevant language
@@ -183,8 +137,6 @@ These rules remain mandatory:
   and `$project-workflow` to route test-harness, build, CI, Makefile, release,
   validation, command-discovery, or repository-workflow candidates away from
   `FEATURES.md` before returning feature proposals.
-- Require each agent to return proposals in the same shape as the `FEATURES.md`
-  format, without final IDs unless useful locally.
 - Confirm each candidate feature against the acceptance gate, code, generated
   surfaces, framework wrappers, shared helpers, vendored dependency behavior
   when delegated, docs, tests, examples, command behavior, current
@@ -193,12 +145,6 @@ These rules remain mandatory:
   supported, whether the repository owns the behavior, whether the likely
   audience exists, and whether the feature can be added incrementally using
   local patterns.
-- For reusable library, helper, or shared-tooling scopes, inspect supported
-  usage evidence before recording a high-confidence feature gap: a real
-  consumer, executable example, integration test, module wiring path,
-  documented contract, CI workflow, or comparable usage path that shows the
-  current limitation and audience benefit. Treat package-local fakes, synthetic
-  tests, manual construction, and unsupported downstream patterns as leads only.
 - Record feature gaps only when the proposal names the audience, current
   product workflow limitation, practical audience benefit, repository-owned
   product surface, evidence of user, operator, service-author, package-consumer,
@@ -224,13 +170,6 @@ These rules remain mandatory:
 - If a candidate would mostly require CI, build, Makefile, release, validation
   preflight, command discovery, setup, or repository workflow changes, route it
   to `$project-gaps` instead of recording it here.
-- If no confirmed feature gaps are found, report that no feature gaps were
-  found and do not create `FEATURES.md`.
-- If confirmed feature gaps are found, write all proposals to the scoped
-  `FEATURES.md` before making any changes.
-- Assign every proposal a unique ID for the session in the form `FEATURE-N`.
-- Stop after presenting the ledger and plan. Do not implement proposals in the
-  same pass.
 
 ## `FEATURES.md` Format
 
@@ -303,35 +242,17 @@ and a plausible implementation path.
 
 ## Implement Mode
 
-Follow `references/plan.md#implement-mode-plan`.
+Follow `references/plan.md#implement-mode-plan` and the implementation rules in
+`../references/gap-workflow.md`.
 
-These rules remain mandatory:
+These feature implementation rules remain mandatory:
 
-- If no scope is provided, stop and ask for the package or folder.
-- Before checking, reading, creating, or updating the scoped `FEATURES.md`
-  ledger, ensure the consuming repository root `.gitignore` exists and contains
-  `FEATURES.md` as a standalone pattern. If the pattern is missing, add it.
-- Read `FEATURES.md` in the requested package or folder first and treat it as
-  the working feature ledger.
-- If scoped `FEATURES.md` does not exist, stop and ask whether to run Find mode
-  first for that scope.
-- Work through feature proposals sequentially by ID unless the human explicitly
-  names a different proposal.
 - Before proposing an implementation for each feature, re-check the current
   code, generated surfaces, framework wrappers, shared helpers, vendored
   dependency behavior when delegated, docs, tests, examples, command behavior,
   and comparable-tool evidence. Treat the ledger as something that can go
   stale: dismiss or revise proposals that are already supported, duplicate
   another feature, no longer fit the repository, or belong in another workflow.
-- Stop after proposing the solution. Do not edit files, update `FEATURES.md`,
-  or start validation until the human explicitly agrees to that feature's
-  solution.
-- Treat a request that names a feature and asks to fix, implement, or verify it
-  as permission to select that feature, re-check current evidence, and present
-  or refresh the proposal. It is not approval to edit unless the request also
-  explicitly agrees to the proposed solution. If the proposal was already
-  presented and remains unchanged after re-checking, state only the concise
-  approval gate instead of repeating the full proposal.
 - Ask questions when audience, product direction, compatibility, dependency
   policy, UX/DX behavior, test layer, validation, or user intent is ambiguous.
   Treat silence or a broad "implement feature gaps" request as permission to
@@ -359,19 +280,11 @@ These rules remain mandatory:
 - Report the result for that feature with `Red`, `Green`, `Refactor`, and
   `Validation` entries. Use `Refactor: none` when no cleanup was needed after
   green. Then ask the human to verify and explicitly say `FEATURE-N is done`.
-- During automatic continuations while waiting for approval or `FEATURE-N is
-  done`, do not repeat the full proposal or result. State the current waiting
-  gate once, concisely.
-- Do not move to the next proposal until the human says `FEATURE-N is done`.
-- After the human confirms a proposal is done, remove that proposal from scoped
-  `FEATURES.md`. If a proposal is deemed invalid or not actually a feature gap,
-  remove it only after explaining why and getting human agreement.
-- Once all proposals are resolved and confirmed done by the human, delete the
-  scoped `FEATURES.md`.
 
 ## References
 
 - Read `references/plan.md` before starting Find mode or Implement mode.
+- Read `../references/gap-workflow.md` for shared scoped-ledger, delegation, coverage, confidence, and approval gates.
 - Use `$project-workflow` for repository command discovery, documented
   entrypoints, CI expectations, examples, and `./bin` wiring before review
   planning or validation, and route standalone project workflow gaps to

--- a/skills/feature-gaps/agents/openai.yaml
+++ b/skills/feature-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Feature Gaps"
   short_description: "Find product feature opportunities"
-  default_prompt: "Use $feature-gaps to find scoped main product capability gaps with explicit audience benefit, exclude downstream bin/** unless explicitly scoped to shared tooling, store confirmed proposals in FEATURES.md, answer feature ID follow-ups such as FEATURE-1, or propose and implement explicitly agreed product feature changes one at a time; route test and project workflow gaps to their own skills."
+  default_prompt: "Use $feature-gaps with its shared gap workflow to find scoped main product capability gaps with explicit audience benefit, exclude downstream bin/** unless explicitly scoped to shared tooling, store confirmed proposals in FEATURES.md, answer feature ID follow-ups such as FEATURE-1, or propose and implement explicitly agreed product feature changes one at a time; route test and project workflow gaps to their own skills."

--- a/skills/feature-gaps/references/plan.md
+++ b/skills/feature-gaps/references/plan.md
@@ -1,55 +1,12 @@
 # Feature Gaps Plan
 
-Use this reference to instantiate the active execution plan for
-`$feature-gaps`. The active plan is runtime state. Do not write it into the
-repository unless the human explicitly asks for a durable plan file. In
-downstream repositories that vendor this project as `./bin`, instantiate the
-plan from the consuming repository root and keep `bin/` as shared guidance.
+Use this reference to instantiate the feature-gap-specific active plan for
+`$feature-gaps`. Read it with the shared gap workflow named in `SKILL.md`; that
+workflow owns common plan state, goal state, scoped-ledger, delegation,
+coverage, and implementation gates.
 
-## Plan State Rules
-
-- Keep exactly one active phase in progress at a time.
-- Preserve stop gates as plan boundaries; do not continue past a stop gate
-  based on silence or a broad request.
-- Update the active plan when scope, audience, product surface, validation,
-  delegation, external research, or ledger state changes.
-- Treat validation as stale when files change after a command ran.
-- Before checking, reading, creating, or updating the scoped `FEATURES.md`
-  ledger, ensure the consuming repository root `.gitignore` exists and contains
-  `FEATURES.md` as a standalone pattern. If the pattern is missing, add it.
-- Record durable feature proposals only in the scoped `FEATURES.md` ledger
-  defined by the skill.
-- In downstream repositories that vendor this project as `./bin`, exclude
-  `bin/**` from recursive inventory, review slices, and durable proposals unless
-  the requested scope is explicitly about shared `bin` tooling. Inspect only
-  included shared fragments or selected skill guidance needed as evidence, and
-  route upstream-only proposals to a separate `bin`-scoped run.
-- Track broad-scope coverage explicitly as reviewed deeply, skimmed, excluded,
-  and deferred. Deferred entries must name runnable follow-up scopes.
-
-## Goal State Rules
-
-- Bind the active goal to the selected mode and requested scope.
-- In Find mode, the goal is complete when no confirmed feature gaps are found
-  and reported, or when the scoped `FEATURES.md` ledger is written and
-  presented.
-- For broad scopes, a no-gap result is complete only when the summary states
-  whether all high-value slices were deeply reviewed. If any relevant slice was
-  skimmed or deferred, completion requires coverage notes and runnable
-  follow-up scopes, not an unqualified all-scope no-gap claim.
-- In Implement mode, the goal is waiting while the human has not approved the
-  proposed feature solution, or after validation until the human confirms
-  `FEATURE-<number> is done`.
-- During automatic continuations while waiting for approval or done
-  confirmation, state the waiting gate once and do not repeat the full
-  proposal or result.
-- In Implement mode, the goal is complete for a proposal only after the human
-  confirms it is done and the scoped ledger is updated accordingly.
-- Record a blocked reason when a required scope is missing, the scoped ledger
-  required by the mode is absent or already exists in a conflicting state,
-  required permission is denied, or the selected feature cannot be re-checked
-  without human input. Follow runtime rules for when that reason changes goal
-  status.
+Track feature-gap-specific state for scope, audience, product surface,
+validation, delegation, external research, ledger state, and workflow routing.
 
 ## Find Mode Plan
 

--- a/skills/project-gaps/SKILL.md
+++ b/skills/project-gaps/SKILL.md
@@ -12,13 +12,10 @@ Use this skill in two distinct modes:
 
 Do not combine the two modes in one pass.
 
-Before starting Find mode or Implement mode, read `references/plan.md` and use
-it to maintain the active execution plan. The active plan is runtime state; do
-not write it into the repository unless the human explicitly asks for a durable
-plan file.
-When the runtime supports goals, bind the selected mode and requested scope to
-one active goal and update that goal as ledger, proposal, approval, validation,
-or human-confirmation state changes.
+Before starting Find mode or Implement mode, read `references/plan.md` and
+`../references/gap-workflow.md`. The plan owns active runtime state; the shared
+gap workflow owns ledger, delegation, scope, coverage, confidence, and approval
+gates.
 
 ## Operating Stance
 
@@ -85,46 +82,13 @@ an imagined future workflow, private implementation preference, or generic
 
 ## Find Mode
 
-Follow `references/plan.md#find-mode-plan`.
+Follow `references/plan.md#find-mode-plan` and the find/audit rules in
+`../references/gap-workflow.md`.
 
-These rules remain mandatory:
+These project-gap rules remain mandatory:
 
-- If no scope is provided, stop and ask for the package or folder.
-- Before checking, reading, creating, or updating the scoped `PROJECTS.md`
-  ledger, ensure the consuming repository root `.gitignore` exists and contains
-  `PROJECTS.md` as a standalone pattern. If the pattern is missing, add it.
 - Use `PROJECTS.md` in the requested package or folder as the proposal ledger,
   for example `PACKAGE_OR_FOLDER/PROJECTS.md`.
-- If `PROJECTS.md` already exists in the requested package or folder, stop.
-  Tell the user the existing scoped project ledger must be resolved first, or
-  the human must delete that scoped `PROJECTS.md` before a new find pass there.
-- Treat `Find $project-gaps in PACKAGE_OR_FOLDER` or `Find project gaps in
-  PACKAGE_OR_FOLDER` as the user's explicit request to delegate project-gap
-  discovery for that scope. Do not require the user to separately say "use
-  sub-agents", "spawn agents", or "delegate".
-- Use sub-agents for Find mode whenever the active runtime provides them and
-  runtime policy/tooling permits delegation. Do not treat sub-agents as
-  optional based on scope size, and do not perform the project-gap review
-  locally first.
-- Do not claim that extra delegation wording is needed before launching review
-  agents. The Find mode invocation is the explicit delegation request.
-- If delegation is denied, stop instead of falling back to a local review. If
-  sub-agents are unavailable, say so briefly and perform the review locally for
-  the requested scope.
-- Ask for human permission before agents run commands that require approval,
-  such as network, SSH, GitHub auth, registry auth, remote writes, cloning,
-  destructive operations, or non-read-only validation.
-- Exclude generated files and folders, vendored dependencies, caches, build
-  output, generated API docs, and generated lockfile churn unless the requested
-  scope is explicitly about them.
-- In downstream repositories that vendor this project as `./bin`, treat
-  `bin/**` as vendored shared tooling unless the requested scope is explicitly
-  about shared `bin` tooling, Makefile includes, skills, or submodule wiring.
-  Exclude `bin/**` from recursive review and inventory by default; inspect only
-  included `bin/build/make/*.mak` fragments or selected `bin/skills/**`
-  guidance needed as evidence. Route upstream-only shared-tooling findings to a
-  separate `bin`-scoped run instead of writing them into the consuming
-  repository's `PROJECTS.md`.
 - Classify every candidate's implementation home before recording it. Use:
   `current repo` when the requested scope owns the fix; `shared bin` when
   reusable `bin` tooling owns the fix; `external repo` when another repository
@@ -137,40 +101,22 @@ These rules remain mandatory:
   validation entrypoints, release/deploy/versioning surfaces, setup flows,
   command discovery surfaces, generated/vendor/build/cache exclusions, tests,
   docs, examples, and likely project workflow extension points.
-- Do not assign broad recursive subtrees merely because they are first-level
-  subfolders. When a subtree contains many independent workflows or audiences,
-  split it into smaller workflow-owned or audience-owned slices before
-  delegation.
 - Prefer slices based on repository-owned project workflow value: Make targets
   and fragments, CI jobs, setup and dependency installation, validation and
   local preflight, release/versioning/publishing paths, reusable scripts,
   command discovery/help entrypoints, downstream `./bin` wiring, and changed or
   recently touched project tooling.
-- If the requested scope is too broad to review credibly in one pass, review
-  the highest-value slices first and record explicit coverage: reviewed deeply,
-  skimmed, excluded, and deferred.
-- Do not present a broad requested scope as fully reviewed when any relevant
-  slice was only skimmed or deferred. Name those slices in the final coverage
-  notes and provide runnable follow-up scopes for deferred review.
 - Each assigned agent owns recursive review only within its bounded slice. Each
   agent must perform project-gap discovery for that slice, pairing with
   `$project-workflow`, `$change-safety`, `$change-validation`, relevant
   language standards, and `$testing-standards` only when needed to route
   test-surface concerns correctly.
-- Require each agent to return proposals in the same shape as the `PROJECTS.md`
-  format, without final IDs unless useful locally.
 - Confirm each candidate project gap against the acceptance gate, repository
   commands, CI config, Makefiles, scripts, docs, tests, examples, and current
   architecture before recording it. Try to disprove the candidate by asking
   whether the workflow is already supported, whether the repository owns the
   surface, whether the likely audience exists, and whether the project change
   can be added incrementally using local patterns.
-- For reusable library, helper, or shared-tooling scopes, inspect supported
-  usage evidence before recording a high-confidence project gap: a real
-  consumer, executable example, integration test, module wiring path,
-  documented contract, CI workflow, or comparable usage path that shows the
-  workflow friction. Treat package-local fakes, synthetic tests, manual
-  construction, and unsupported downstream patterns as leads only.
 - Do not record confirmed bugs, security issues, compatibility breaks,
   reliability gaps, missing tests, stale docs, unclear naming, or main product
   feature ideas as project gaps. Route them to `$code-issues`,
@@ -189,13 +135,6 @@ These rules remain mandatory:
   `Routed Project Follow-Ups` with the owning home and local evidence, or route
   it to a separate project-gaps run in the owning repository or shared tooling
   scope.
-- If no confirmed project gaps are found, report that no project gaps were
-  found and do not create `PROJECTS.md`.
-- If confirmed project gaps are found, write all proposals to the scoped
-  `PROJECTS.md` before making any changes.
-- Assign every proposal a unique ID for the session in the form `PROJECT-N`.
-- Stop after presenting the ledger and plan. Do not implement proposals in the
-  same pass.
 
 ## `PROJECTS.md` Format
 
@@ -263,20 +202,11 @@ evidence, audience, fit, and a plausible implementation path.
 
 ## Implement Mode
 
-Follow `references/plan.md#implement-mode-plan`.
+Follow `references/plan.md#implement-mode-plan` and the implementation rules in
+`../references/gap-workflow.md`.
 
-These rules remain mandatory:
+These project-gap implementation rules remain mandatory:
 
-- If no scope is provided, stop and ask for the package or folder.
-- Before checking, reading, creating, or updating the scoped `PROJECTS.md`
-  ledger, ensure the consuming repository root `.gitignore` exists and contains
-  `PROJECTS.md` as a standalone pattern. If the pattern is missing, add it.
-- Read `PROJECTS.md` in the requested package or folder first and treat it as
-  the working project-gap ledger.
-- If scoped `PROJECTS.md` does not exist, stop and ask whether to run Find mode
-  first for that scope.
-- Work through project proposals sequentially by ID unless the human explicitly
-  names a different proposal.
 - Before proposing an implementation for each project gap, re-check current
   Makefiles, CI config, scripts, docs, tests, examples, command behavior, and
   comparable workflow evidence. Treat the ledger as something that can go
@@ -285,15 +215,6 @@ These rules remain mandatory:
   workflow, or have an implementation home outside the requested scope.
 - If the proposal's implementation home is outside the requested scope, stop
   and propose moving or reclassifying it instead of implementing it locally.
-- Stop after proposing the solution. Do not edit files, update `PROJECTS.md`,
-  or start validation until the human explicitly agrees to that project-gap
-  solution.
-- Treat a request that names a project gap and asks to fix, implement, or verify
-  it as permission to select that project gap, re-check current evidence, and
-  present or refresh the proposal. It is not approval to edit unless the request
-  also explicitly agrees to the proposed solution. If the proposal was already
-  presented and remains unchanged after re-checking, state only the concise
-  approval gate instead of repeating the full proposal.
 - Ask questions when audience, workflow ownership, compatibility, dependency
   policy, validation, or user intent is ambiguous. Treat silence or a broad
   "implement project gaps" request as permission to start the proposal
@@ -323,19 +244,11 @@ These rules remain mandatory:
 - Report the result for that project gap with `Red`, `Green`, `Refactor`, and
   `Validation` entries. Use `Refactor: none` when no cleanup was needed after
   green. Then ask the human to verify and explicitly say `PROJECT-N is done`.
-- During automatic continuations while waiting for approval or `PROJECT-N is
-  done`, do not repeat the full proposal or result. State the current waiting
-  gate once, concisely.
-- Do not move to the next proposal until the human says `PROJECT-N is done`.
-- After the human confirms a proposal is done, remove that proposal from scoped
-  `PROJECTS.md`. If a proposal is deemed invalid or not actually a project gap,
-  remove it only after explaining why and getting human agreement.
-- Once all proposals are resolved and confirmed done by the human, delete the
-  scoped `PROJECTS.md`.
 
 ## References
 
 - Read `references/plan.md` before starting Find mode or Implement mode.
+- Read `../references/gap-workflow.md` for shared scoped-ledger, delegation, coverage, confidence, and approval gates.
 - Use `$project-workflow` for repository command discovery, documented
   entrypoints, CI expectations, examples, and `./bin` wiring before review
   planning or validation.

--- a/skills/project-gaps/agents/openai.yaml
+++ b/skills/project-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Project Gaps"
   short_description: "Find scoped project workflow gaps"
-  default_prompt: "Use $project-gaps to find scoped build, CI, Makefile, release, setup, validation, command discovery, and repository workflow gaps; classify each proposal's implementation home as current repo, shared bin, external repo, or mixed; exclude downstream bin/** unless explicitly scoped to shared tooling; store confirmed in-scope proposals in PROJECTS.md; answer project gap ID follow-ups such as PROJECT-1; or implement agreed project workflow fixes one gap at a time."
+  default_prompt: "Use $project-gaps with its shared gap workflow to find scoped build, CI, Makefile, release, setup, validation, command discovery, and repository workflow gaps; classify each proposal's implementation home as current repo, shared bin, external repo, or mixed; exclude downstream bin/** unless explicitly scoped to shared tooling; store confirmed in-scope proposals in PROJECTS.md; answer project gap ID follow-ups such as PROJECT-1; or implement agreed project workflow fixes one gap at a time."

--- a/skills/project-gaps/references/plan.md
+++ b/skills/project-gaps/references/plan.md
@@ -1,55 +1,12 @@
 # Project Gaps Plan
 
-Use this reference to instantiate the active execution plan for
-`$project-gaps`. The active plan is runtime state. Do not write it into the
-repository unless the human explicitly asks for a durable plan file. In
-downstream repositories that vendor this project as `./bin`, instantiate the
-plan from the consuming repository root and keep `bin/` as shared guidance.
+Use this reference to instantiate the project-gap-specific active plan for
+`$project-gaps`. Read it with the shared gap workflow named in `SKILL.md`; that
+workflow owns common plan state, goal state, scoped-ledger, delegation,
+coverage, and implementation gates.
 
-## Plan State Rules
-
-- Keep exactly one active phase in progress at a time.
-- Preserve stop gates as plan boundaries; do not continue past a stop gate
-  based on silence or a broad request.
-- Update the active plan when scope, audience, project workflow surface,
-  implementation home, validation, delegation, or ledger state changes.
-- Treat validation as stale when files change after a command ran.
-- Before checking, reading, creating, or updating the scoped `PROJECTS.md`
-  ledger, ensure the consuming repository root `.gitignore` exists and contains
-  `PROJECTS.md` as a standalone pattern. If the pattern is missing, add it.
-- Record durable project proposals only in the scoped `PROJECTS.md` ledger
-  defined by the skill.
-- In downstream repositories that vendor this project as `./bin`, exclude
-  `bin/**` from recursive inventory, review slices, and durable proposals unless
-  the requested scope is explicitly about shared `bin` tooling. Inspect only
-  included shared fragments or selected skill guidance needed as evidence, and
-  route upstream-only proposals to a separate `bin`-scoped run.
-- Track broad-scope coverage explicitly as reviewed deeply, skimmed, excluded,
-  and deferred. Deferred entries must name runnable follow-up scopes.
-
-## Goal State Rules
-
-- Bind the active goal to the selected mode and requested scope.
-- In Find mode, the goal is complete when no confirmed project gaps are found
-  and reported, or when the scoped `PROJECTS.md` ledger is written and
-  presented.
-- For broad scopes, a no-gap result is complete only when the summary states
-  whether all high-value project workflow slices were deeply reviewed. If any
-  relevant slice was skimmed or deferred, completion requires coverage notes
-  and runnable follow-up scopes, not an unqualified all-scope no-gap claim.
-- In Implement mode, the goal is waiting while the human has not approved the
-  proposed project-gap solution, or after validation until the human confirms
-  `PROJECT-<number> is done`.
-- During automatic continuations while waiting for approval or done
-  confirmation, state the waiting gate once and do not repeat the full
-  proposal or result.
-- In Implement mode, the goal is complete for a proposal only after the human
-  confirms it is done and the scoped ledger is updated accordingly.
-- Record a blocked reason when a required scope is missing, the scoped ledger
-  required by the mode is absent or already exists in a conflicting state,
-  required permission is denied, or the selected project gap cannot be
-  re-checked without human input. Follow runtime rules for when that reason
-  changes goal status.
+Track project-gap-specific state for scope, audience, project workflow surface,
+implementation home, validation, delegation, ledger state, and workflow routing.
 
 ## Find Mode Plan
 

--- a/skills/references/gap-workflow.md
+++ b/skills/references/gap-workflow.md
@@ -1,0 +1,155 @@
+# Gap Workflow
+
+Use this reference for scoped gap-finding and gap-implementation skills. The
+selected skill owns domain judgment, ledger format, mode names, and final output.
+These shared rules own workflow mechanics.
+
+## Mode And Plan State
+
+- If no scope is provided, stop and ask for the package or folder.
+- Before starting a find, audit, one-pass, or implement mode, read the selected
+  skill's `references/plan.md` and maintain it as active runtime state. Do not
+  write the plan into the repository unless the human explicitly asks for a
+  durable plan file.
+- When the runtime supports goals, bind the selected mode and requested scope to
+  one active goal and update it as ledger, proposal, approval, validation,
+  summary, unresolved-ledger, or human-confirmation state changes.
+- Do not combine find and implement modes in one pass unless the selected skill
+  explicitly defines a one-pass mode.
+- Preserve stop gates as plan boundaries. Do not continue past a stop gate based
+  on silence or a broad request.
+- Treat validation as stale when files change after a command ran.
+
+## Scoped Ledgers
+
+- Before checking, reading, creating, or updating a scoped ledger, ensure the
+  consuming repository root `.gitignore` exists and contains that ledger
+  filename as a standalone pattern. If the pattern is missing, add it.
+- Use the selected skill's ledger filename in the requested package or folder,
+  such as `PACKAGE_OR_FOLDER/ISSUES.md`, `TESTS.md`, `DOCS.md`,
+  `FEATURES.md`, `PROJECTS.md`, or `RELIABILITY.md`.
+- In find or audit-only modes, if the scoped ledger already exists, stop unless
+  the selected skill explicitly allows reading or refreshing that ledger.
+- In implement mode, read the scoped ledger first and treat it as the working
+  ledger. If it does not exist, stop and ask whether to run the matching find
+  mode first for that scope.
+- Record durable findings or proposals only in the scoped ledger defined by the
+  selected skill.
+- Assign IDs using the selected skill's prefix, such as `ISSUE-N`, `TEST-N`,
+  `DOC-N`, `FEATURE-N`, `PROJECT-N`, or `REL-N`.
+
+## Delegation And Permissions
+
+- Treat a find or audit invocation as the user's explicit request to delegate
+  review for that scope when the selected skill says so. Do not require the
+  user to separately say "use sub-agents", "spawn agents", or "delegate".
+- Use sub-agents for find or audit review whenever the active runtime provides
+  them and runtime policy/tooling permits delegation. Do not perform the review
+  locally first when delegation is available and required by the selected skill.
+- If delegation is denied, stop instead of falling back to a local review. If
+  sub-agents are unavailable, say so briefly and perform the review locally for
+  the requested scope.
+- Ask for human permission before agents run commands that require approval,
+  such as network, SSH, GitHub auth, registry auth, cloning, destructive
+  operations, remote writes, or non-read-only validation.
+
+## Scope Inventory And Slicing
+
+- Exclude generated files and folders, vendored dependencies, caches, build
+  output, generated API docs, and generated lockfile churn unless the requested
+  scope is explicitly about them.
+- In downstream repositories that vendor this project as `./bin`, treat
+  `bin/**` as vendored shared tooling unless the requested scope is explicitly
+  about shared `bin` tooling, Makefile includes, skills, or submodule wiring.
+  Exclude `bin/**` from recursive review and inventory by default; inspect only
+  included `bin/build/make/*.mak` fragments or selected `bin/skills/**`
+  guidance needed as evidence. Route upstream-only shared-tooling findings to a
+  separate `bin`-scoped run instead of writing them into the consuming
+  repository's scoped ledger.
+- Before assigning review agents, build a recursive scope inventory for the
+  requested package or folder. Include relevant file count, first-level
+  subfolders, nested packages, dominant languages, public entrypoints,
+  generated/vendor/build/cache exclusions, docs, examples, tests, validation
+  entrypoints, and the selected skill's domain-specific surfaces.
+- Do not assign broad recursive subtrees merely because they are first-level
+  subfolders. When a subtree contains many independent owners, workflows,
+  responsibilities, packages, products, or audiences, split it into smaller
+  behavior-owned, documentation-owned, workflow-owned, or audience-owned slices.
+- Use depth only as a discovery aid, not as the review boundary.
+- If the requested scope is too broad to review credibly in one pass, review
+  the highest-risk or highest-value slices first and record explicit coverage:
+  reviewed deeply, skimmed, excluded, and deferred.
+- Do not present a broad requested scope as fully reviewed when any relevant
+  slice was only skimmed or deferred. Name those slices in the final coverage
+  notes and provide runnable follow-up scopes for deferred review.
+
+## Candidate Handling
+
+- Require each assigned agent to return candidates in the selected skill's
+  ledger format, without final IDs unless useful locally.
+- Use `../references/finding-severity.md` to discard low-confidence candidates
+  before assigning severity or confidence when the selected skill records
+  findings.
+- Confirm each candidate against current code, docs, examples, tests, command
+  behavior, CI config, generated contracts, and public interfaces relevant to
+  the selected skill before recording, fixing, or dismissing it.
+- For reusable library, helper, or shared-tooling scopes, inspect supported
+  usage evidence before recording or accepting a high-confidence issue, gap, or
+  proposal: a real consumer, executable example, integration test, module wiring
+  path, documented contract, CI workflow, or comparable usage path that can
+  trigger the candidate or show the audience/action at risk. Treat package-local
+  fakes, synthetic tests, manual construction, and unsupported downstream
+  patterns as leads only.
+- When prose, comments, examples, or docs contradict implementation, require
+  non-prose evidence before treating implementation as wrong or routing the
+  candidate to code, security, reliability, or test workflows. If current code,
+  tests, runtime behavior, generated contracts, CI, or history support the
+  implementation, route stale prose to `$doc-gaps`.
+- Dismiss candidates already covered by the correct authoritative surface,
+  below the selected skill's threshold, duplicative, out of scope, or owned by a
+  different workflow. When useful, state the authoritative surface or workflow
+  that owns the concern.
+
+## Find And Audit Outcomes
+
+- If no confirmed gaps or proposals remain, report that result with coverage
+  state and do not create a scoped ledger.
+- If confirmed gaps or proposals remain, write them to the scoped ledger before
+  making changes unless the selected skill explicitly defines a one-pass fix
+  mode.
+- Stop after presenting the ledger and plan in find/audit modes when the
+  selected skill requires a separate implementation pass.
+
+## Implementation Gates
+
+- Work through scoped ledger entries sequentially by ID unless the human
+  explicitly names a different entry.
+- Before proposing a fix for each entry, re-check current code, docs, tests,
+  config, CI, command behavior, and nearby patterns. Treat ledgers as stale:
+  dismiss or revise entries that are already addressed, duplicated, invalid, or
+  owned by another workflow.
+- Stop after proposing a solution. Do not edit files, update the scoped ledger,
+  or start validation until the human explicitly agrees to that entry's
+  solution.
+- A request that names an entry and asks to fix, implement, or verify it is
+  permission to select that entry, re-check current evidence, and present or
+  refresh the proposal. It is not approval to edit unless the request also
+  explicitly agrees to the proposed solution.
+- Ask questions when behavior, compatibility, documentation location, test
+  layer, implementation home, validation, operator workflow, or user intent is
+  ambiguous enough that a correct change cannot be inferred from local context.
+- After the human agrees and before editing, state the selected local pattern,
+  dominant relevant test harness or validation path, planned validation command,
+  and any deviation from `AGENTS.md` or selected skills. If a deviation is
+  needed, stop and ask before editing.
+- Implement only the agreed entry with the smallest clear change using existing
+  local patterns.
+- During automatic continuations while waiting for approval or an "`ID` is
+  done" confirmation, do not repeat the full proposal or result. State the
+  current waiting gate once, concisely.
+- Do not move to the next entry until the human says the current entry is done.
+- After the human confirms an entry is done, remove or revise that entry in the
+  scoped ledger. If an entry is deemed invalid, remove it only after explaining
+  why and getting human agreement.
+- Once all entries are resolved and confirmed done by the human, delete the
+  scoped ledger.

--- a/skills/reliability-gaps/SKILL.md
+++ b/skills/reliability-gaps/SKILL.md
@@ -12,13 +12,10 @@ Use this skill in two distinct modes:
 
 Do not combine the two modes in one pass.
 
-Before starting Find mode or Implement mode, read `references/plan.md` and use
-it to maintain the active execution plan. The active plan is runtime state; do
-not write it into the repository unless the human explicitly asks for a durable
-plan file.
-When the runtime supports goals, bind the selected mode and requested scope to
-one active goal and update that goal as ledger, proposal, approval, validation,
-or human-confirmation state changes.
+Before starting Find mode or Implement mode, read `references/plan.md` and
+`../references/gap-workflow.md`. The plan owns active runtime state; the shared
+gap workflow owns ledger, delegation, scope, coverage, confidence, and approval
+gates.
 
 ## Operating Stance
 
@@ -45,45 +42,16 @@ implementation, route the mismatch to `$doc-gaps` instead.
 
 ## Find Mode
 
-Follow `references/plan.md#find-mode-plan`.
+Follow `references/plan.md#find-mode-plan` and the find/audit rules in
+`../references/gap-workflow.md`.
 
-These rules remain mandatory:
+These reliability-gap rules remain mandatory:
 
-- If no scope is provided, stop and ask for the package or folder.
-- Before checking, reading, creating, or updating the scoped `RELIABILITY.md`
-  ledger, ensure the consuming repository root `.gitignore` exists and contains
-  `RELIABILITY.md` as a standalone pattern. If the pattern is missing, add it.
-- Use `RELIABILITY.md` in the requested package or folder as the review ledger, for example `PACKAGE_OR_FOLDER/RELIABILITY.md`.
-- If `RELIABILITY.md` already exists in the requested package or folder, stop. Tell the user the existing scoped ledger must be resolved first, or the human must delete that scoped `RELIABILITY.md` before a new find pass there.
-- Treat `Find $reliability-gaps in PACKAGE_OR_FOLDER` or `Find reliability gaps in PACKAGE_OR_FOLDER` as the user's explicit request to delegate reliability review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
-- Use sub-agents for Find mode whenever the active runtime provides them and runtime policy/tooling permits delegation. Do not treat sub-agents as optional based on scope size, and do not perform the reliability-gap review locally first.
-- Do not claim that extra delegation wording is needed before launching review agents. The Find mode invocation is the explicit delegation request.
-- If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
-- Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, destructive operations, or non-read-only validation.
-- Exclude generated files and folders, vendored dependencies, caches, build output, generated API docs, and generated lockfile churn unless the requested scope is explicitly about them.
-- In downstream repositories that vendor this project as `./bin`, treat
-  `bin/**` as vendored shared tooling unless the requested scope is explicitly
-  about shared `bin` tooling, Makefile includes, skills, or submodule wiring.
-  Exclude `bin/**` from recursive review and inventory by default; inspect only
-  included `bin/build/make/*.mak` fragments or selected `bin/skills/**`
-  guidance needed as evidence. Route upstream-only shared-tooling findings to a
-  separate `bin`-scoped run instead of writing them into the consuming
-  repository's `RELIABILITY.md`.
-- Before assigning review agents, build a recursive scope inventory for the requested package or folder: relevant file count, first-level subfolders, nested packages, dominant languages, tests, public entrypoints, generated/vendor/build/cache exclusions, and reliability-sensitive surfaces.
-- Do not assign broad recursive subtrees merely because they are first-level subfolders. When a subtree contains many independent nested packages, mixed operational responsibilities, or too many relevant files for a credible single pass, split it into smaller behavior-owned slices before delegation.
+- Use `RELIABILITY.md` in the requested package or folder as the review ledger,
+  for example `PACKAGE_OR_FOLDER/RELIABILITY.md`.
 - Prefer slices based on repository-owned reliability and operational risk: public commands/APIs, changed or recently touched areas, retries/timeouts/backpressure, config/CI/release paths, observability/runbook surfaces, documented workflows, and nearby tests. Use depth only as a discovery aid, not as the review boundary.
-- If the requested scope is too broad to review credibly in one pass, review the highest-risk slices first and record explicit coverage: reviewed deeply, skimmed, excluded, and deferred.
-- Do not present a broad requested scope as fully reviewed when any relevant slice was only skimmed or deferred. Name those slices in the final coverage notes and provide runnable follow-up scopes for deferred review.
 - Each assigned agent owns recursive review only within its bounded slice. Each agent must perform a thorough `$reliability-standards` review for that slice, pairing with `$change-safety`, `$security-audit`, `$testing-standards`, and `$change-validation` as the surface requires.
-- Require each agent to return findings in the same shape as the `RELIABILITY.md` format, without final IDs unless useful locally.
-- Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity and confidence.
 - Confirm each candidate gap against current evidence before recording it. Try to disprove the candidate by tracing the current code path, reading the documented workflow, checking the relevant config, inspecting existing tests, or running an allowed local command. A gap must name the affected reliability promise or operational expectation, the trigger condition, the failure mode, the missing or weak control, and the likely user or operator impact.
-- For reusable library, helper, or shared-tooling scopes, inspect supported
-  usage evidence before recording a high-confidence reliability gap: a real
-  consumer, executable example, integration test, module wiring path,
-  documented contract, CI workflow, or comparable usage path that can trigger
-  the failure mode. Treat package-local fakes, synthetic tests, manual
-  construction, and unsupported downstream patterns as leads only.
 - For candidates based on documentation or comments contradicting code, require non-prose proof that the implementation or repository-owned reliability control is wrong before recording a reliability gap. If current code, tests, runtime behavior, CI, or history support the implementation, treat the prose as a doc gap.
 - Record reliability gaps only when they involve repository-owned behavior or documented/implicit operational contracts, such as:
    - missing or weak SLO, SLI, alertability, dashboard, runbook, or operator diagnostic coverage for behavior the repository claims or owns.
@@ -110,10 +78,6 @@ These rules remain mandatory:
 - Do not record standalone missing, weak, flaky, misleading, or wrong-layer tests as reliability gaps. Use `$test-gaps` when missing failure-path coverage is the finding.
 - Do not record standalone missing, weak, stale, misleading, or wrong-location operational docs as reliability gaps. Use `$doc-gaps` when documentation itself is the finding.
 - Do not report optional maturity improvements, cloud-architecture preferences, private implementation preferences, or "best practice" checkboxes as findings by themselves. List them only as optional follow-up notes when relevant.
-- If no confirmed reliability gaps are found, report that no reliability gaps were found and do not create `RELIABILITY.md`.
-- If confirmed reliability gaps are found, write all findings to the scoped `RELIABILITY.md` before making any fixes.
-- Assign every finding a unique ID for the session in the form `REL-N`.
-- Stop after presenting the ledger and plan. Do not fix findings in the same pass.
 
 ## `RELIABILITY.md` Format
 
@@ -144,28 +108,13 @@ Keep optional follow-up notes separate from findings:
 
 ## Implement Mode
 
-Follow `references/plan.md#implement-mode-plan`.
+Follow `references/plan.md#implement-mode-plan` and the implementation rules in
+`../references/gap-workflow.md`.
 
-These rules remain mandatory:
+These reliability implementation rules remain mandatory:
 
-- If no scope is provided, stop and ask for the package or folder.
-- Before checking, reading, creating, or updating the scoped `RELIABILITY.md`
-  ledger, ensure the consuming repository root `.gitignore` exists and contains
-  `RELIABILITY.md` as a standalone pattern. If the pattern is missing, add it.
-- Read `RELIABILITY.md` in the requested package or folder first and treat it as the working reliability-gap ledger.
-- If scoped `RELIABILITY.md` does not exist, stop and ask whether to run Find mode first for that scope.
-- Work through findings sequentially by ID unless the human explicitly names a different finding.
 - Before proposing a fix for each finding, re-check the current code, config, tests, docs, and CI. Treat the ledger as something that can go stale: dismiss or revise findings that are already addressed, no longer have a concrete failure mode, duplicate another issue, or belong in `$code-issues`, `$security-audit`, `$test-gaps`, or `$doc-gaps`.
 - When re-checking a finding whose evidence depends on documentation or comments contradicting implementation, prove the implementation or reliability control is wrong with non-prose evidence before proposing a reliability change. If non-prose evidence supports the implementation, explain that the ledger item is invalid as a reliability gap and propose reclassifying or fixing documentation instead.
-- Stop after proposing the solution. Do not edit files, update
-  `RELIABILITY.md`, or start validation until the human explicitly agrees to
-  that finding's solution.
-- Treat a request that names a finding and asks to fix, implement, or verify it
-  as permission to select that finding, re-check current evidence, and present
-  or refresh the proposal. It is not approval to edit unless the request also
-  explicitly agrees to the proposed solution. If the proposal was already
-  presented and remains unchanged after re-checking, state only the concise
-  approval gate instead of repeating the full proposal.
 - Ask questions when SLOs, expected failure behavior, operator workflow, compatibility, rollout, validation, or user intent is ambiguous. Treat silence or a broad "implement reliability gaps" request as permission to start the proposal workflow, not as permission to edit.
 - After the human agrees and before editing, state the selected local code/config/docs pattern, dominant relevant test harness, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
 - For behavior-changing fixes, state the reliability execution checklist before editing:
@@ -178,16 +127,11 @@ These rules remain mandatory:
 - Implement only the agreed finding with the smallest clear reliability change.
 - Use `$reliability-standards` for reliability design, `$change-safety` for public or operational compatibility, `$testing-standards` for failure-path tests, and `$change-validation` for checks. Pair with `$security-audit` when the fix touches auth, secrets, privilege, DoS, logs, supply chain, or incident containment.
 - Report the result for that finding with `Red`, `Green`, `Refactor`, and `Validation` entries. Use `Refactor: none` when no cleanup was needed after green. Then ask the human to verify and explicitly say `REL-N is done`.
-- During automatic continuations while waiting for approval or `REL-N is done`,
-  do not repeat the full proposal or result. State the current waiting gate
-  once, concisely.
-- Do not move to the next finding until the human says `REL-N is done`.
-- After the human confirms a finding is done, remove that finding from scoped `RELIABILITY.md`. If a finding is deemed invalid or not actually a reliability gap, remove it only after explaining why and getting human agreement.
-- Once all findings are resolved and confirmed done by the human, delete the scoped `RELIABILITY.md`.
 
 ## References
 
 - Read `references/plan.md` before starting Find mode or Implement mode.
+- Read `../references/gap-workflow.md` for shared scoped-ledger, delegation, coverage, confidence, and approval gates.
 - Use `../references/finding-severity.md` for confidence filtering, confidence labels, and severity.
 - Use `$reliability-standards` for SRE, NALSD, resilience, recovery, overload, observability, release-safety, and production-readiness judgment.
 - Use `$project-workflow` for repository command discovery, CI expectations, documented entrypoints, operational docs, and `./bin` wiring before review planning or validation.

--- a/skills/reliability-gaps/agents/openai.yaml
+++ b/skills/reliability-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Reliability Gaps"
   short_description: "Find scoped SRE readiness gaps"
-  default_prompt: "Use $reliability-gaps with its active goal and plan to find scoped reliability gaps, exclude downstream bin/** unless explicitly scoped to shared tooling, store confirmed gaps in RELIABILITY.md, answer reliability gap ID follow-ups such as REL-1, and implement agreed fixes. For behavior-changing fixes, report the TDD decision plus Red, Green, Refactor, and Validation; otherwise use the appropriate docs/config validation path."
+  default_prompt: "Use $reliability-gaps with its active goal, plan, and shared gap workflow to find scoped reliability gaps, exclude downstream bin/** unless explicitly scoped to shared tooling, store confirmed gaps in RELIABILITY.md, answer reliability gap ID follow-ups such as REL-1, and implement agreed fixes. For behavior-changing fixes, report the TDD decision plus Red, Green, Refactor, and Validation; otherwise use the appropriate docs/config validation path."

--- a/skills/reliability-gaps/references/plan.md
+++ b/skills/reliability-gaps/references/plan.md
@@ -1,55 +1,13 @@
 # Reliability Gaps Plan
 
-Use this reference to instantiate the active execution plan for
-`$reliability-gaps`. The active plan is runtime state. Do not write it into the
-repository unless the human explicitly asks for a durable plan file. In
-downstream repositories that vendor this project as `./bin`, instantiate the
-plan from the consuming repository root and keep `bin/` as shared guidance.
+Use this reference to instantiate the reliability-gap-specific active plan for
+`$reliability-gaps`. Read it with the shared gap workflow named in `SKILL.md`;
+that workflow owns common plan state, goal state, scoped-ledger, delegation,
+coverage, and implementation gates.
 
-## Plan State Rules
-
-- Keep exactly one active phase in progress at a time.
-- Preserve stop gates as plan boundaries; do not continue past a stop gate based
-  on silence or a broad request.
-- Update the active plan when scope, reliability surface, validation,
-  delegation, or ledger state changes.
-- Treat validation as stale when files change after a command ran.
-- Before checking, reading, creating, or updating the scoped `RELIABILITY.md`
-  ledger, ensure the consuming repository root `.gitignore` exists and contains
-  `RELIABILITY.md` as a standalone pattern. If the pattern is missing, add it.
-- Record durable findings only in the scoped `RELIABILITY.md` ledger defined by
-  the skill.
-- In downstream repositories that vendor this project as `./bin`, exclude
-  `bin/**` from recursive inventory, review slices, and durable findings unless
-  the requested scope is explicitly about shared `bin` tooling. Inspect only
-  included shared fragments or selected skill guidance needed as evidence, and
-  route upstream-only findings to a separate `bin`-scoped run.
-- Track broad-scope coverage explicitly as reviewed deeply, skimmed, excluded,
-  and deferred. Deferred entries must name runnable follow-up scopes.
-
-## Goal State Rules
-
-- Bind the active goal to the selected mode and requested scope.
-- In Find mode, the goal is complete when no confirmed reliability gaps are
-  found and reported, or when the scoped `RELIABILITY.md` ledger is written and
-  presented.
-- For broad scopes, a no-gap result is complete only when the summary states
-  whether all high-risk slices were deeply reviewed. If any relevant slice was
-  skimmed or deferred, completion requires coverage notes and runnable
-  follow-up scopes, not an unqualified all-scope no-gap claim.
-- In Implement mode, the goal is waiting while the human has not approved the
-  proposed reliability-gap solution, or after validation until the human
-  confirms `REL-<number> is done`.
-- During automatic continuations while waiting for approval or done
-  confirmation, state the waiting gate once and do not repeat the full
-  proposal or result.
-- In Implement mode, the goal is complete for a finding only after the human
-  confirms it is done and the scoped ledger is updated accordingly.
-- Record a blocked reason when a required scope is missing, the scoped ledger
-  required by the mode is absent or already exists in a conflicting state,
-  required permission is denied, or the selected finding cannot be re-checked
-  without human input. Follow runtime rules for when that reason changes goal
-  status.
+Track reliability-gap-specific state for scope, reliability surface,
+validation, delegation, ledger state, operational expectation, and failure-mode
+evidence.
 
 ## Find Mode Plan
 

--- a/skills/test-gaps/SKILL.md
+++ b/skills/test-gaps/SKILL.md
@@ -12,13 +12,10 @@ Use this skill in two distinct modes:
 
 Do not combine the two modes in one pass.
 
-Before starting Find mode or Implement mode, read `references/plan.md` and use
-it to maintain the active execution plan. The active plan is runtime state; do
-not write it into the repository unless the human explicitly asks for a durable
-plan file.
-When the runtime supports goals, bind the selected mode and requested scope to
-one active goal and update that goal as ledger, proposal, approval, validation,
-or human-confirmation state changes.
+Before starting Find mode or Implement mode, read `references/plan.md` and
+`../references/gap-workflow.md`. The plan owns active runtime state; the shared
+gap workflow owns ledger, delegation, scope, coverage, confidence, and approval
+gates.
 
 ## Operating Stance
 
@@ -48,45 +45,17 @@ improvements to `$project-gaps`.
 
 ## Find Mode
 
-Follow `references/plan.md#find-mode-plan`.
+Follow `references/plan.md#find-mode-plan` and the find/audit rules in
+`../references/gap-workflow.md`.
 
-These rules remain mandatory:
+These test-gap rules remain mandatory:
 
-- If no scope is provided, stop and ask for the package or folder.
-- Before checking, reading, creating, or updating the scoped `TESTS.md` ledger,
-  ensure the consuming repository root `.gitignore` exists and contains
-  `TESTS.md` as a standalone pattern. If the pattern is missing, add it.
-- Use `TESTS.md` in the requested package or folder as the review ledger, for example `PACKAGE_OR_FOLDER/TESTS.md`.
-- If `TESTS.md` already exists in the requested package or folder, stop. Tell the user the existing scoped ledger must be resolved first, or the human must delete that scoped `TESTS.md` before a new find pass there.
-- Treat `Find $test-gaps in PACKAGE_OR_FOLDER` or `Find test gaps in PACKAGE_OR_FOLDER` as the user's explicit request to delegate test-gap review for that scope. Do not require the user to separately say "use sub-agents", "spawn agents", or "delegate".
-- Use sub-agents for Find mode whenever the active runtime provides them and runtime policy/tooling permits delegation. Do not treat sub-agents as optional based on scope size, and do not perform the test-gap review locally first.
-- Do not claim that extra delegation wording is needed before launching review agents. The Find mode invocation is the explicit delegation request.
-- If delegation is denied, stop instead of falling back to a local review. If sub-agents are unavailable, say so briefly and perform the review locally for the requested scope.
-- Ask for human permission before agents run commands that require approval, such as network, SSH, GitHub auth, registry auth, remote writes, or other non-read-only validation.
-- Exclude generated files and folders, vendored dependencies, caches, build output, and generated lockfile churn unless the requested scope is explicitly about them.
-- In downstream repositories that vendor this project as `./bin`, treat
-  `bin/**` as vendored shared tooling unless the requested scope is explicitly
-  about shared `bin` tooling, Makefile includes, skills, or submodule wiring.
-  Exclude `bin/**` from recursive review and inventory by default; inspect only
-  included `bin/build/make/*.mak` fragments or selected `bin/skills/**`
-  guidance needed as evidence. Route upstream-only shared-tooling findings to a
-  separate `bin`-scoped run instead of writing them into the consuming
-  repository's `TESTS.md`.
-- Before assigning review agents, build a recursive scope inventory for the requested package or folder: relevant file count, first-level subfolders, nested packages, dominant languages, tests, public entrypoints, generated/vendor/build/cache exclusions, and existing test harnesses.
-- Do not assign broad recursive subtrees merely because they are first-level subfolders. When a subtree contains many independent nested packages, mixed responsibilities, or too many relevant files for a credible single pass, split it into smaller behavior-owned slices before delegation.
+- Use `TESTS.md` in the requested package or folder as the review ledger, for
+  example `PACKAGE_OR_FOLDER/TESTS.md`.
 - Prefer slices based on repository-owned behavior and test risk: public commands/APIs, changed or recently touched areas, documented workflows, compatibility-sensitive behavior, release paths, and nearby existing tests. Use depth only as a discovery aid, not as the review boundary.
-- If the requested scope is too broad to review credibly in one pass, review the highest-risk slices first and record explicit coverage: reviewed deeply, skimmed, excluded, and deferred.
-- Do not present a broad requested scope as fully reviewed when any relevant slice was only skimmed or deferred. Name those slices in the final coverage notes and provide runnable follow-up scopes for deferred review.
 - Each assigned agent owns recursive review only within its bounded slice. Each agent must perform a thorough and accurate `$testing-standards` review for that slice, pairing with relevant language standards and `$change-validation` for likely validation commands.
 - Require each agent to return findings in the same shape as the `TESTS.md` format, without final IDs unless useful locally. Each finding must name the repository-owned behavior being protected; reject findings that only test dependency semantics, aliases, or pass-through wrappers.
-- Use `../references/finding-severity.md` to discard low-confidence candidates before assigning severity and confidence.
 - Confirm each candidate gap against the code and existing tests before recording it. Gaps must be concrete missing, weak, misleading, flaky, or wrong-layer coverage with credible risk to changed behavior, public contracts, compatibility, release-sensitive workflows, or documented command/API behavior.
-- For reusable library, helper, or shared-tooling scopes, inspect supported
-  usage evidence before recording a high-confidence test gap: a real consumer,
-  executable example, integration test, module wiring path, documented
-  contract, CI workflow, or comparable usage path that can observe the
-  unprotected behavior. Treat package-local fakes, synthetic tests, manual
-  construction, and unsupported downstream patterns as leads only.
 - For each candidate, identify the real front door: the command, scenario,
   package/API consumer, service boundary, workflow, or documented entrypoint
   that would observe the behavior. Do not record a gap merely because an
@@ -115,10 +84,6 @@ These rules remain mandatory:
 - Do not record confirmed production bugs, security issues, compatibility breaks, or violated public contracts as test gaps. If such broken behavior is discovered during review, report it as out of scope for the test-gap ledger and recommend `$code-issues`; use this skill when the unprotected or poorly protected behavior is the finding.
 - Do not record standalone missing, weak, stale, misleading, or wrong-location documentation, README, example, comment, or docstring gaps as test gaps. Use `$doc-gaps` when documentation itself is the finding.
 - Do not report optional nice-to-have tests, private implementation coverage, arbitrary coverage percentage improvements, style preferences, or docs-only validation as findings by themselves. List them only as doc gaps or optional follow-up notes when relevant.
-- If no confirmed test gaps are found, report that no test gaps were found and do not create `TESTS.md`.
-- If confirmed test gaps are found, write all findings to the scoped `TESTS.md` before making any fixes.
-- Assign every finding a unique ID for the session in the form `TEST-N`.
-- Stop after presenting the ledger and plan. Do not fix findings in the same pass.
 
 ## `TESTS.md` Format
 
@@ -149,41 +114,22 @@ Keep optional follow-up notes separate from findings:
 
 ## Implement Mode
 
-Follow `references/plan.md#implement-mode-plan`.
+Follow `references/plan.md#implement-mode-plan` and the implementation rules in
+`../references/gap-workflow.md`.
 
-These rules remain mandatory:
+These test-gap implementation rules remain mandatory:
 
-- If no scope is provided, stop and ask for the package or folder.
-- Before checking, reading, creating, or updating the scoped `TESTS.md` ledger,
-  ensure the consuming repository root `.gitignore` exists and contains
-  `TESTS.md` as a standalone pattern. If the pattern is missing, add it.
-- Read `TESTS.md` in the requested package or folder first and treat it as the working test-gap ledger.
-- If scoped `TESTS.md` does not exist, stop and ask whether to run Find mode first for that scope.
-- Work through findings sequentially by ID unless the human explicitly names a different finding.
 - Before proposing a fix for each finding, re-check the current code and nearby tests. Treat the ledger as something that can go stale: dismiss or revise findings that are already covered, would duplicate the local test shape, test only underlying libraries/frameworks, or require validation modes the repository does not run.
 - When re-checking a finding whose evidence depends on documentation or comments contradicting implementation, prove the expected behavior with non-prose evidence before proposing tests. If non-prose evidence supports the implementation, explain that the ledger item is invalid as a test gap and propose reclassifying or fixing documentation instead.
-- Stop after proposing the solution. Do not edit code, update `TESTS.md`, or
-  start validation until the human explicitly agrees to that finding's solution.
-- Treat a request that names a finding and asks to fix, implement, or verify it
-  as permission to select that finding, re-check current evidence, and present
-  or refresh the proposal. It is not approval to edit unless the request also
-  explicitly agrees to the proposed solution. If the proposal was already
-  presented and remains unchanged after re-checking, state only the concise
-  approval gate instead of repeating the full proposal.
 - Ask questions when behavior, compatibility, test layer, fixture strategy, validation, or user intent is ambiguous. Treat silence or a broad "implement test gaps" request as permission to start the proposal workflow, not as permission to code.
 - After the human agrees and before editing, state the selected local test pattern, dominant relevant test harness, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
 - Implement only the agreed finding with the smallest clear test change, preferring the existing local test shape over new standalone structure.
 - Use `$testing-standards` for test design and pair with the relevant language standard for local idioms. If implementing the test gap requires production behavior to change, prefer the test-first or scenario-first loop from `$testing-standards`.
-- During automatic continuations while waiting for approval or `TEST-N is done`,
-  do not repeat the full proposal or result. State the current waiting gate
-  once, concisely.
-- Do not move to the next finding until the human says `TEST-N is done`.
-- After the human confirms a finding is done, remove that finding from scoped `TESTS.md`. If a finding is deemed invalid or not actually a test gap, remove it only after explaining why and getting human agreement.
-- Once all findings are resolved and confirmed done by the human, delete the scoped `TESTS.md`.
 
 ## References
 
 - Read `references/plan.md` before starting Find mode or Implement mode.
+- Read `../references/gap-workflow.md` for shared scoped-ledger, delegation, coverage, confidence, and approval gates.
 - Use `../references/finding-severity.md` for confidence filtering, confidence labels, and severity.
 - Use `$testing-standards` for cross-language test quality, coverage, fixtures, determinism, and test-layer decisions.
 - Use relevant language standards for local test idioms.

--- a/skills/test-gaps/agents/openai.yaml
+++ b/skills/test-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Test Gaps"
   short_description: "Find weak tests and harness gaps"
-  default_prompt: "Use $test-gaps with its active goal and plan to find scoped missing, weak, misleading, flaky, wrong-layer, or test-harness coverage gaps; exclude downstream bin/** unless explicitly scoped to shared tooling; reject implementation-only or no-front-door candidates; store confirmed gaps in TESTS.md; answer test gap ID follow-ups such as TEST-1; or implement agreed test fixes one gap at a time."
+  default_prompt: "Use $test-gaps with its active goal, plan, and shared gap workflow to find scoped missing, weak, misleading, flaky, wrong-layer, or test-harness coverage gaps; exclude downstream bin/** unless explicitly scoped to shared tooling; reject implementation-only or no-front-door candidates; store confirmed gaps in TESTS.md; answer test gap ID follow-ups such as TEST-1; or implement agreed test fixes one gap at a time."

--- a/skills/test-gaps/references/plan.md
+++ b/skills/test-gaps/references/plan.md
@@ -1,54 +1,12 @@
 # Test Gaps Plan
 
-Use this reference to instantiate the active execution plan for `$test-gaps`.
-The active plan is runtime state. Do not write it into the repository unless the
-human explicitly asks for a durable plan file. In downstream repositories that
-vendor this project as `./bin`, instantiate the plan from the consuming
-repository root and keep `bin/` as shared guidance.
+Use this reference to instantiate the test-gap-specific active plan for
+`$test-gaps`. Read it with the shared gap workflow named in `SKILL.md`; that
+workflow owns common plan state, goal state, scoped-ledger, delegation,
+coverage, and implementation gates.
 
-## Plan State Rules
-
-- Keep exactly one active phase in progress at a time.
-- Preserve stop gates as plan boundaries; do not continue past a stop gate based
-  on silence or a broad request.
-- Update the active plan when scope, dominant test harness, test-support
-  surface, validation, delegation, or ledger state changes.
-- Treat validation as stale when files change after a command ran.
-- Before checking, reading, creating, or updating the scoped `TESTS.md` ledger,
-  ensure the consuming repository root `.gitignore` exists and contains
-  `TESTS.md` as a standalone pattern. If the pattern is missing, add it.
-- Record durable findings only in the scoped `TESTS.md` ledger defined by the
-  skill.
-- In downstream repositories that vendor this project as `./bin`, exclude
-  `bin/**` from recursive inventory, review slices, and durable findings unless
-  the requested scope is explicitly about shared `bin` tooling. Inspect only
-  included shared fragments or selected skill guidance needed as evidence, and
-  route upstream-only findings to a separate `bin`-scoped run.
-- Track broad-scope coverage explicitly as reviewed deeply, skimmed, excluded,
-  and deferred. Deferred entries must name runnable follow-up scopes.
-
-## Goal State Rules
-
-- Bind the active goal to the selected mode and requested scope.
-- In Find mode, the goal is complete when no confirmed test gaps are found and
-  reported, or when the scoped `TESTS.md` ledger is written and presented.
-- For broad scopes, a no-gap result is complete only when the summary states
-  whether all high-risk slices were deeply reviewed. If any relevant slice was
-  skimmed or deferred, completion requires coverage notes and runnable
-  follow-up scopes, not an unqualified all-scope no-gap claim.
-- In Implement mode, the goal is waiting while the human has not approved the
-  proposed test-gap solution, or after validation until the human confirms
-  `TEST-<number> is done`.
-- During automatic continuations while waiting for approval or done
-  confirmation, state the waiting gate once and do not repeat the full
-  proposal or result.
-- In Implement mode, the goal is complete for a finding only after the human
-  confirms it is done and the scoped ledger is updated accordingly.
-- Record a blocked reason when a required scope is missing, the scoped ledger
-  required by the mode is absent or already exists in a conflicting state,
-  required permission is denied, or the selected finding cannot be re-checked
-  without human input. Follow runtime rules for when that reason changes goal
-  status.
+Track test-gap-specific state for scope, dominant test harness, test-support
+surface, validation, delegation, ledger state, and repository-owned behavior.
 
 ## Find Mode Plan
 


### PR DESCRIPTION
## What

- Extract shared gap workflow mechanics into `skills/references/gap-workflow.md` and have the gap skills and their active plans point to it.
- Tighten skill metadata linting so gap skills keep matching ledgers, ID prefixes, plans, agent metadata, shared workflow references, and resolvable bundled Markdown references.
- Add the missing `PROJECTS.md` ledger ignore pattern and enforce all scoped gap ledgers in `.gitignore`.

## Why

- This reduces repeated operating instructions across the gap skills while keeping their domain-specific review and implementation plans intact.
- The stronger lint checks make future skill changes safer by catching broken reference paths, missing agent metadata, and drift from the shared gap workflow contract before they reach downstream repositories.

## Testing

- `make dep` - passed
- `make clean-dep` - passed
- `make scripts-lint` - passed
- `make skills-lint` - passed
- `make docker-lint` - passed
- `make lint` - passed
- `make sec` - passed
- `git diff --check` - passed
- Downstream verification inspected 18 sibling repositories using this `bin` submodule and confirmed canonical submodule wiring, shared Make inclusion, CircleCI presence, consistent submodule revision, and ledger ignore coverage.

AI-assisted-by: [Codex](https://openai.com/codex/)
