### PR TITLE
feat(skills): track audit evidence explicitly

### DIFF
--- a/skills/code-issues/agents/openai.yaml
+++ b/skills/code-issues/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Code Issues"
   short_description: "Find scoped code defects and risks"
-  default_prompt: "Use $code-issues with its active goal, plan, and shared gap workflow to delegate scoped code issue finding, exclude downstream bin/** unless explicitly scoped to shared tooling, store confirmed findings in that scope's ISSUES.md, answer issue ID follow-ups such as ISSUE-1, or propose and implement explicitly agreed fixes one code issue at a time."
+  default_prompt: "Use $code-issues with its active goal, plan, and shared gap workflow to delegate scoped code issue finding, track inventory/slice coverage plus validation evidence and confidence, exclude downstream bin/** unless explicitly scoped to shared tooling, store only confirmed findings in that scope's ISSUES.md, create no ledger when there are no confirmed findings, answer issue ID follow-ups such as ISSUE-1, or propose and implement explicitly agreed fixes one code issue at a time."

--- a/skills/code-issues/references/plan.md
+++ b/skills/code-issues/references/plan.md
@@ -13,44 +13,51 @@ state, code/security/compatibility evidence, and public contract evidence.
 1. Confirm the requested package or folder scope.
 2. Check whether scoped `ISSUES.md` already exists and stop if it does.
 3. Run `$project-workflow` discovery for entrypoints, CI, and `./bin` wiring.
-4. Build a recursive scope inventory for the requested package or folder:
+4. Run the shared audit preflight from `../../references/gap-workflow.md`,
+   including applicable tool availability, service dependencies, validation
+   ladder, and command-failure classification.
+5. Build a recursive scope inventory for the requested package or folder:
    relevant file count, first-level subfolders, nested packages, dominant
    languages, tests, public entrypoints, generated/vendor/build/cache
-   exclusions, and security-sensitive surfaces.
-5. Split the inventory into bounded behavior-owned review slices. Use depth
+   exclusions, security-sensitive surfaces, inventory count when applicable,
+   and the coverage accounting required by the shared workflow.
+6. Split the inventory into bounded behavior-owned review slices. Use depth
    only as a discovery aid; do not assign a broad recursive subtree merely
    because it is a first-level subfolder.
-6. If the scope is too broad for a credible single pass, select the highest-risk
+7. If the scope is too broad for a credible single pass, select the highest-risk
    slices first and initialize coverage entries for reviewed deeply, skimmed,
    excluded, and deferred slices. Deferred entries must be exact follow-up
    scopes such as `path/to/package` or `path/to/package/subpackage`.
-7. Ask for required permission before any agent runs non-read-only, network,
+8. Ask for required permission before any agent runs non-read-only, network,
    auth, remote-write, or otherwise approval-gated commands.
-8. Launch the required review agents when available, or perform the local
+9. Launch the required review agents when available, or perform the local
    fallback only when sub-agents are unavailable.
-9. Wait for all review work to finish.
-10. Update coverage state for every planned slice before judging the requested
+10. Wait for all review work to finish.
+11. Update coverage state for every planned slice before judging the requested
     scope.
-11. Deduplicate candidates and directly re-check conflicting or overlapping
+12. Deduplicate candidates and directly re-check conflicting or overlapping
     conclusions.
-12. Confirm each finding is a concrete code issue, security issue,
+13. Confirm each finding is a concrete code issue, security issue,
     compatibility break, or public contract violation. If the evidence is a
     documentation/comment mismatch, prove the implementation is wrong with
     non-prose evidence before treating it as a code issue; otherwise classify it
     as a documentation gap.
-13. Before concluding there are no issues, run a final code-issue closeout
+14. Classify validation outcomes as repository finding, local environment
+    issue, missing tool, or inconclusive; apply the confidence evidence rubric
+    from `../../references/finding-severity.md`.
+15. Before concluding there are no issues, run a final code-issue closeout
     check. Name the public APIs, constructors, exported helpers, supported DI or
     documented usage paths, real call sites, nil/error/edge behavior, tests or
     CI evidence, and repository policy exclusions that were checked. If any of
     these were not applicable, say why.
-14. If no confirmed issues remain, report that result with the no-finding
+16. If no confirmed issues remain, report that result with the no-finding
     closeout required by the shared gap workflow, do not create `ISSUES.md`, and
     stop.
