### PR TITLE
feat(skills): require residual gap evidence

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    json (2.19.9)
+    json (2.20.0)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -18,7 +18,7 @@ GEM
       prism (>= 1.6.0)
       tsort
     regexp_parser (2.12.0)
-    rubocop (1.88.0)
+    rubocop (1.88.1)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)

--- a/skills/feature-gaps/SKILL.md
+++ b/skills/feature-gaps/SKILL.md
@@ -63,6 +63,15 @@ candidate instead of recording it as low priority.
 - **Current limitation**: State the existing workflow limitation, missing
   capability, or friction. The limitation must exist today and must not already
   be solved by current code, docs, examples, or command behavior.
+- **Existing coverage**: Name the current product surfaces that already address
+  part or all of the need, including APIs, commands, endpoints, generated
+  contracts, runtime health or metrics, docs, examples, configuration, and
+  supported workflows. Reject the candidate if an existing surface already
+  solves the practical user action.
+- **Residual gap**: After accounting for existing coverage, state the remaining
+  supported action or outcome the audience still cannot complete. Reject the
+  candidate if the residual is only a weaker spelling of "more flexible",
+  "more convenient", or "another way to do the same thing".
 - **Negative capability proof**: If the proposal depends on a capability being
   absent, verify that absence across every layer that could already provide it:
   local code, generated code, framework wrappers, shared helpers, vendored
@@ -75,6 +84,11 @@ candidate instead of recording it as low priority.
   unlocked use cases, safer operation, or reduced support burden. Reject the
   candidate if the benefit cannot be stated as a specific improvement to the
   named audience's workflow.
+- **Common operation**: For new product capability, show that the action is a
+  normal or credibly recurring workflow for the named audience in this
+  repository's domain. Comparable-tool support alone is not enough; reject or
+  defer candidates whose value is mostly rare operator preference, library
+  affordance parity, or speculative future use.
 - **Repository ownership**: Show that this repository owns the behavior,
   interface, workflow, helper, or documentation surface where the feature
   belongs.
@@ -103,10 +117,10 @@ candidate instead of recording it as low priority.
   naming issue, style preference, or unsupported roadmap decision.
 
 Reject ideas whose support is only novelty, taste, competitor parity, a trend,
-an imagined future user, framework preference, private implementation
-preference, generic "nice to have" polish, or a vague benefit such as "more
-flexible", "better", "cleaner", or "more powerful" without a concrete audience
-outcome.
+an imagined future user, uncommon operation, framework preference, private
+implementation preference, generic "nice to have" polish, or a vague benefit
+such as "more flexible", "better", "cleaner", or "more powerful" without a
+concrete audience outcome.
 
 ## Find Mode
 
@@ -145,13 +159,22 @@ These feature-gap rules remain mandatory:
   architecture, and available comparable-tool evidence before recording it. Try
   to disprove the candidate by asking whether the workflow is already
   supported, whether the repository owns the behavior, whether the likely
-  audience exists, and whether the feature can be added incrementally using
-  local patterns.
+  audience exists, whether existing product surfaces already cover enough of the
+  workflow, whether the residual gap is still meaningful after that coverage,
+  whether the operation is common enough for the audience, and whether the
+  feature can be added incrementally using local patterns.
+- When sub-agents are authorized and candidate volume justifies delegation,
+  assign at least one disprover slice when practical. The disprover should look
+  for existing APIs, commands, endpoints, health/metrics, generated contracts,
+  docs, examples, tests, shared helpers, framework behavior, or workflow routing
+  that already covers each proposed feature, and should try to route weak leads
+  to another gap workflow or optional follow-up.
 - Record feature gaps only when the proposal names the audience, current
-  product workflow limitation, practical audience benefit, repository-owned
-  product surface, evidence of user, operator, service-author, package-consumer,
-  CLI, API, or library value, fit with existing patterns, smallest plausible
-  implementation path, compatibility risk, and validation path.
+  product workflow limitation, existing coverage, residual gap, practical
+  audience benefit, common-operation evidence, repository-owned product surface,
+  evidence of user, operator, service-author, package-consumer, CLI, API, or
+  library value, fit with existing patterns, smallest plausible implementation
+  path, compatibility risk, and validation path.
 - Do not record confirmed bugs, security issues, compatibility breaks,
   reliability gaps, missing tests, test-harness quality issues, stale docs,
   project workflow gaps, or unclear naming as feature gaps. Route them to
@@ -159,8 +182,8 @@ These feature-gap rules remain mandatory:
   `$doc-gaps`, `$project-gaps`, or `$naming-standards` as appropriate.
 - Do not record feature ideas whose evidence is only novelty, personal
   preference, a competitor checklist, a trend, an undocumented future roadmap,
-  a broad rewrite, a new framework preference, or optional polish with no
-  concrete workflow improvement.
+  an uncommon operation, a broad rewrite, a new framework preference, or
+  optional polish with no concrete workflow improvement.
 - Do not record feature proposals that require a new product direction,
   breaking public behavior, new external service, new dependency class, or
   significant maintenance commitment unless the current repository already
@@ -188,7 +211,13 @@ Use this structure:
 - Scope: path/to/file-or-folder
 - Audience: User|Developer|Maintainer|Operator|Package consumer|Service author
 - Current limitation: The workflow limitation, missing capability, or friction.
