### PR TITLE
feat(skills): add agent approval continuation

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -129,6 +129,10 @@ Use these short commands instead of spelling out the full workflow:
   for both sub-agents and a runtime goal.
 - `Approved. Continue.`: approve the most recently proposed solution and allow
   the selected skill to implement it through its validation and review gates.
+- `Agent approved. Continue.`: same as `Approved. Continue.`, plus explicit
+  current-request authorization to use sub-agents during implementation and
+  fresh review when they can work on disjoint slices, validation support, or
+  independent review without bypassing the selected skill's gates.
 
 These commands are shorthand only. They do not bypass solution agreement,
 scoped ledger rules, validation freshness, confidence thresholds, remote-write

--- a/skills/references/gap-workflow.md
+++ b/skills/references/gap-workflow.md
@@ -17,6 +17,11 @@ These shared rules own workflow mechanics.
     goal for the current request.
   - `Approved. Continue.` approves the most recently proposed solution and
     permits implementation to continue under the selected skill.
+  - `Agent approved. Continue.` approves the most recently proposed solution
+    and explicitly authorizes sub-agents for the current implementation request.
+    Use them for disjoint implementation slices, validation support, or fresh
+    review when they materially improve throughput, coverage, confidence, or
+    implementation safety.
   These shorthands do not bypass solution agreement, scoped ledger rules,
   validation freshness, confidence thresholds, remote-write permission, or the
   selected skill's output format.
@@ -516,6 +521,11 @@ For implement modes:
   ask only blocking questions after research, and work in thin validated
   slices. This does not authorize combining find and implement modes or editing
   outside the agreed entry.
+- When the current implementation request authorizes agents, use sub-agents for
+  disjoint slices, validation support, or fresh review when they can materially
+  improve throughput, coverage, confidence, or implementation safety. Keep one
+  active ledger entry owner and do not let parallel work bypass the selected
+  skill's validation, review, or human confirmation gates.
 - Implement only the agreed entry with the smallest clear change using existing
   local patterns.
 - Before accepting substantial implementation work as complete, apply the fresh


### PR DESCRIPTION
## What

- Add `Agent approved. Continue.` as a remembered command for approving the proposed solution while explicitly re-authorizing sub-agents for the implementation turn.
- Document that implementation-time agents may be used for disjoint slices, validation support, or fresh review when they improve throughput, coverage, confidence, or safety.
- Preserve the existing ledger workflow constraints: one active ledger entry owner, selected-skill validation and review gates, human confirmation gates, and remote-write boundaries.

## Why

- The initial remembered-command flow made it easy to authorize agents during planning, but the follow-up approval command did not clearly carry agent authorization into the implementation request.
- This gives maintainers a short approval phrase that keeps implementation from falling back to fully local serial work when sub-agents can safely help.

## Testing

- `make skills-lint` - passed
- `git diff --check` - passed
- Local challenge pass reviewed agent authorization semantics, ledger sequencing, validation freshness, review gates, human confirmation gates, and remote-write boundaries; no blocking findings.