-15. If confirmed issues remain, write the scoped `ISSUES.md` with
+17. If confirmed issues remain, write the scoped `ISSUES.md` with
     `ISSUE-<number>` IDs.
-16. Present the scoped ledger, proposed fix plan, coverage state for broad
+18. Present the scoped ledger, proposed fix plan, coverage state for broad
     scopes, and runnable follow-up scopes for deferred slices.
-17. Stop before making fixes.
+19. Stop before making fixes.
 
 ## Implement Mode Plan
 

--- a/skills/go-standards/references/conventions.md
+++ b/skills/go-standards/references/conventions.md
@@ -65,6 +65,31 @@ Use this reference when working in Go repositories.
 - Do not write internal Go tests in the production package just to reach unexported functions, methods, fields, or collaborators.
 - Keep test cases and test functions first in the file. Place fakes, stubs, spies, mock implementations, and helper types after the tests at the bottom of the file.
 
+## Audit And Validation
+
+- When a code, reliability, security, test-gap, or review workflow audits Go
+  behavior, pair the selected skill's shared inventory and confidence rules with
+  Go-specific coverage accounting when the repository exposes the relevant
+  commands.
+- Use `go list ./...` or the repository-defined equivalent to record Go package
+  count when the requested scope is broad enough for package inventory to affect
+  confidence. Name excluded paths such as `bin/**`, `vendor/**`, generated
+  folders, caches, build output, and intentionally skipped packages.
+- For broad Go audits, consider major reviewed groups such as config/CLI,
+  DI/module/lifecycle, HTTP/gRPC transport, token/access/limiter, SQL/cache,
+  encoding/compress, telemetry/feature/events, crypto, and
+  health/debug/time/id/helpers when those groups exist in the repository.
+- Preflight Go tool availability only when repository Make targets, CI,
+  scripts, or tests require it. Common tools in this ecosystem include the Go
+  toolchain, `fieldalignment`, `golangci-lint`, `buf`, `govulncheck`, Trivy,
+  sidecars, and service dependencies.
+- Preserve Go tooling nuance in audit notes: `fieldalignment` may report
+  `./... matched no packages` in a restricted sandbox or stale tool context;
+  `go test`, `make specs`, and `httptest` may need localhost listener
+  permissions; and `govulncheck`, Trivy, and Buf may need cache writes under
+  the user home directory. A sandbox failure is not automatically a repository
+  finding.
+
 ## Method Layout
 
 - For types with both exported and unexported methods, keep exported methods near the top of the type's method group and unexported methods below them.

--- a/skills/references/finding-severity.md
+++ b/skills/references/finding-severity.md
@@ -70,6 +70,54 @@ regression. If current code and tests support the implementation, classify the
 candidate as a documentation gap or discard it instead of assigning severity to
 a code, test, reliability, or security finding.
 
+## Confidence Evidence Rubric
+
+Use confidence as a compact statement of completed evidence, not optimism. The
+same percentage can mean different work in a small package and a broad repo
+audit, so state the evidence behind it. For broad no-findings claims, release or
+PR readiness, compatibility conclusions, and definitely-fixed claims, require
+95% confidence or state the remaining blocker.
+
+- **Static/manual pass**: supports a scoped candidate or no-findings claim only
+  for the files, packages, modules, components, commands, services, or areas
+  actually inspected. It is not enough for a broad repo claim unless paired with
+  inventory accounting and supported usage evidence.
+- **Inventory/count reviewed**: raises confidence that the scope is complete
+  when the count or inventory comes from the repository-defined discovery path,
+  and exclusions like vendored dependencies, generated files, caches, ignored
+  submodules, build output, or skipped slices are named.
+- **Static analyzers**: increase confidence for the classes they analyze only
+  when they ran against the intended files, packages, modules, components, or
+  commands and did not no-op because of sandbox, cache, stale tool context, or
+  discovery failures.
+- **Unit or package tests**: increase confidence for behavior covered by the
+  repository's language-native test layer. Listener, cache, service, or sandbox
+  failures must be classified before treating them as repository evidence.
+- **Repository spec or feature target, such as `make specs`**: increases
+  confidence for supported end-to-end, integration, or service behavior when
+  that target is the dominant relevant harness.
+- **Lint target, such as `make lint` or the repository's exposed lint split**:
+  increases confidence for style, static policy, generated metadata, and
+  language/tooling checks that the target actually ran. Optional-tool no-ops do
+  not provide full coverage.
+- **Security target, such as `make sec`**: increases confidence for dependency,
+  vulnerability, container, or security-policy coverage that the target owns.
+  Network, cache, credential, or scanner failures must be reported as
+  validation gaps unless repository-owned code caused them.
+- **Generated freshness target**: increases confidence only for
+  generated-contract drift covered by the repository's documented stale or
+  generated check, such as `make proto-stale` when exposed.
+- **Remaining missing tools or environment blockers**: cap confidence to the
+  evidence still available. Record the blocker as missing tool, local
+  environment issue, or inconclusive validation instead of treating it as a
+  repository finding.
+
+For no-findings results, distinguish `No confirmed findings`, `No findings, but
+validation incomplete because X`, and `No findings and validation clean`.
+Report residual risk in concrete terms: unrun targets, no-op wrappers, skipped
+slices, unsupported paths, missing sidecars, unavailable scanners, or evidence
+that was limited to static review.
+
 ## Severity
 
 - `Critical`: Near-certain severe production breakage, data loss or corruption,

