### PR TITLE
feat(skills): document config ownership guidance

### DIFF
--- a/skills/go-standards/references/conventions.md
+++ b/skills/go-standards/references/conventions.md
@@ -18,6 +18,17 @@ Use this reference when working in Go repositories.
   wiring path, documented public contract, observed bug, concurrency boundary,
   security boundary, or realistic external input can trigger it. Otherwise make
   the narrower contract explicit in code or GoDoc and let misuse fail plainly.
+- When adding configuration, classify each field before choosing its home:
+  shared mechanics, domain-specific behavior, or test/setup convenience. Keep
+  shared config limited to behavior that is truly transport-, backend-, or
+  domain-agnostic. Put domain-specific classification near the package that owns
+  the native concept.
+- Do not overload policy callbacks with unrelated decisions. A policy should
+  answer one domain question, such as operation eligibility; separate failure
+  classification, routing, formatting, or transport-specific matching into
+  owned config or helpers.
+- Prefer native domain types over wrapper types unless the wrapper adds
+  validation, behavior, compatibility, or a repository-owned abstraction.
 
 ## Abstractions And Helpers
 
@@ -33,6 +44,11 @@ Use this reference when working in Go repositories.
   external boundary, or repository pattern needs the extra shape.
 - During refactor passes, inline helpers that merely restate their only call,
   especially when the helper name is no clearer than the wrapped expression.
+- When a helper grows a long parameter list, separate stable configuration from
+  per-call data before adding a new abstraction. Prefer an existing receiver
+  type when it already owns the state; use closure capture for small local
+  behavior; add a private struct only when it clarifies ownership or removes a
+  real data clump.
 
 ## Documentation
 

--- a/skills/testing-standards/SKILL.md
+++ b/skills/testing-standards/SKILL.md
@@ -211,6 +211,10 @@ These are mandatory gates, not guidance.
 - Make failures obvious and descriptive. Avoid bare assertions such as `expected true but got false`; include the case, input, expected behavior, and observed behavior when the assertion framework does not do so clearly.
 - For repeated low-information assertions, do not rely only on generic framework output such as `Should be false`, `expected true but got false`, or `expected 2, got 1`. Add a short assertion message or use named subtests so the failure identifies the specific scenario. This applies especially to repeated boolean and numeric assertions.
 - Keep tests readable. Add small helpers, fixtures, builders, or assertions when they make behavior easier to read, but avoid abstractions that hide the scenario being tested. If a test needs a derived value, prefer a named local or helper whose name explains the behavior over dense inline setup.
+- When tests repeat the same configuration literals, prefer the repository's
+  established fixture/helper location for a small constructor or builder. Keep
+  test call sites focused on the scenario-specific values, and avoid scattering
+  config construction across unrelated tests.
 - Use broader suites for shared infrastructure, compatibility-sensitive behavior, release-sensitive behavior, or changes that cross package, command, or service boundaries.
 - Use focused package, file, scenario, example, focus-tag, or test-name runs for
   fast feedback when the dominant harness supports them. Broaden only when the


### PR DESCRIPTION
## What

- Added Go standards guidance for classifying configuration fields by ownership before choosing their package home.
- Added Go standards guidance to keep policy callbacks focused on one domain decision and prefer native domain types unless wrappers add real behavior.
- Added helper guidance for reducing long parameter lists by separating stable configuration from per-call data.
- Added testing guidance to centralize repeated configuration literals in existing fixture/helper locations.

## Why

- Captures design lessons from recent retry configuration work so future changes keep shared configuration, transport-specific behavior, policies, helpers, and tests in clearer ownership boundaries.
- Reduces repeated test setup noise and discourages unnecessary wrappers or abstractions that make future maintenance harder.

## Testing

- `zsh -lic 'gmake skills-lint'` - passed
- `git diff --check` - passed
- `gmake skills-lint` under the agent default shell failed before validation because system Ruby 2.6 lacks `YAML.safe_load_file`; rerunning through the initialized user shell used the expected environment and passed.
