### PR TITLE
feat(skills): surface actionable health and comparable leads

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -69,8 +69,8 @@ or approved escalation path, or report the blocker.
   command discovery, and workflow gaps in `PROJECTS.md`.
 - `reliability-gaps`: records SRE, operability, overload, observability,
   release-safety, recovery, or data-integrity gaps in `RELIABILITY.md`.
-- `repo-health`: summarizes delivery, CI, release/deploy, and reliability
-  health from supported sources.
+- `repo-health`: summarizes actionable delivery, CI, release/deploy, and
+  reliability health from supported sources.
 - `diagnose-issue`: performs read-only diagnosis of selected CI, deployment,
   rollout, runtime, monitor, or latest-version failures.
 - `code-review`: reviews for bugs, regressions, compatibility, missing

--- a/skills/references/comparable-lead-generation.md
+++ b/skills/references/comparable-lead-generation.md
@@ -1,0 +1,130 @@
+# Comparable Lead Generation
+
+Use this reference from `gap-lead-generation.md` when a ledger-style find,
+audit-only, or one-pass review would benefit from similar repositories,
+templates, or ecosystem frameworks. Comparable evidence improves recall only;
+it does not lower the selected skill's ownership, confidence, reproduction,
+validation, or approval gates.
+
+## When To Use
+
+Use comparable lead generation for broad or ambiguous scopes, shared tooling,
+service templates, reusable libraries, project workflow reviews, reliability
+reviews, test-harness reviews, documentation audits, and feature discovery.
+
+Skip it when the requested scope is narrow, the relevant behavior is already
+fully explained by local evidence, the run is blocked by time or permissions,
+or comparable research would mainly add parity/taste ideas instead of
+repository-owned risks.
+
+## GitHub Inventory First
+
+Treat the GitHub owner as the canonical inventory and local checkouts as the
+evidence cache.
+
+Default owner selection:
+
+1. Use the owner explicitly named by the human.
+2. Otherwise derive the owner from the current repository's `origin` remote.
+3. In this repository ecosystem, use `alexfalkowski` when the owner is still
+   ambiguous.
+
+Use `gh repo list` when GitHub network/auth access is available and approved:
+
+```sh
+gh repo list <owner> --limit 1000 \
+  --json nameWithOwner,sshUrl,url,isArchived,isFork,primaryLanguage,repositoryTopics,pushedAt
+```
+
+If `gh` is unavailable, unauthenticated, blocked by sandbox/network policy, or
+not approved for the current request, record GitHub inventory as `blocked` and
+continue with local-only comparable evidence only when that still supports the
+selected skill's confidence threshold.
+
+## Local Checkout Mapping
+
+Do not hard-code a machine-specific checkout path into a skill. Discover local
+checkouts from configured or inferred roots:
+
+1. Use `CODEX_REPO_ROOTS` when set. Treat it as a colon-separated list of
+   search roots.
+2. Otherwise search the current repository's parent directory and, when useful,
+   its grandparent directory.
+3. If no plausible local checkout root exists and comparable evidence is needed
+   for credible confidence, ask the human for a local checkout root.
+
+For each candidate local Git repository, read its origin and normalize SSH,
+HTTPS, and `ssh://` GitHub URLs to `owner/repo`:
+
+```sh
+git -C <candidate> remote get-url origin
+```
+
+Use local checkouts only when their normalized `owner/repo` matches the GitHub
+inventory. Treat unmatched local directories, forks, mirrors, vendored
+submodules, generated repos, and archived repos as supporting context only
+unless the selected scope explicitly owns them.
+
+## Selecting Comparables
+
+Prefer a small, relevant comparison set:
+
+- same archetype: service, library, shared tooling, Docker/infra, Ruby/static;
+- same public surface: gRPC, HTTP, CLI, package API, Make fragment, test
+  harness, release workflow, or operator workflow;
+- same shared dependency or template family;
+- recent activity or recent changes in the same area;
+- known consumers of the package, helper, command, or shared `bin` behavior.
+
+Record which comparables were checked and why. For broad no-finding closeout,
+also record relevant comparables that were skipped, blocked, or deferred.
+
+## What To Compare
+
+Use comparables to generate leads for the selected skill:
+
+- `code-issues`: contract drift, sibling error cases, adapter mappings,
+  generated/provider values, compatibility behavior, and supported call paths.
+- `test-gaps`: dominant harness shape, feature/scenario coverage, failure-path
+  coverage, fixtures, flaky-test controls, fuzz/benchmark/race/property tests,
+  and wrong-layer tests.
+- `doc-gaps`: README shape, command help, API examples, operational notes,
+  migration notes, configuration docs, and discoverability.
+- `feature-gaps`: product-facing capabilities, service-author ergonomics,
+  operator diagnostics, extension points, and first-use workflows.
+- `project-gaps`: Make targets, CI jobs, setup, command discovery,
+  validation preflight, release/versioning, generated checks, and shared
+  tooling ownership.
+- `reliability-gaps`: health/readiness, startup/shutdown/drain, overload,
+  timeout/retry/backpressure, observability, rollback, recovery, and
+  deployment controls.
+
+## External Frameworks
+
+Use external frameworks only as lead-generation checklists, not as acceptance
+evidence:
+
+- DORA for delivery, deploy, change failure, and recovery leads.
+- SPACE or DevEx-style frameworks for balanced productivity signals and
+  avoiding activity-only conclusions.
+- OpenSSF Scorecard-style checks for security and project-health leads.
+- Backstage/catalog scorecard ideas for ownership, metadata, discoverability,
+  service classification, and operational maturity leads.
+
+Do not record a finding merely because a comparable repository or framework has
+something the target lacks. First prove the target repository owns the surface,
+the current limitation is real, the audience benefits, and the smallest fix
+fits local patterns.
+
+## Accounting
+
+Include comparable evidence in the selected skill's normal lead accounting:
+
+- `Confirmed`: comparable lead became a local finding after reproduction.
+- `Rejected`: comparable pattern does not fit, is already covered, or is only
+  parity/taste.
+- `Routed`: lead belongs to shared `bin`, another repository, an upstream
+  library, a third-party tool, or another ledger skill.
+- `Deferred`: exact comparable repo or framework area not reviewed deeply.
+- `Blocked`: GitHub inventory, local checkout mapping, auth, network, or local
+  root discovery was unavailable.

