### PR TITLE
feat(make): add targeted fuzz command support

### DIFF
--- a/build/go/fuzz
+++ b/build/go/fuzz
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091
+# Run one Go fuzz target for a bounded time.
+
+set -eo pipefail
+
+if [[ -z ${package:-} ]]; then
+  echo "missing package" >&2
+  exit 1
+fi
+
+if [[ -z ${name:-} ]]; then
+  echo "missing name" >&2
+  exit 1
+fi
+
+source "$(dirname "$0")/../../lib/validate.sh"
+validate_package
+
+go test -vet=off -mod vendor -run '^$' "-fuzz=$name" "-fuzztime=${fuzztime:-10s}" "./$package"

--- a/build/make/_service.mak
+++ b/build/make/_service.mak
@@ -16,6 +16,8 @@ override export image_type := $(value image_type)
 override export module := $(value module)
 override export id := $(value id)
 override export kind := $(value kind)
+override export name := $(value name)
+override export fuzztime := $(value fuzztime)
 
 download:
 	@go mod download
@@ -114,6 +116,10 @@ benchmarks: build
 # Set package=internal/foo, not ./internal/foo, to test one package.
 specs:
 	@$(BIN_ROOT)/build/go/test "$(if $(package),,$(COVER_PACKAGES))" $(if $(package),,$(PACKAGES))
+
+# Fuzz one Go target. Set package=internal/foo and name=FuzzName; fuzztime defaults to 10s.
+fuzz:
+	@$(BIN_ROOT)/build/go/fuzz
 
 # Fetch a Go module (set module=<path>).
 go-get:

--- a/build/make/go.mak
+++ b/build/make/go.mak
@@ -13,6 +13,8 @@ override export kind := $(value kind)
 override export module := $(value module)
 override export package := $(value package)
 override export benchtime := $(value benchtime)
+override export name := $(value name)
+override export fuzztime := $(value fuzztime)
 
 download:
 	@go mod download
@@ -84,6 +86,10 @@ format:
 # Set package=internal/foo, not ./internal/foo, to test one package.
 specs:
 	@$(BIN_ROOT)/build/go/test "$(if $(package),,$(COVER_PACKAGES))" $(if $(package),,$(PACKAGES))
+
+# Fuzz one Go target. Set package=internal/foo and name=FuzzName; fuzztime defaults to 10s.
+fuzz:
+	@$(BIN_ROOT)/build/go/fuzz
 
 # Run benchmarks for package=internal/foo, or the module root when unset.
 # Set benchtime=<duration-or-count> to pass -benchtime to go test.


### PR DESCRIPTION
## What

- Add a shared Go fuzz wrapper that runs one named fuzz target for a bounded duration.
- Expose `make fuzz package=... name=...` from both standalone Go and service Make fragments.
- Preserve existing package-path validation and default fuzz runs to `10s` unless `fuzztime` is supplied.

## Why

- Gives downstream Go repositories a standard Make entrypoint for targeted fuzz campaigns instead of copying ad hoc `go test -fuzz` commands.
- Keeps fuzzing intentionally scoped to one package and one target so it is practical for local security and parser hardening work.

## Testing

- `git diff --check` - passed
- `bash -n build/go/fuzz` - passed
- `gmake scripts-lint` - passed
- `gmake -f /Users/alejandro/code/bin/build/make/help.mak -f /Users/alejandro/code/bin/build/make/go.mak fuzz package=sample name=FuzzEcho fuzztime=1x` - passed in a temporary Go module