--- a/skills/references/gap-workflow.md
+++ b/skills/references/gap-workflow.md
@@ -71,6 +71,13 @@ These shared rules own workflow mechanics.
   subfolders, nested packages, dominant languages, public entrypoints,
   generated/vendor/build/cache exclusions, docs, examples, tests, validation
   entrypoints, and the selected skill's domain-specific surfaces.
+- When the requested scope has repository-defined package, module, component,
+  command, service, or area discovery, record coverage accounting from that
+  discovery path: count or inventory summary; excluded paths such as `bin/**`,
+  vendored dependencies, generated folders, caches, build output, and
+  explicitly out-of-scope subtrees; major reviewed groups named in the
+  repository's own terminology; and any slices intentionally skipped with the
+  concrete reason.
 - Do not assign broad recursive subtrees merely because they are first-level
   subfolders. When a subtree contains many independent owners, workflows,
   responsibilities, packages, products, or audiences, split it into smaller
@@ -82,6 +89,36 @@ These shared rules own workflow mechanics.
 - Do not present a broad requested scope as fully reviewed when any relevant
   slice was only skimmed or deferred. Name those slices in the final coverage
   notes and provide runnable follow-up scopes for deferred review.
+
+## Audit Preflight And Validation Ladder
+
+- Before a long find or audit pass, run a tool and environment preflight through
+  `$project-workflow` and `$change-validation`: repository root, documented
+  entrypoints, CI analogue, initialized user shell, and applicable tool
+  availability or version checks. For toolchain-heavy audits, check required
+  language runtimes, analyzers, linters, schema or generation tools, security
+  scanners, sidecars, and service dependencies only when the repository's Make
+  targets, CI, scripts, or tests actually require them.
+- Preflight is evidence planning, not a reason to bypass repository Make
+  targets. Prefer the repository-defined target that owns each tool or service.
+- Run checks normally first. If a failure is clearly sandbox, cache-permission,
+  localhost listener, network, credential, service-dependency, or user-shell
+  environment related, retry only through the runtime's approved escalation or
+  initialized-shell path.
+- Classify every failed or skipped validation command as exactly one of:
+  repository finding, local environment issue, missing tool, or inconclusive.
+  Do not treat a target failure in the sandbox as a repository finding unless
+  repository-owned code, config, or workflow evidence proves it.
+- Do not lower confidence for a sandbox-only failure when the same command
+  passes through an approved outside-sandbox or initialized-shell path on the
+  same file state. Do lower or cap confidence when validation remains blocked,
+  missing, no-op, or inconclusive.
+- Preserve analyzer nuance in audit notes when relevant: analyzers may no-op or
+  report no matched packages, modules, files, or components in a restricted
+  sandbox or stale tool context; integration tests may need localhost listener
+  permissions or service dependencies; dependency, security, or generation
+  tools may need network access or cache writes outside the workspace; and a
+  target failing in the sandbox is not automatically a repository finding.
 
 ## Candidate Handling
 
