### PR TITLE
feat(skills): require approval for incidental edits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,15 @@ Agents MUST:
   repository-owned dependency/tooling response; route project-owned upstream
   library bugs to that library's agent or ledger unless local adapter behavior is
   independently wrong.
+- Treat unowned working-tree changes as human changes by default. Do not undo,
+  overwrite, reformat, relocate, or "clean up" changes the agent did not make;
+  if they affect the current task, explain the conflict and ask before editing
+  them.
+- When reviewing, auditing, or incidentally noticing an issue outside the
+  current explicitly approved implementation scope, validate the candidate
+  against repository evidence and present the proposed fix before editing. When
+  more than one credible fix exists, compare the practical options and evidence
+  instead of implementing a self-selected design.
 - Follow existing repository patterns over personal judgment.
 - Treat skill workflow steps using "must", "do not", or "stop" language as
   blocking requirements.
@@ -74,6 +83,11 @@ Agents MUST NOT:
   contract changes.
 - Introduce import aliases, abstractions, helpers, files, or validation paths
   for personal clarity when local patterns already exist.
+- Start edits for review findings, audit findings, incidental discoveries, or
+  adjacent issues before the human approves what will change. When multiple
+  credible approaches exist, present the options and evidence first. This gate
+  is waived only when the current request explicitly says not to use it or
+  grants free-form implementation authority for that scope.
 - Treat `AGENTS.md` or `SKILL.md` instructions as optional.
 - Continue after discovering they violated an instruction; they must correct
   course immediately and remove their own noncompliant change.


### PR DESCRIPTION
## What

- Adds agent rules that treat unowned working-tree changes as human-owned by default and require asking before touching conflicting changes.
- Adds review, audit, and incidental-discovery guidance to validate candidates, present proposed fixes, compare credible approaches, and wait for approval of planned edits unless the request grants free-form authority.

## Why

- Prevents agents from undoing human work or silently expanding review or discovery scope with self-selected fixes.
- Keeps the policy in `AGENTS.md`, the shared authoritative operating-rules surface.

## Testing

- `zsh -lic 'make dep'` - passed
- `zsh -lic 'make clean-dep'` - passed
- `zsh -lic 'make scripts-lint'` - passed
- `zsh -lic 'make skills-lint'` - passed
- `zsh -lic 'make docker-lint'` - passed
- `zsh -lic 'make lint'` - passed
- `zsh -lic 'make sec'` - passed
- `git diff --check -- AGENTS.md` - passed
- Initialized-shell Make checks emitted sandbox startup warnings from oh-my-zsh cache and zcompdump permissions, but each command exited 0.