--- a/skills/references/gap-lead-generation.md
+++ b/skills/references/gap-lead-generation.md
@@ -7,16 +7,23 @@ selected skill applies its evidence gate.
 ## How To Use
 
 1. Classify the requested scope by repository archetype and public surface.
-2. Build a lead inventory from the matching archetype prompts below.
-3. For each lead, choose the owning workflow before investigating deeply.
-4. Try to disprove each lead using current code, docs, tests, command behavior,
+2. Use `comparable-lead-generation.md` when sibling repositories, GitHub owner
+   inventory, local checkouts, or external framework checklists would improve
+   recall for the requested scope.
+3. Build a lead inventory from the matching archetype prompts below and any
+   applicable comparable leads.
+4. For each lead, choose the owning workflow before investigating deeply.
+5. Try to disprove each lead using current code, docs, tests, command behavior,
    CI, generated contracts, and supported usage evidence.
-5. Record only leads that satisfy the selected skill's confidence and
+6. Record only leads that satisfy the selected skill's confidence and
    reproduction rules. Report rejected, routed, deferred, and blocked leads in
    closeout so a quiet audit still shows what was checked.
 
 Lead generation finds candidates; it does not lower confidence, ownership,
 reproduction, validation, or approval gates.
+Comparable systems are recall evidence only: do not record a finding merely
+because a sibling repository, GitHub inventory item, or external framework has a
+pattern the target lacks.
 
 ## Repository Archetypes
 
@@ -141,6 +148,10 @@ Before no-finding or incomplete closeout, include compact accounting:
 - `Deferred`: exact follow-up scopes that were not reviewed deeply.
 - `Blocked`: leads blocked by missing tools, credentials, services, sandbox,
   or ambiguous setup.
+
+When comparable lead generation was used or skipped, include the GitHub owner,
+matched local checkouts, comparable repositories, external frameworks, and any
+blocked inventory or checkout-mapping steps in the accounting.
 
 Rejected and routed leads should be brief, but they must be specific enough for
 a later reviewer to understand why the audit did not record them.

--- a/skills/references/gap-workflow.md
+++ b/skills/references/gap-workflow.md
@@ -56,8 +56,9 @@ Use these mechanics with the selected skill's `references/plan.md`. The plan
 names the domain-specific inventory surfaces, candidate tests, closeout
 questions, ledger filename, ID prefix, and implementation pairings.
 Use `gap-lead-generation.md` during find, audit-only, and one-pass modes to
-classify repository archetypes, build a lead inventory, and account for
-confirmed, rejected, routed, deferred, and blocked leads.
+classify repository archetypes, build a lead inventory, use comparable
+repositories or framework checklists when useful, and account for confirmed,
+rejected, routed, deferred, and blocked leads.
 
 For find, audit-only, and one-pass modes:
 
@@ -304,6 +305,11 @@ For implement modes:
   selected skill's plan and `gap-lead-generation.md`. Lead inventory is a recall
   tool only: it does not lower the selected skill's confidence, ownership,
   reproduction, validation, or approval gates.
+- Treat comparable repository and external-framework evidence as lead
+  generation only. Before recording a candidate derived from GitHub owner
+  inventory, local checkout mapping, sibling repositories, or external
+  frameworks, reproduce the current repository-owned limitation through the
+  selected skill's normal evidence path.
 - Confirm each candidate against current code, docs, examples, tests, command
   behavior, CI config, generated contracts, and public interfaces relevant to
   the selected skill before recording, fixing, or dismissing it.

--- a/skills/repo-health/SKILL.md
+++ b/skills/repo-health/SKILL.md
@@ -8,7 +8,8 @@ description: Use when the user asks for repo health, repository health report, d
 Use this skill to turn repository activity and operational evidence into a
 concise daily or weekly engineering-health report. Report what changed, whether
 delivery was smooth, and whether the repo or service looks healthier than the
-comparison period.
+comparison period. Convert measured bottlenecks into prioritized,
+evidence-backed follow-up actions that repository owners can complete.
 
 ## Workflow
 
@@ -46,7 +47,13 @@ comparison period.
 9. Keep collection read-only. API calls, `gh`, `curl`, `git log`, and
    repository searches are acceptable; do not modify remote systems, clusters,
    monitors, branches, PRs, or releases while producing the summary.
-10. Produce the summary in Markdown tables with a short narrative. Do not create
+10. Identify the top bottleneck from the collected evidence. Use `None from the
+   available data` when no threshold-backed bottleneck is present.
+11. Produce a prioritized action queue from stale PRs, review latency, CI
+   failures, deploy failures, flaky tests, release readiness, rollbacks,
+   incidents, uptime, response time, Kubernetes readiness, and missing material
+   data sources.
+12. Produce the summary in Markdown tables with a short narrative. Do not create
    files unless the user asks for a durable report.
 
 ## Reporting Rules
@@ -62,6 +69,8 @@ comparison period.
 - Prefer medians over averages for age, lead-time, duration, and recovery-time
   metrics.
 - Prefer period-over-period deltas over standalone counts.
+- Prefer threshold-backed action items over generic recommendations.
+- Include four-window trend context when the collector returns enough data.
 - Include exact window boundaries in the final report.
 - Call out interpretation separately from measured facts.
 
@@ -69,15 +78,17 @@ comparison period.
 
 - **Weekly**: Best for management rhythm, maintenance review, and service
   health. Include delivery flow, CI quality, release/deploy activity, service
-  reliability when applicable, notable changes, and risks.
+  reliability when applicable, trend context, notable changes, and prioritized
+  action items.
 - **Daily**: Best for operational check-ins. Emphasize yesterday/today flow,
   failed checks, deploys, incidents, open review bottlenecks, and follow-up
   actions.
 - **Library**: Omit service reliability unless monitors or deploys exist.
   Emphasize maintenance throughput, release readiness, CI, dependency/security
-  signals when available, and downstream-impact notes visible in the repo.
+  signals when available, unreleased commits, latest release age, and
+  downstream-impact notes visible in the repo.
 - **Service**: Include deployment, uptime, incident, response-time, Kubernetes,
