### PR TITLE
feat(skills): add pre-edit complexity gates

### DIFF
--- a/skills/feature-gaps/SKILL.md
+++ b/skills/feature-gaps/SKILL.md
@@ -263,6 +263,15 @@ These feature implementation rules remain mandatory:
   Treat silence or a broad "implement feature gaps" request as permission to
   start the proposal workflow, not as permission to edit.
 - After the human agrees and before editing, state the selected local code/config/docs pattern, dominant relevant test harness, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
+- In that pre-edit statement, also state the simplest implementation shape that
+  satisfies the feature using existing local code, config, docs, harness,
+  lifecycle, and validation patterns.
+- Treat new orchestration, lifecycle, or harness machinery as a complexity
+  trigger. Before adding extra processes, ports, config files, startup paths,
+  lifecycle hooks, env/config indirection, harness classes, generated fixtures,
+  or helper layers, stop and explain why the existing repository pattern cannot
+  support the approved feature. If the reason is only flexibility,
+  convenience, experimentation, or personal clarity, do not add the machinery.
 - For behavior-changing features, state the feature execution checklist before
   editing:
    - `TDD decision`: yes/no, with the concrete reason if no.

--- a/skills/testing-standards/SKILL.md
+++ b/skills/testing-standards/SKILL.md
@@ -46,6 +46,12 @@ These are mandatory gates, not guidance.
 - Personal clarity, convenience, faster local execution, implementation
   language, or direct access to private functions are not valid reasons to
   bypass the dominant harness.
+- Tests MUST use the existing harness lifecycle and configuration shape unless
+  the changed behavior cannot be exercised through it. Before adding a second
+  process, port, config file, startup mode, lifecycle hook, env/config
+  indirection, custom harness class, fixture generator, or helper layer, agents
+  MUST stop and explain why the current harness cannot cover the behavior. If a
+  simpler existing config or scenario edit can cover it, use that path.
 - If the human asks to remove, skip, or simplify a test during a behavior
   change, agents MUST NOT infer that test-first workflow or coverage is waived.
   Ask whether to replace it with better-shaped coverage or explicitly accept no


### PR DESCRIPTION
## What

- Add feature-gap implementation gates that force agents to state the simplest existing-pattern implementation shape before editing.
- Add complexity triggers for extra processes, ports, config files, startup paths, lifecycle hooks, env/config indirection, harness classes, fixture generators, and helper layers.
- Add testing-standards guidance that keeps tests on the existing harness lifecycle and configuration shape unless the current harness cannot cover the behavior.

## Why

- This reduces over-engineered feature implementations by making agents justify orchestration and harness complexity before adding it.
- It preserves local repository patterns when a simpler config or scenario edit can cover the approved behavior.

## Testing

- `zsh -lic 'gmake skills-lint'` - passed
- `git diff --check` - passed
- Direct `quality/skills/lint` under system Ruby was not used as validation because the local Ruby 2.6/Psych path fails before skill policy checks; the repository target passed through the initialized shell.