+- Existing coverage: Current product surfaces that already address part or all
+  of the need, and why they are insufficient for the named audience.
+- Residual gap: Even with the existing coverage, the audience still cannot
+  complete this specific supported workflow or outcome.
 - Benefit: Why this matters to the named audience and how their workflow becomes better.
+- Common operation: Evidence that this is a normal or recurring workflow for
+  the named audience, not only comparable-tool parity.
 - Evidence: Concrete file and line references, command behavior, docs, examples, comparable-tool evidence, or user/developer workflow evidence.
 - Reproduction: Smallest supported user, developer, service-author, operator,
   or package-consumer workflow trace that demonstrates the current limitation

--- a/skills/feature-gaps/references/plan.md
+++ b/skills/feature-gaps/references/plan.md
@@ -25,20 +25,27 @@ validation, delegation, external research, ledger state, and workflow routing.
 5. Route standalone test-harness, CI, build, Makefile, release, validation,
    command discovery, setup, and repository workflow concerns to `$test-gaps` or
    `$project-gaps`.
-6. Apply `SKILL.md#acceptance-gate` to each candidate and confirm audience,
-   current product limitation, practical audience benefit, repository-owned
-   surface, value evidence, repository fit, smallest plausible implementation
-   path, compatibility and maintenance tradeoffs, validation path, and correct
+6. Challenge each candidate against existing product surfaces before accepting
+   it: APIs, commands, endpoints, generated contracts, runtime health/metrics,
+   docs, examples, configuration, supported workflows, framework behavior, and
+   shared helpers. Keep only candidates with a concrete residual gap after that
+   coverage is accounted for.
+7. Apply `SKILL.md#acceptance-gate` to each candidate and confirm audience,
+   current product limitation, existing coverage, residual gap, practical
+   audience benefit, common-operation evidence, repository-owned surface, value
+   evidence, repository fit, smallest plausible implementation path,
+   compatibility and maintenance tradeoffs, validation path, and correct
    workflow routing.
-7. Reject novelty, competitor checklists, trend-following, broad rewrites,
+8. Reject novelty, competitor checklists, trend-following, broad rewrites,
    new-framework preferences, future-roadmap assumptions, optional polish, vague
-   benefits without concrete audience outcome, and findings belonging to other
+   benefits without concrete audience outcome, uncommon operations without
+   evidence that the named audience needs them, and findings belonging to other
    workflows.
-8. Before a no-gap closeout, name audiences, product surfaces, documented
+9. Before a no-gap closeout, name audiences, product surfaces, documented
    workflows, public commands/APIs or package-consumer paths, comparable-tool
    research decisions, rejected and routed leads, validation evidence, and
    policy exclusions checked.
-9. If confirmed gaps remain, write scoped `FEATURES.md`, present the ledger,
+10. If confirmed gaps remain, write scoped `FEATURES.md`, present the ledger,
    coverage state, proposed implementation plan, and runnable follow-up scopes,
    then stop before implementing features.
 

--- a/skills/references/gap-workflow.md
+++ b/skills/references/gap-workflow.md
@@ -310,6 +310,17 @@ For implement modes:
   inventory, local checkout mapping, sibling repositories, or external
   frameworks, reproduce the current repository-owned limitation through the
   selected skill's normal evidence path.
+- Before recording a candidate, run an existing-surface challenge. List the
+  authoritative repository surfaces that could already satisfy the proposed
+  need, such as public APIs, commands, endpoints, generated contracts, runtime
+  health or metrics, shared helpers, framework behavior, configuration
+  defaults, docs, examples, tests, and supported consumer workflows. Reject or
+  route the candidate when the correct surface already covers the workflow.
+- For candidates that survive the existing-surface challenge, state the
+  residual gap: "Even with <existing surface>, the audience still cannot
+  <specific supported action/outcome>." If that sentence is weak, vague, or
+  mostly describes optional convenience, keep the lead below the selected
+  skill's ledger threshold and report it as rejected, routed, or deferred.
 - Confirm each candidate against current code, docs, examples, tests, command
   behavior, CI config, generated contracts, and public interfaces relevant to
   the selected skill before recording, fixing, or dismissing it.
@@ -366,6 +377,11 @@ For implement modes:
   below the selected skill's threshold, duplicative, out of scope, or owned by a
   different workflow. When useful, state the authoritative surface or workflow
   that owns the concern.
+- Treat optional follow-ups, speculative improvements, and leads that need
+  production evidence or a separate product/security/reliability design as
+  closeout notes only. Do not create a scoped ledger solely to store optional
+  follow-ups when no confirmed entries survive the selected skill's evidence
+  gate.
 - For local review as well as delegated review, preserve rejected, routed,
   deferred, and blocked lead notes. A quiet audit without these notes is not
   enough evidence for broad no-finding confidence.


### PR DESCRIPTION
## What

- Adds an existing-surface challenge and residual-gap requirement to the shared gap workflow before candidates can become ledger entries.
- Tightens feature-gap discovery with existing coverage, residual gap, common-operation evidence, and optional disprover sub-agent guidance.
- Updates the feature-gap plan and `FEATURES.md` template so confirmed proposals document the stronger evidence gates.

## Why

- Comparable-tool research can generate useful leads, but it should not promote ideas that are already covered, uncommon, optional-only, or mostly parity-driven.
- Requiring residual value after existing product surfaces are checked makes weak feature and gap leads easier to reject or route before they become actionable IDs.

## Testing

- `git diff --check` - passed
- `zsh -lic 'gmake skills-lint'` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