-  and monitor-health evidence when available.
+  monitor-health evidence, and operational follow-up actions when available.
 
 ## References
 

--- a/skills/repo-health/agents/openai.yaml
+++ b/skills/repo-health/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Repo Health"
-  short_description: "Summarize repo delivery and health"
-  default_prompt: "Use $repo-health to produce daily or weekly delivery, CI quality, release/deploy, and service-reliability summaries for the requested repository and period, with explicit comparison windows and missing-source boundaries."
+  short_description: "Summarize actionable repo health"
+  default_prompt: "Use $repo-health to produce daily or weekly delivery, CI quality, release/deploy, and service-reliability summaries for the requested repository and period, with explicit comparison windows, top bottleneck, prioritized action queue, trend context, and missing-source setup actions."

--- a/skills/repo-health/references/metrics.md
+++ b/skills/repo-health/references/metrics.md
@@ -15,6 +15,45 @@ For GitHub search date ranges, use inclusive date syntax for the calendar dates
 that correspond to the requested window, then filter timestamps precisely when
 the API returns full timestamps.
 
+## Action Thresholds
+
+Use thresholds to turn measured facts into follow-up work. Thresholds are
+triage triggers, not hard service objectives, unless the repository documents a
+stricter target.
+
+| Trigger | Suggested Priority | Action |
+| --- | --- | --- |
+| Workflow success rate below 90% | P1 | Inspect failed workflows before merging or releasing. |
+| Any failed deploy job | P1 | Inspect failed deploy jobs before the next release. |
+| Any incident, rollback, revert, or uptime below 99.9% | P1 | Review the incident, release, or rollback path and confirm recovery. |
+| Any stale PR older than 7 days | P2 | Close, merge, or revive each stale PR. |
+| Median PR age, review latency, p95 workflow duration, or response time worsens by more than 25% | P2 or P3 | Inspect the bottleneck owner: review, CI, runtime, or dependencies. |
+| Any flaky test reported by CircleCI | P2 | Fix or quarantine the named flaky tests. |
+| Unreleased commits exist and no release/tag was created in the period | P3 | Decide whether accumulated library changes need a release. |
+| Unreleased commits exist and the latest release is older than 90 days | P2 | Review release readiness and downstream impact. |
+
+Use `P1` for work that can block release, deployment, or reliable operation.
+Use `P2` for active bottlenecks or trust issues. Use `P3` for maintenance work
+that should be scheduled but is not blocking the current flow.
+
+## Trend Context
+
+When data is available, include a four-window trend for high-signal metrics:
+the current window, previous window, and two older same-length windows. Report
+the current value, previous value, four-window median, delta from median, and
+signal.
+
+Use trend context for:
+
+- median PR age and review latency;
+- workflow success rate, failed workflow count, and p95 workflow duration;
+- tag/release count, deploy failures, and rollback or revert count;
+- uptime, incident count, downtime, and average response time.
+
+Do not over-interpret trends with missing source data or very small sample
+sizes. Call those limits out in `Risks And Follow-Ups` or `Data Quality
+Actions`.
+
 ## Delivery Flow
 
 | Metric | Definition |
@@ -27,6 +66,7 @@ the API returns full timestamps.
 | Stale PRs | Open PRs with no commits, comments, review, or status update for at least 7 days unless the repo has another documented threshold. |
 | Median PR age | Median time from PR creation to merge for PRs merged in the period. |
 | Median review latency | Median time from PR creation to first human review or review comment when available. |
+| Release readiness | Latest tag, latest tag age, and unreleased commit count when tag history is available. |
 
 Interpretation:
 
@@ -71,6 +111,8 @@ For libraries, treat releases as the deployment analogue. For services, prefer
 actual deploy events over inferred tag or image activity.
 When CI has explicit deploy jobs, report successful deploy jobs and failed
 deploy jobs separately from releases/tags.
+For library repos, call out unreleased commits, latest release age, and whether
+the current period produced a tag or release.
 
 ## Service Reliability
 

--- a/skills/repo-health/references/output.md
+++ b/skills/repo-health/references/output.md
@@ -15,13 +15,17 @@ Start with the repository and exact window:
 Then include these sections:
 
 1. `**Summary**`
-2. `**Delivery Flow**`
-3. `**CI Quality**`
-4. `**Release And Deploy**`
-5. `**Service Reliability**` for services only
-6. `**Notable Work**`
-7. `**Risks And Follow-Ups**`
-8. `**Data Sources**`
+2. `**Top Bottleneck**`
+3. `**Action Queue**`
+4. `**Delivery Flow**`
+5. `**CI Quality**`
+6. `**Release And Deploy**`
+7. `**Service Reliability**` for services only
+8. `**Trend Context**`
+9. `**Notable Work**`
+10. `**Risks And Follow-Ups**`
+11. `**Data Quality Actions**`
+12. `**Data Sources**`
 
 Omit `Service Reliability` for libraries unless service evidence exists.
 
@@ -34,6 +38,39 @@ Good examples:
 - `Delivery improved: 12 PRs merged versus 8 in the prior week, while median PR age fell from 2.1d to 1.3d.`
 - `CI is the main weak spot: success rate dropped to 84% and the deploy workflow accounts for most failures.`
 - `Service health was steady: uptime stayed at 99.99% with no visible incidents.`
+
+## Top Bottleneck
+
+Name the highest-priority actionable bottleneck from the measured data. Keep it
+to one line. If there is no evidence-backed bottleneck, write:
+
+```markdown
+- None from the available data.
+```
+
+Good example:
+
+```markdown
+- P1 CI: workflow success rate is 82.0% with 3 failed workflows; inspect the latest failed workflows before merging or releasing.
+```
+
+## Action Queue
+
+List actionable work in priority order. Use only evidence-backed actions from
+the collected data or write `- None from the available data.`
+
+```markdown
+| Priority | Area | Evidence | Suggested Action |
+| --- | --- | --- | --- |
+| P1 | CI | Workflow success rate is 82.0% with 3 failed workflows. | Inspect the latest failed workflows before merging or releasing. |
+| P2 | Review | 4 open PRs are stale for more than 7 days. | Close, merge, or revive each stale PR. |
+```
+
+Use priorities as:
+
+- `P1`: blocks release, deployment, or reliable operation;
+- `P2`: active bottleneck, quality issue, or reliability trust issue;
+- `P3`: maintenance follow-up that should be scheduled.
 
 ## Metric Tables
 