@@ -121,15 +158,21 @@ These shared rules own workflow mechanics.
 ## Find And Audit Outcomes
 
 - If no confirmed gaps or proposals remain, report that result with a no-finding
-  closeout and do not create a scoped ledger. The closeout must include:
-  reviewed files or slices; supported usage, call sites, commands, tests, or CI
-  evidence checked; excluded or deferred files; repository policy exclusions or
-  suppressions applied; confidence as a percentage or narrow range; and the
-  remaining limits on that confidence. Do not present "nothing found" as a
-  broad assurance without this evidence.
+  closeout and do not create a scoped ledger. Use one of these outcomes:
+  `No confirmed findings`; `No findings, but validation incomplete because X`;
+  or `No findings and validation clean`. The closeout must include reviewed
+  files or slices; package count or inventory summary when applicable;
+  supported usage, call sites, commands, tests, or CI evidence checked;
+  validation commands and their classified results; excluded or deferred files;
+  repository policy exclusions or suppressions applied; confidence as a
+  percentage or narrow range; and the remaining limits on that confidence. Do
+  not present "nothing found" as a broad assurance without this evidence.
 - If confirmed gaps or proposals remain, write them to the scoped ledger before
   making changes unless the selected skill explicitly defines a one-pass fix
-  mode.
+  mode. Record only high-confidence, actionable findings with file/line,
+  command, config, runtime, or supported-usage evidence. Do not record
+  speculative exclusions, unsupported paths, or examples already ruled out by
+  `AGENTS.md` or the selected skill.
 - Stop after presenting the ledger and plan in find/audit modes when the
   selected skill requires a separate implementation pass.
 

--- a/skills/reliability-gaps/agents/openai.yaml
+++ b/skills/reliability-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Reliability Gaps"
   short_description: "Find scoped SRE readiness gaps"
-  default_prompt: "Use $reliability-gaps with its active goal, plan, and shared gap workflow to find scoped reliability gaps, exclude downstream bin/** unless explicitly scoped to shared tooling, store confirmed gaps in RELIABILITY.md, answer reliability gap ID follow-ups such as REL-1, and implement agreed fixes. For behavior-changing fixes, report the TDD decision plus Red, Green, Refactor, and Validation; otherwise use the appropriate docs/config validation path."
+  default_prompt: "Use $reliability-gaps with its active goal, plan, and shared gap workflow to find scoped reliability gaps, track inventory/slice coverage plus validation evidence and confidence, exclude downstream bin/** unless explicitly scoped to shared tooling, store only confirmed gaps in RELIABILITY.md, create no ledger when there are no confirmed gaps, answer reliability gap ID follow-ups such as REL-1, and implement agreed fixes. For behavior-changing fixes, report the TDD decision plus Red, Green, Refactor, and Validation; otherwise use the appropriate docs/config validation path."

--- a/skills/reliability-gaps/references/plan.md
+++ b/skills/reliability-gaps/references/plan.md
@@ -15,36 +15,40 @@ evidence.
 2. Check whether scoped `RELIABILITY.md` already exists and stop if it does.
 3. Run `$project-workflow` discovery for entrypoints, CI, documented commands,
    operational docs, release/config surfaces, and `./bin` wiring.
-4. Identify the reliability surface in scope, including services, APIs, CLIs,
+4. Run the shared audit preflight from `../../references/gap-workflow.md`,
+   including applicable tool availability, service dependencies, validation
+   ladder, and command-failure classification.
+5. Identify the reliability surface in scope, including services, APIs, CLIs,
    jobs, scripts, deployment/config, observability, release, recovery, and
    operability evidence.
-5. Build a recursive scope inventory for the requested package or folder:
+6. Build a recursive scope inventory for the requested package or folder:
    relevant file count, first-level subfolders, nested packages, dominant
    languages, tests, public entrypoints, generated/vendor/build/cache
-   exclusions, and reliability-sensitive surfaces.
-6. Split the inventory into bounded reliability-risk or behavior-owned review
+   exclusions, reliability-sensitive surfaces, inventory count when applicable,
+   and the coverage accounting required by the shared workflow.
+7. Split the inventory into bounded reliability-risk or behavior-owned review
    slices. Use depth only as a discovery aid; do not assign a broad recursive
    subtree merely because it is a first-level subfolder.
