### PR TITLE
feat(skills): require evidenced clean review closeouts

### DIFF
--- a/skills/code-issues/references/plan.md
+++ b/skills/code-issues/references/plan.md
@@ -38,13 +38,19 @@ state, code/security/compatibility evidence, and public contract evidence.
     documentation/comment mismatch, prove the implementation is wrong with
     non-prose evidence before treating it as a code issue; otherwise classify it
     as a documentation gap.
-13. If no confirmed issues remain, report that result with the coverage state,
-    do not create `ISSUES.md`, and stop.
-14. If confirmed issues remain, write the scoped `ISSUES.md` with
+13. Before concluding there are no issues, run a final code-issue closeout
+    check. Name the public APIs, constructors, exported helpers, supported DI or
+    documented usage paths, real call sites, nil/error/edge behavior, tests or
+    CI evidence, and repository policy exclusions that were checked. If any of
+    these were not applicable, say why.
+14. If no confirmed issues remain, report that result with the no-finding
+    closeout required by the shared gap workflow, do not create `ISSUES.md`, and
+    stop.
+15. If confirmed issues remain, write the scoped `ISSUES.md` with
     `ISSUE-<number>` IDs.
-15. Present the scoped ledger, proposed fix plan, coverage state for broad
+16. Present the scoped ledger, proposed fix plan, coverage state for broad
     scopes, and runnable follow-up scopes for deferred slices.
-16. Stop before making fixes.
+17. Stop before making fixes.
 
 ## Implement Mode Plan
 

--- a/skills/references/gap-workflow.md
+++ b/skills/references/gap-workflow.md
@@ -112,8 +112,13 @@ These shared rules own workflow mechanics.
 
 ## Find And Audit Outcomes
 
-- If no confirmed gaps or proposals remain, report that result with coverage
-  state and do not create a scoped ledger.
+- If no confirmed gaps or proposals remain, report that result with a no-finding
+  closeout and do not create a scoped ledger. The closeout must include:
+  reviewed files or slices; supported usage, call sites, commands, tests, or CI
+  evidence checked; excluded or deferred files; repository policy exclusions or
+  suppressions applied; confidence as a percentage or narrow range; and the
+  remaining limits on that confidence. Do not present "nothing found" as a
+  broad assurance without this evidence.
 - If confirmed gaps or proposals remain, write them to the scoped ledger before
   making changes unless the selected skill explicitly defines a one-pass fix
   mode.

--- a/skills/reliability-gaps/references/plan.md
+++ b/skills/reliability-gaps/references/plan.md
@@ -55,13 +55,20 @@ evidence.
 16. Reject generic maturity advice, future-scale assumptions, private
     preferences, and findings that belong in code, security, test, or doc
     ledgers.
-17. If no confirmed gaps remain, report that result with the coverage state, do
-    not create `RELIABILITY.md`, and stop.
-18. If confirmed gaps remain, write the scoped `RELIABILITY.md` with
+17. Before concluding there are no reliability gaps, run a final reliability
+    closeout check. Name the cancellation/context handling, deadlines, timeouts,
+    retries, backoff, bounded memory/network/file/process behavior, lifecycle
+    cleanup, shutdown/drain/health/readiness behavior, observability or operator
+    impact, and CI/sidecar/runtime controls that were checked. If any of these
+    were not applicable, say why.
+18. If no confirmed gaps remain, report that result with the no-finding closeout
+    required by the shared gap workflow, do not create `RELIABILITY.md`, and
+    stop.
+19. If confirmed gaps remain, write the scoped `RELIABILITY.md` with
     `REL-<number>` IDs.
-19. Present the scoped ledger, proposed reliability-fix plan, coverage state for
+20. Present the scoped ledger, proposed reliability-fix plan, coverage state for
     broad scopes, and runnable follow-up scopes for deferred slices.
-20. Stop before making fixes.
+21. Stop before making fixes.
 
 ## Implement Mode Plan
 


### PR DESCRIPTION
## What

- Require scoped gap reviews with no findings to report an evidence-backed closeout instead of only saying nothing was found.
- Add code-issue closeout checks for APIs, constructors, DI or documented usage paths, call sites, edge behavior, tests or CI evidence, and repository policy exclusions.
- Add reliability closeout checks for cancellation, deadlines, retries, bounded resources, lifecycle behavior, health/readiness/drain behavior, observability, and CI/runtime controls.

## Why

- Clean review results should be auditable and confidence-bearing, especially when a package has no ledger findings.
- The added closeout requirements make future reviews clearer about what was checked, what was excluded, and what limits remain.

## Testing

- `zsh -lic 'ruby -v && gmake skills-lint'` - passed
- `git diff --check` - passed