@@ -57,6 +94,21 @@ Use `n/a` for unavailable values. In `Signal`, use:
 
 Use `better` or `worse` only when direction clearly maps to health. Use `up` or
 `down` for neutral volume changes.
+
+## Trend Context
+
+When the collector returns trend context, include compact trend tables for the
+most useful metrics. Prefer one table per area only when data is available.
+
+```markdown
+| Metric | Current | Previous | 4-window Median | Delta From Median | Signal |
+| --- | ---: | ---: | ---: | ---: | --- |
+| Workflow success rate | 82.0% | 96.0% | 94.0% | -12.0pp | worse |
+| p95 workflow duration | 18.2m | 12.1m | 12.5m | +5.7m | worse |
+```
+
+If trend data is missing or partial, say which source is missing rather than
+filling trend values with guessed numbers.
 
 ## Notable Work
 
@@ -82,6 +134,23 @@ If a metric is collection-time only, stale, or based on partial samples, call
 that out here rather than hiding it in the data-source table.
 If CircleCI has `max_auto_reruns`, mention the rerun context when discussing
 workflow failure counts.
+
+## Data Quality Actions
+
+List source setup work that would make the report more actionable:
+
+```markdown
+| Source | Missing Impact | Setup Action |
+| --- | --- | --- |
+| CircleCI | Cannot measure workflow reliability, duration, deploy, or flaky-test metrics. | Ensure CircleCI API access and set `CIRCLE_TOKEN` or configure the CLI token. |
+| UptimeRobot | Cannot measure external uptime, incident, MTTR, or response-time metrics. | Ensure UptimeRobot API access and set `UPTIMEROBOT_API_KEY` plus `UPTIMEROBOT_MONITOR_IDS`. |
+```
+
+If all material sources were available or intentionally skipped, write:
+
+```markdown
+- None.
+```
 
 ## Data Sources
 

--- a/skills/repo-health/references/sources.md
+++ b/skills/repo-health/references/sources.md
@@ -136,8 +136,8 @@ Useful read-only API pattern:
 
 1. List project pipelines for `gh/<owner>/<repo>` and the relevant branch:
    `/api/v2/project/gh/<owner>/<repo>/pipeline?branch=<branch>`.
-2. Page backward until the oldest collected pipeline is before the comparison
-   period start.
+2. Page backward until the oldest collected pipeline is before the oldest
+   requested trend window.
 3. For each pipeline, list workflows with `/api/v2/pipeline/<pipeline-id>/workflow`.
 4. Bucket workflows by `created_at`; count completed workflows, successes, and
    failures.
@@ -227,8 +227,9 @@ Useful data:
 When only a public status page is available, report only the facts visible from
 that page and label them as public status-page evidence.
 When an API key is available, use `custom_uptime_ranges` with exact Unix-second
-window boundaries for current and comparison periods. UptimeRobot returns the
-range values as a hyphen-separated string in the same order as requested.
+window boundaries for current, comparison, and trend periods. UptimeRobot
+returns the range values as a hyphen-separated string in the same order as
+requested.
 Request `logs=1` for incidents and `response_times=1` for response-time
 samples. If response-time samples do not cover the comparison window, report the
 previous response time as `n/a` instead of reusing account-level averages.

--- a/skills/repo-health/scripts/collect.rb
+++ b/skills/repo-health/scripts/collect.rb
@@ -15,6 +15,11 @@ require 'yaml'
 # sources, then prints a JSON document for the skill to summarize.
 class RepoHealthCollector
   HTTP_TIMEOUT_SECONDS = 15
+  TREND_WINDOW_COUNT = 4
+  STALE_PR_SECONDS = 7 * 24 * 60 * 60
+  CI_SUCCESS_RATE_ACTION_THRESHOLD = 0.90
+  CHANGE_RATIO_ACTION_THRESHOLD = 0.25
+  LIBRARY_RELEASE_AGE_ACTION_SECONDS = 90 * 24 * 60 * 60
 
   def initialize(options)
     @repo_path = File.expand_path(options.fetch(:repo_path))
@@ -88,6 +93,8 @@ class RepoHealthCollector
       cd_file: File.exist?(File.join(root, '.cd')),
       current: local_period(@current_start, @current_end),
       previous: local_period(@previous_start, @previous_end),
+      trend: period_windows.map { |window| local_period(window.fetch(:start), window.fetch(:end)) },
+      release_state: local_release_state,
       circleci_config: circleci_config(root)
     }
   end
@@ -123,6 +130,20 @@ class RepoHealthCollector
     }
   end
 
+  def local_release_state
+    latest = git_lines('for-each-ref', 'refs/tags', '--sort=-creatordate',
+                       '--format=%(refname:short)%09%(creatordate:iso-strict)').first
+    return { latest_tag: nil, unreleased_commit_count: git('rev-list', '--count', 'HEAD').to_i } unless latest
+
+    tag, created_at = latest.split("\t", 2)
+    {
+      latest_tag: tag,
+      latest_tag_created_at: created_at,
+      latest_release_age_seconds: @now - Time.parse(created_at),
+      unreleased_commit_count: git('rev-list', '--count', "#{tag}..HEAD").to_i
+    }
+  end
+
   def circleci_config(root)
     path = File.join(root, '.circleci', 'config.yml')
     return { present: false } unless File.exist?(path)
@@ -148,12 +169,14 @@ class RepoHealthCollector
     )
     stale_prs = open_prs.select do |pull_request|
       updated = pull_request['updatedAt'] && Time.parse(pull_request.fetch('updatedAt'))
-      updated && updated < @current_end - (7 * 24 * 60 * 60)
+      updated && updated < @current_end - STALE_PR_SECONDS
     end