-7. If the scope is too broad for a credible single pass, select the highest-risk
+8. If the scope is too broad for a credible single pass, select the highest-risk
    slices first and initialize coverage entries for reviewed deeply, skimmed,
    excluded, and deferred slices. Deferred entries must be exact follow-up
    scopes such as `path/to/package` or `path/to/package/subpackage`.
-8. Ask for required permission before any agent runs non-read-only, network,
+9. Ask for required permission before any agent runs non-read-only, network,
    auth, remote-write, destructive, or otherwise approval-gated commands.
-9. Launch the required review agents when available, or perform the local
+10. Launch the required review agents when available, or perform the local
    fallback only when sub-agents are unavailable.
-10. Wait for all review work to finish.
-11. Update coverage state for every planned slice before judging the requested
+11. Wait for all review work to finish.
+12. Update coverage state for every planned slice before judging the requested
     scope.
-12. Deduplicate candidates and directly re-check conflicting or overlapping
+13. Deduplicate candidates and directly re-check conflicting or overlapping
     conclusions against code, config, tests, docs, and CI.
-13. For candidates based on prose contradicting implementation, prove with
+14. For candidates based on prose contradicting implementation, prove with
     non-prose evidence that the implementation or repository-owned reliability
     control is wrong; otherwise classify the mismatch as a documentation gap.
-14. Confirm each gap names a current reliability promise or operational
+15. Confirm each gap names a current reliability promise or operational
     expectation, trigger, failure mode, missing or weak control, and user or
     operator impact.
-15. Run a final finding calibration pass:
+16. Run a final finding calibration pass:
     - Does the trigger exist in current supported operation?
     - Is the missing control repository-owned rather than normal review, CI, or
       deployment discipline?
@@ -52,23 +56,26 @@ evidence.
     - Would a skeptical maintainer likely agree this is more than optional
       hardening?
     If any answer is no, discard the candidate or move it to optional follow-up.
-16. Reject generic maturity advice, future-scale assumptions, private
+17. Reject generic maturity advice, future-scale assumptions, private
     preferences, and findings that belong in code, security, test, or doc
     ledgers.
-17. Before concluding there are no reliability gaps, run a final reliability
+18. Classify validation outcomes as repository finding, local environment
+    issue, missing tool, or inconclusive; apply the confidence evidence rubric
+    from `../../references/finding-severity.md`.
+19. Before concluding there are no reliability gaps, run a final reliability
     closeout check. Name the cancellation/context handling, deadlines, timeouts,
     retries, backoff, bounded memory/network/file/process behavior, lifecycle
     cleanup, shutdown/drain/health/readiness behavior, observability or operator
     impact, and CI/sidecar/runtime controls that were checked. If any of these
     were not applicable, say why.
-18. If no confirmed gaps remain, report that result with the no-finding closeout
+20. If no confirmed gaps remain, report that result with the no-finding closeout
     required by the shared gap workflow, do not create `RELIABILITY.md`, and
     stop.
-19. If confirmed gaps remain, write the scoped `RELIABILITY.md` with
+21. If confirmed gaps remain, write the scoped `RELIABILITY.md` with
     `REL-<number>` IDs.
-20. Present the scoped ledger, proposed reliability-fix plan, coverage state for
+22. Present the scoped ledger, proposed reliability-fix plan, coverage state for
     broad scopes, and runnable follow-up scopes for deferred slices.
-21. Stop before making fixes.
+23. Stop before making fixes.
 
 ## Implement Mode Plan
 


### PR DESCRIPTION
## What

- Add shared audit workflow rules for evidence tracking, validation classification, no-findings closeouts, and scoped ledger creation.
- Add a confidence rubric tying claims to inventory, analyzers, tests, lint, security, generated freshness, and environment blockers.
- Move Go-specific audit examples into Go conventions while keeping code-issues and reliability-gaps plans/prompts aligned with neutral inventory wording.

## Why

- Makes code-issue and reliability-gap audit runs more repeatable and evidence-backed without forcing Go-specific assumptions into shared guidance.
- Reduces false positives by distinguishing confirmed findings from environment/tooling gaps and avoiding ledgers when no durable findings exist.

## Testing

- `make skills-lint` - passed
- `git diff --check` - passed