+    trend = period_windows.map { |window| github_period(owner_repo, window.fetch(:start), window.fetch(:end)) }
 
     {
-      current: github_period(owner_repo, @current_start, @current_end),
-      previous: github_period(owner_repo, @previous_start, @previous_end),
+      current: trend[0],
+      previous: trend[1],
+      trend: trend,
       open_pr_count: open_prs.length,
       open_prs: open_prs,
       stale_pr_count: stale_prs.length,
@@ -217,10 +240,12 @@ class RepoHealthCollector
     workflows = circleci_workflows(pipelines, token)
     jobs = @include_jobs || mode == 'service' ? circleci_jobs(workflows, token) : []
     flaky = circleci_get("/insights/gh/#{owner_repo}/flaky-tests?branch=#{url_query(branch)}", token)
+    trend = period_windows.map { |window| circleci_period(workflows, jobs, window.fetch(:start), window.fetch(:end)) }
 
     {
-      current: circleci_period(workflows, jobs, @current_start, @current_end),
-      previous: circleci_period(workflows, jobs, @previous_start, @previous_end),
+      current: trend[0],
+      previous: trend[1],
+      trend: trend,
       flaky_tests: {
         total: flaky['total_flaky_tests'],
         examples: flaky.fetch('flaky_tests', []).map do |test|
@@ -331,7 +356,7 @@ class RepoHealthCollector
     key = ENV.fetch('UPTIMEROBOT_API_KEY', '').strip
     return unavailable('UPTIMEROBOT_API_KEY is not set') if key.empty?
 
-    ranges = "#{@current_start.to_i}_#{@current_end.to_i}-#{@previous_start.to_i}_#{@previous_end.to_i}"
+    ranges = period_windows.map { |window| "#{window.fetch(:start).to_i}_#{window.fetch(:end).to_i}" }.join('-')
     params = {
       'api_key' => key,
       'format' => 'json',
@@ -355,6 +380,9 @@ class RepoHealthCollector
     samples = monitor.fetch('response_times', [])
     current_samples = response_samples(samples, @current_start, @current_end)
     previous_samples = response_samples(samples, @previous_start, @previous_end)
+    response_averages = period_windows.map do |window|
+      average(response_samples(samples, window.fetch(:start), window.fetch(:end)))
+    end
 
     {
       status: 'used',
@@ -364,7 +392,8 @@ class RepoHealthCollector
       current_response_time_average_ms: average(current_samples),
       current_response_time_samples: current_samples.length,
       previous_response_time_average_ms: average(previous_samples),
-      previous_response_time_samples: previous_samples.length
+      previous_response_time_samples: previous_samples.length,
+      response_time_average_ms_by_period: response_averages
     }
   rescue StandardError => e
     unavailable(e.message)
@@ -412,6 +441,14 @@ class RepoHealthCollector
   end
 
   def summary_result(result)
+    delivery_flow = summary_delivery_flow(result)
+    ci_quality = summary_ci_quality(result)
+    release_and_deploy = summary_release_and_deploy(result)
+    service_reliability = summary_service_reliability(result)
+    trend_context = summary_trend_context(result)
+    action_queue = summary_action_queue(delivery_flow, ci_quality, release_and_deploy, service_reliability)
+    data_quality_actions = summary_data_quality_actions(result)
+
     {
       repository: result[:repository],
       repo_path: result[:repo_path],
@@ -421,10 +458,14 @@ class RepoHealthCollector
       window: result[:window],
       comparison_window: result[:comparison_window],
       sources: source_summary(result),
-      delivery_flow: summary_delivery_flow(result),
-      ci_quality: summary_ci_quality(result),
-      release_and_deploy: summary_release_and_deploy(result),
-      service_reliability: summary_service_reliability(result),
+      top_bottleneck: summary_top_bottleneck(action_queue),
+      action_queue: action_queue,
+      trend_context: trend_context,
+      data_quality_actions: data_quality_actions,
+      delivery_flow: delivery_flow,
+      ci_quality: ci_quality,
+      release_and_deploy: release_and_deploy,
+      service_reliability: service_reliability,
       notable_work: summary_notable_work(result)
     }
   end
@@ -445,7 +486,8 @@ class RepoHealthCollector
       previous: summary_delivery_period(result.dig(:local, :previous), summary_github_period(github, :previous)),
       open_pr_count: github_value(github, :open_pr_count),
       stale_pr_count: github_value(github, :stale_pr_count),
-      stale_prs: github_value(github, :stale_prs)
+      stale_prs: github_value(github, :stale_prs),
+      release_state: result.dig(:local, :release_state)
     }
   end
 
@@ -469,6 +511,7 @@ class RepoHealthCollector
     {
       current: summary_ci_period(circleci[:current]),
       previous: summary_ci_period(circleci[:previous]),
+      trend: circleci[:trend]&.map { |period| summary_ci_period(period) },
       flaky_tests: circleci[:flaky_tests],
       config: circleci[:config],
       pipelines_collected: circleci[:pipelines_collected],
@@ -496,7 +539,8 @@ class RepoHealthCollector
   def summary_release_and_deploy(result)
     {
       current: summary_release_period(result.dig(:local, :current), result.dig(:circleci, :current)),
-      previous: summary_release_period(result.dig(:local, :previous), result.dig(:circleci, :previous))
+      previous: summary_release_period(result.dig(:local, :previous), result.dig(:circleci, :previous)),
+      release_state: result.dig(:local, :release_state)
     }
   end
 
@@ -544,11 +588,397 @@ class RepoHealthCollector
       current_uptime: current_uptime,
       previous_uptime: previous_uptime,
       logs: uptimerobot[:logs],
+      current_incident_count: incident_logs(uptimerobot[:logs], @current_start, @current_end).length,
+      previous_incident_count: incident_logs(uptimerobot[:logs], @previous_start, @previous_end).length,
+      current_downtime_seconds: downtime_seconds(uptimerobot[:logs], @current_start, @current_end),
+      previous_downtime_seconds: downtime_seconds(uptimerobot[:logs], @previous_start, @previous_end),
+      current_mttr_seconds: mttr_seconds(uptimerobot[:logs], @current_start, @current_end),
+      previous_mttr_seconds: mttr_seconds(uptimerobot[:logs], @previous_start, @previous_end),
       current_response_time_average_ms: uptimerobot[:current_response_time_average_ms],
       current_response_time_samples: uptimerobot[:current_response_time_samples],
       previous_response_time_average_ms: uptimerobot[:previous_response_time_average_ms],
-      previous_response_time_samples: uptimerobot[:previous_response_time_samples]
+      previous_response_time_samples: uptimerobot[:previous_response_time_samples],
+      trend: summary_uptimerobot_trend(uptimerobot)
     }
+  end
+
+  def summary_trend_context(result)
+    {
+      window_count: TREND_WINDOW_COUNT,
+      windows: trend_window_summary,
+      delivery_flow: trend_metrics(summary_delivery_trend(result), {
+                                     commit_count: :neutral,
+                                     pr_merged: :neutral,
+                                     median_pr_age_seconds: :lower,
+                                     median_review_latency_seconds: :lower
+                                   }),
+      ci_quality: trend_metrics(summary_ci_trend(result), {
+                                  workflow_success_rate: :higher,
+                                  workflows_failed: :lower,
+                                  p95_workflow_duration_seconds: :lower
+                                }),
+      release_and_deploy: trend_metrics(summary_release_trend(result), {
+                                          tag_count: :neutral,
+                                          deploy_job_failed: :lower,
+                                          rollback_or_revert_count: :lower
+                                        }),
+      service_reliability: trend_metrics(summary_service_reliability_trend(result), {
+                                           uptime: :higher,
+                                           incident_count: :lower,
+                                           response_time_average_ms: :lower,
+                                           downtime_seconds: :lower
+                                         })
+    }
+  end
+
+  def summary_action_queue(delivery_flow, ci_quality, release_and_deploy, service_reliability)
+    actions = []
+    actions.concat(delivery_actions(delivery_flow))
+    actions.concat(ci_actions(ci_quality))
+    actions.concat(release_actions(release_and_deploy))
+    actions.concat(reliability_actions(service_reliability))
+    actions.sort_by { |action| [priority_rank(action.fetch(:priority)), action.fetch(:area)] }
+  end
+
+  def summary_top_bottleneck(action_queue)
+    action = action_queue.first
+    return nil unless action
+
+    pick_symbol(action, :priority, :area, :evidence, :suggested_action)
+  end
+
+  def summary_data_quality_actions(result)
+    actions = []
+    sources = source_summary(result)
+    actions << data_quality_action('GitHub', sources[:github], 'PR, review, release, and stale-queue metrics',
+                                   'Ensure GitHub API access and authenticate `gh` or set `GITHUB_TOKEN`/`GH_TOKEN`.')
+    actions << data_quality_action(
+      'CircleCI',
+      sources[:circleci],
+      'workflow reliability, duration, deploy, and flaky-test metrics',
+      'Ensure CircleCI API access and set `CIRCLE_TOKEN`/`CIRCLECI_TOKEN` or configure the CLI token.'
+    )
+
+    if result[:mode].start_with?('service')
+      actions << data_quality_action(
+        'UptimeRobot',
+        sources[:uptimerobot],
+        'external uptime, incident, MTTR, and response-time metrics',
+        'Ensure UptimeRobot API access and set `UPTIMEROBOT_API_KEY` plus `UPTIMEROBOT_MONITOR_IDS`.'
+      )
+      actions << data_quality_action('Kubernetes', sources[:kubernetes], 'runtime image, readiness, and restart state',
+                                     'Ensure `kubectl` can reach the target cluster context.')
+      actions << data_quality_action('DigitalOcean', sources[:digitalocean], 'cluster inventory and platform state',
+                                     'Ensure DigitalOcean API access and set `DIGITALOCEAN_ACCESS_TOKEN`.')
+    end
+
+    actions.compact
+  end
+
+  def summary_delivery_trend(result)
+    github = result[:github]
+    local_periods = result.dig(:local, :trend) || []
+    github_periods = summary_github_period(github, :trend) || []
+    period_count = [local_periods.length, github_periods.length].max
+
+    period_count.times.map do |index|
+      summary_delivery_period(local_periods[index], github_periods[index])
+    end
+  end
+
+  def summary_ci_trend(result)
+    circleci = result[:circleci]
+    return [] if unavailable_source?(circleci)
+
+    circleci.fetch(:trend, []).map { |period| summary_ci_period(period) }
+  end
+
+  def summary_release_trend(result)
+    local_periods = result.dig(:local, :trend) || []
+    circleci_periods = result.dig(:circleci, :trend) || []
+    period_count = [local_periods.length, circleci_periods.length].max
+
+    period_count.times.map do |index|
+      summary_release_period(local_periods[index], circleci_periods[index]).tap do |period|
+        period[:deploy_job_failed] = period.dig(:deploy_job, :failed)
+      end
+    end
+  end
+
+  def summary_service_reliability_trend(result)
+    uptimerobot = result[:uptimerobot]
+    return [] if unavailable_source?(uptimerobot)
+
+    summary_uptimerobot_trend(uptimerobot)
+  end
+
+  def summary_uptimerobot_trend(uptimerobot)
+    uptimes = uptime_ranges(uptimerobot)
+    response_averages = uptimerobot[:response_time_average_ms_by_period] || []
+    period_windows.map.with_index do |window, index|
+      {
+        uptime: numeric(uptimes[index]),
+        incident_count: incident_logs(uptimerobot[:logs], window.fetch(:start), window.fetch(:end)).length,
+        downtime_seconds: downtime_seconds(uptimerobot[:logs], window.fetch(:start), window.fetch(:end)),
+        mttr_seconds: mttr_seconds(uptimerobot[:logs], window.fetch(:start), window.fetch(:end)),
+        response_time_average_ms: response_averages[index]
+      }
+    end
+  end
+
+  def trend_metrics(periods, metrics)
+    metrics.to_h do |metric, direction|
+      [metric, trend_metric(periods, metric, direction)]
+    end
+  end
+
+  def trend_metric(periods, metric, direction)
+    values = periods.map { |period| period && period[metric] }
+    current = values[0]
+    previous = values[1]
+    four_window_median = median(values)
+    {
+      current: current,
+      previous: previous,
+      four_window_median: four_window_median,
+      delta_from_median: current && four_window_median ? current - four_window_median : nil,
+      signal: trend_signal(current, four_window_median, direction)
+    }
+  end
+
+  def trend_signal(current, baseline, direction)
+    return 'n/a' if current.nil? || baseline.nil?
+
+    delta = current - baseline
+    return 'flat' if delta.zero?
+    return delta.positive? ? 'up' : 'down' if direction == :neutral
+
+    better = direction == :higher ? delta.positive? : delta.negative?
+    better ? 'better' : 'worse'
+  end
+
+  def delivery_actions(delivery_flow)
+    return [] if unavailable_source?(delivery_flow)
+
+    current = delivery_flow[:current] || {}
+    previous = delivery_flow[:previous] || {}
+    actions = []
+
+    if delivery_flow[:stale_pr_count].to_i.positive?
+      actions << action('P2', 'Review', "#{delivery_flow[:stale_pr_count]} open PR(s) stale for more than 7 days.",
+                        'Close, merge, or revive each stale PR.')
+    end
+    if worsened?(current[:median_pr_age_seconds], previous[:median_pr_age_seconds], :lower)
+      evidence = "Median PR age rose from #{format_duration(previous[:median_pr_age_seconds])} " \
+                 "to #{format_duration(current[:median_pr_age_seconds])}."
+      actions << action('P2', 'Delivery', evidence,
+                        'Inspect the oldest merged and open PRs for review, CI, or release blockers.')
+    end
+    if worsened?(current[:median_review_latency_seconds], previous[:median_review_latency_seconds], :lower)
+      evidence = "Median review latency rose from #{format_duration(previous[:median_review_latency_seconds])} " \
+                 "to #{format_duration(current[:median_review_latency_seconds])}."
+      actions << action('P2', 'Review', evidence, 'Assign first-review ownership for active PRs.')
+    end
+
+    actions
+  end
+
+  def ci_actions(ci_quality)
+    return [] if unavailable_source?(ci_quality)
+
+    current = ci_quality[:current] || {}
+    previous = ci_quality[:previous] || {}
+    actions = []
+    success_rate = current[:workflow_success_rate]
+
+    if success_rate && success_rate < CI_SUCCESS_RATE_ACTION_THRESHOLD
+      evidence = "Workflow success rate is #{format_rate(success_rate)} " \
+                 "with #{current[:workflows_failed].to_i} failed workflow(s)."
+      actions << action('P1', 'CI', evidence,
+                        'Inspect the latest failed workflows before merging or releasing.')
+    elsif current[:workflows_failed].to_i.positive?
+      actions << action('P2', 'CI', "#{current[:workflows_failed]} workflow(s) failed in the window.",
+                        'Triage failed workflows and confirm reruns were not hiding a persistent failure.')
+    end
+    if worsened?(current[:p95_workflow_duration_seconds], previous[:p95_workflow_duration_seconds], :lower)
+      evidence = "p95 workflow duration rose from #{format_duration(previous[:p95_workflow_duration_seconds])} " \
+                 "to #{format_duration(current[:p95_workflow_duration_seconds])}."
+      actions << action('P3', 'CI', evidence,
+                        'Check the slowest workflows for dependency, cache, or test-runtime regressions.')
+    end
+    if ci_quality.dig(:flaky_tests, :total).to_i.positive?
+      actions << action('P2', 'Tests', "#{ci_quality.dig(:flaky_tests, :total)} flaky test(s) reported by CircleCI.",
+                        'Fix or quarantine the named flaky tests before relying on green reruns.')
+    end
+
+    actions
+  end
+
+  def release_actions(release_and_deploy)
+    current = release_and_deploy[:current] || {}
+    release_state = release_and_deploy[:release_state] || {}
+    deploy_job = current[:deploy_job] || {}
+    actions = []
+
+    if deploy_job[:failed].to_i.positive?
+      actions << action('P1', 'Deploy', "`deploy` failed #{deploy_job[:failed]} time(s).",
+                        'Inspect failed deploy jobs before the next release.')
+    end
+    if current[:rollback_or_revert_count].to_i.positive?
+      actions << action('P1', 'Release', "#{current[:rollback_or_revert_count]} revert or rollback commit(s) found.",
+                        'Review the reverted changes and confirm the release path is stable.')
+    end
+    if release_state[:unreleased_commit_count].to_i.positive? && current[:tag_count].to_i.zero?
+      priority = release_state[:latest_release_age_seconds].to_i > LIBRARY_RELEASE_AGE_ACTION_SECONDS ? 'P2' : 'P3'
+      evidence = "#{release_state[:unreleased_commit_count]} commit(s) " \
+                 "since latest tag #{release_state[:latest_tag] || 'n/a'}."
+      actions << action(priority, 'Release', evidence, 'Decide whether the accumulated changes need a release.')
+    end
+
+    actions
+  end
+
+  def reliability_actions(service_reliability)
+    actions = []
+    kubernetes = service_reliability[:kubernetes]
+    uptimerobot = service_reliability[:uptimerobot]
+
+    unless unavailable_source?(kubernetes)
+      if kubernetes[:pod_count].to_i.positive? && kubernetes[:ready_pod_count].to_i < kubernetes[:pod_count].to_i
+        actions << action('P1', 'Runtime', "#{kubernetes[:ready_pod_count]}/#{kubernetes[:pod_count]} pod(s) ready.",
+                          'Inspect the non-ready pods and rollout status.')
+      end
+      if kubernetes[:pod_restart_count].to_i.positive?
+        evidence = "#{kubernetes[:pod_restart_count]} pod/container restart(s) observed at collection time."
+        actions << action('P2', 'Runtime', evidence,
+                          'Check recent pod events and logs for recurring crashes.')
+      end
+    end
+
+    unless unavailable_source?(uptimerobot)
+      current_uptime = numeric(uptimerobot[:current_uptime])
+      if current_uptime && current_uptime < 99.9
+        actions << action('P1', 'Reliability', "External uptime is #{current_uptime}%.",
+                          'Review downtime logs and confirm whether the incident is resolved.')
+      end
+      if uptimerobot[:current_incident_count].to_i.positive?
+        actions << action('P1', 'Reliability', "#{uptimerobot[:current_incident_count]} incident(s) in the window.",
+                          'Review incident windows, MTTR, and any overlapping deploys.')
+      end
+      if worsened?(
+        uptimerobot[:current_response_time_average_ms],
+        uptimerobot[:previous_response_time_average_ms],
+        :lower
+      )
+        evidence = "Average response time rose from #{format_ms(uptimerobot[:previous_response_time_average_ms])} " \
+                   "to #{format_ms(uptimerobot[:current_response_time_average_ms])}."
+        actions << action('P2', 'Reliability', evidence,
+                          'Check recent deploys, saturation, and external dependency latency.')
+      end
+    end
+
+    actions
+  end
+
+  def data_quality_action(source, status, impact, setup_action)
+    return nil if status.nil? || status[:status] == 'used'
+    return nil if ['not a service repo', 'no .circleci/config.yml'].include?(status[:notes])
+
+    {
+      source: source,
+      status: status[:status],
+      reason: status[:notes],
+      impact: impact,
+      setup_action: setup_action
+    }
+  end
+
+  def action(priority, area, evidence, suggested_action)
+    {
+      priority: priority,
+      area: area,
+      evidence: evidence,
+      suggested_action: suggested_action
+    }
+  end
+
+  def priority_rank(priority)
+    { 'P1' => 1, 'P2' => 2, 'P3' => 3 }.fetch(priority, 9)
+  end
+
+  def worsened?(current, previous, direction)
+    return false if current.nil? || previous.nil?
+    return current.positive? if previous.zero? && direction == :lower
+    return current < previous if previous.zero? && direction == :higher
+
+    ratio = (current - previous).to_f / previous.abs
+    direction == :lower ? ratio > CHANGE_RATIO_ACTION_THRESHOLD : ratio < -CHANGE_RATIO_ACTION_THRESHOLD
+  end
+
+  def period_windows
+    windows = [
+      { start: @current_start, end: @current_end },
+      { start: @previous_start, end: @previous_end }
+    ]
+    while windows.length < TREND_WINDOW_COUNT
+      end_time = windows.last.fetch(:start)
+      windows << { start: end_time - window_seconds, end: end_time }
+    end
+    windows
+  end
+
+  def trend_window_summary
+    labels = %w[current previous minus_2 minus_3]
+    period_windows.map.with_index do |window, index|
+      { label: labels[index], start: window.fetch(:start).iso8601, end: window.fetch(:end).iso8601 }
+    end
+  end
+
+  def incident_logs(logs, start_time, end_time)
+    Array(logs).select do |log|
+      timestamp = log['datetime'] && Time.at(log.fetch('datetime').to_i)
+      timestamp && within?(timestamp, start_time, end_time) && incident_log?(log)
+    end
+  end
+
+  def incident_log?(log)
+    log['type'].to_i == 1 || log['duration'].to_i.positive?
+  end
+
+  def downtime_seconds(logs, start_time, end_time)
+    incident_logs(logs, start_time, end_time).sum { |log| log['duration'].to_i }
+  end
+
+  def mttr_seconds(logs, start_time, end_time)
+    median(incident_logs(logs, start_time, end_time).filter_map do |log|
+      duration = log['duration'].to_i
+      duration if duration.positive?
+    end)
+  end
+
+  def numeric(value)
+    return nil if value.nil? || value == ''
+
+    Float(value)
+  rescue ArgumentError, TypeError
+    nil
+  end
+
+  def format_duration(seconds)
+    return 'n/a' if seconds.nil?
+
+    return "#{(seconds / 86_400.0).round(1)}d" if seconds >= 86_400
+    return "#{(seconds / 3_600.0).round(1)}h" if seconds >= 3_600
+
+    "#{(seconds / 60.0).round(1)}m"
+  end
+
+  def format_ms(value)
+    value ? "#{value.round}ms" : 'n/a'
+  end
+
+  def format_rate(value)
+    value ? "#{(value * 100).round(1)}%" : 'n/a'
   end
 
   def summary_notable_work(result)
@@ -573,7 +1003,7 @@ class RepoHealthCollector
   end
 
   def uptime_ranges(uptimerobot)
-    uptimerobot.fetch(:uptime_ranges, '').split('-', 2)
+    uptimerobot.fetch(:uptime_ranges, '').split('-')
   end
 
   def pick_symbol(hash, *keys)
@@ -591,7 +1021,7 @@ class RepoHealthCollector
       pipelines.concat(items)
       oldest = items.filter_map { |pipeline| Time.parse(pipeline.fetch('created_at')) }.min
       page_token = data['next_page_token']
-      break if items.empty? || page_token.nil? || (oldest && oldest < @previous_start)
+      break if items.empty? || page_token.nil? || (oldest && oldest < period_windows.last.fetch(:start))
     end
     pipelines
   end


### PR DESCRIPTION
## What

- Add actionable repo-health output with a measured top bottleneck, prioritized action queue, four-window trend context, release readiness, and data-quality setup actions.
- Update repo-health guidance, output docs, metrics docs, source collection notes, and OpenAI metadata so summaries explain what owners can improve next.
- Add comparable lead-generation guidance for ledger-style workflows that can use GitHub owner inventory, local checkout mapping, sibling repositories, and external frameworks without lowering local evidence gates.

## Why

- Repo-health reports become easier to act on because they surface concrete follow-up work instead of only period summaries.
- Ledger workflows get a safer way to broaden search across similar systems while keeping findings tied to repository-owned, reproducible evidence.
- Checkout discovery avoids machine-specific paths and prefers GitHub inventory plus mapped local clones, which fits this shared tooling across consuming repositories.

## Testing

- `make dep` - passed; verified Ruby dependencies are present.
- `make skills-lint` - passed; validated changed skill Markdown and metadata.
- `make lint` - passed; RuboCop inspected the changed Ruby collector.
- `make sec` - passed; Trivy reported 0 Bundler vulnerabilities.
- `git diff --check` - passed; verified whitespace in the full diff.
- `ruby skills/repo-health/scripts/collect.rb --repo /Users/alejandro/code/bin` - passed; verified local library output with the new summary fields.
- `ruby skills/repo-health/scripts/collect.rb --repo /Users/alejandro/code/gocovmerge` - passed; verified downstream library output and release-readiness action generation.
- `ruby skills/repo-health/scripts/collect.rb --repo /Users/alejandro/code/bezeichner` - passed; verified downstream service output and data-quality setup actions when live sources are unavailable.
- Live GitHub, CircleCI, DigitalOcean, Kubernetes, and UptimeRobot success paths were not verified in the sandbox; their unavailable paths were exercised and surfaced as data-quality actions.
