### PR TITLE
feat(skills): share codex permissions across repositories

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,1 @@
+../build/codex/config.toml

--- a/.codex/rules/bin.rules
+++ b/.codex/rules/bin.rules
@@ -1,0 +1,1 @@
+../../build/codex/rules/default.rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -646,7 +646,17 @@ Target-specific rules:
   behavior changes.
 - Keep skills tool-agnostic. `skills/<name>/SKILL.md` is shared by Codex and
   Claude Code, so do not hardcode a single assistant; where attribution or
-  invocation differs, cover both. `build/claude/init` (via `make claude-init`)
+  invocation differs, cover both. `build/codex/init` (via `make codex-init`)
+  wires Codex by symlinking `.agents/skills` to `skills/`, `.codex/config.toml`
+  to the shared permission profile, and `.codex/rules/bin.rules` to the shared
+  host-execution guardrails; repo-owned real config and rule files are left
+  untouched. The project must be trusted before Codex loads project config and
+  rules, and permission profiles require Codex 0.138.0 or later. The shared
+  profile makes workspace `.git` metadata writable for routine staging and
+  commits; remote and destructive Git operations remain governed by the shared
+  rules and explicit workflow permission gates. Per-machine additions belong
+  in `~/.codex/config.toml` and `~/.codex/rules/`.
+  `build/claude/init` (via `make claude-init`)
   wires Claude Code by symlinking `.claude/skills` to `skills/`, symlinking
   `.claude/settings.json` to the shared `build/claude/settings.json`
   permissions baseline (unless the repo owns a real, non-symlink

--- a/README.md
+++ b/README.md
@@ -81,8 +81,36 @@ include bin/build/make/codex.mak
 make codex-init
 ```
 
-This creates a `.agents/skills` symlink to `bin/skills`, so every later clone can
-invoke shared skills with `$`, for example `$code-review`.
+This creates a `.agents/skills` symlink to `bin/skills`, a `.codex/config.toml`
+symlink to the shared permission profile in `bin/build/codex/config.toml`, and a
+`.codex/rules/bin.rules` symlink to the shared host-execution guardrails. A
+repository-owned real config or rule file is left untouched. Every later clone
+can invoke shared skills with `$`, for example `$code-review`, and receives the
+shared permissions after the one-time project trust prompt. Repositories with
+an existing real config can merge the shared settings explicitly.
+
+The permission profile requires Codex 0.138.0 or later. It allows normal edits
+inside the workspace, including Git metadata for routine staging and commits,
+permits the standard Go, RuboCop, and Trivy caches, denies common credential
+files to sandboxed commands, blocks sandboxed command network access by
+default, and sends legitimate escalation requests to the user for approval.
+Making `.git` writable also permits sandboxed commands to
+change repository metadata, configuration, and hooks; use the profile only in
+trusted repositories. The rules classify remote writes and destructive
+operations for approval and forbid catastrophic commands. Codex may therefore
+complete routine work without interrupting the user while retaining the
+explicit permission gates in `AGENTS.md`.
+
+Legacy `sandbox_mode` settings and the `--sandbox` CLI flag take precedence over
+permission profiles. Remove those overrides when the shared profile should be
+active.
+
+Codex loads project config and rules only for trusted repositories. Put
+per-machine additions in `~/.codex/config.toml` and
+`~/.codex/rules/default.rules`; Codex also records accepted persistent command
+prefixes in that user rules file. Re-run `make codex-init` only when the shared
+paths move. Updates to the shared profile or rules propagate with the next
+`bin` submodule update.
 
 Codex reads `AGENTS.md` separately for repository instructions. Downstream
 repositories should still point agents at the shared instructions instead of
@@ -147,6 +175,8 @@ Dockerfile lint targets depend on `shellcheck` and `hadolint`;
 - `build/make/*.mak`: reusable Makefile fragments for downstream projects.
 - `build/codex/init`: one-time Codex wiring for a consuming repository (run via
   `make codex-init`).
+- `build/codex/config.toml` and `build/codex/rules/default.rules`: shared Codex
+  permission profile and host-execution guardrails.
 - `build/claude/init`: one-time Claude Code wiring for a consuming repository
   (run via `make claude-init`).
 - `build/docker/go/Dockerfile`: shared Go service Dockerfile template.

--- a/build/codex/config.toml
+++ b/build/codex/config.toml
@@ -1,0 +1,37 @@
+# Shared Codex permissions for repositories wired through `make codex-init`.
+approval_policy = "on-request"
+approvals_reviewer = "user"
+default_permissions = "shared-development"
+
+[permissions.shared-development]
+description = "Autonomous workspace development with credential files denied."
+extends = ":workspace"
+
+[permissions.shared-development.filesystem]
+glob_scan_max_depth = 12
+"~/.ssh" = "deny"
+"~/.aws" = "deny"
+"~/.netrc" = "deny"
+"~/.docker/config.json" = "deny"
+"~/.kube/config" = "deny"
+"~/.config/gh" = "deny"
+"~/.cache/go-build" = "write"
+"~/.cache/rubocop_cache" = "write"
+"~/.cache/trivy" = "write"
+"~/Library/Caches/go-build" = "write"
+"~/Library/Caches/trivy" = "write"
+"~/go/pkg/mod" = "write"
+
+[permissions.shared-development.filesystem.":workspace_roots"]
+".git" = "write"
+".env" = "deny"
+".env.*" = "deny"
+".envrc" = "deny"
+"*.pem" = "deny"
+"**/.env" = "deny"
+"**/.env.*" = "deny"
+"**/.envrc" = "deny"
+"**/*.pem" = "deny"
+
+[permissions.shared-development.network]
+enabled = false

--- a/build/codex/init
+++ b/build/codex/init
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-# Wire the current repository for Codex from the shared bin skills.
+# Wire the current repository for Codex from the shared bin configuration.
 #
-# Creates a .agents/skills symlink to the shared skills directory so Codex can
-# discover repo-scoped skills for explicit $skill invocation. Safe to run
-# repeatedly.
+# Creates a .agents/skills symlink for shared skills, a .codex/config.toml
+# symlink for the shared permission profile, and a .codex/rules/bin.rules
+# symlink for shared host-execution guardrails. Safe to run repeatedly;
+# repo-owned real config and rule files are never overwritten.
 
 set -eo pipefail
 
@@ -12,9 +13,21 @@ bin_root="${BIN_ROOT:-$(cd "$script_dir/../.." && pwd -P)}"
 project_root="$(pwd -P)"
 
 skills_src="$bin_root/skills"
+config_src="$bin_root/build/codex/config.toml"
+rules_src="$bin_root/build/codex/rules/default.rules"
 
 if [[ ! -d $skills_src ]]; then
   printf 'shared skills not found: %s\n' "$skills_src" >&2
+  exit 1
+fi
+
+if [[ ! -f $config_src ]]; then
+  printf 'shared Codex config not found: %s\n' "$config_src" >&2
+  exit 1
+fi
+
+if [[ ! -f $rules_src ]]; then
+  printf 'shared Codex rules not found: %s\n' "$rules_src" >&2
   exit 1
 fi
 
@@ -26,5 +39,37 @@ mkdir -p "$project_root/.agents"
 rel_skills="$(relpath "$skills_src" "$project_root/.agents")"
 ln -sfn "$rel_skills" "$project_root/.agents/skills"
 
+mkdir -p "$project_root/.codex"
+
+config_dst="$project_root/.codex/config.toml"
+rel_config=""
+if [[ -e $config_dst && ! -L $config_dst ]]; then
+  printf 'leaving repo-owned %s in place (not a symlink)\n' "$config_dst" >&2
+else
+  rel_config="$(relpath "$config_src" "$project_root/.codex")"
+  ln -sfn "$rel_config" "$config_dst"
+fi
+
+rules_dir="$project_root/.codex/rules"
+rel_rules=""
+if [[ -L $rules_dir ]]; then
+  printf 'leaving repo-owned %s in place (symlinked directory)\n' "$rules_dir" >&2
+else
+  mkdir -p "$rules_dir"
+  rules_dst="$rules_dir/bin.rules"
+  if [[ -e $rules_dst && ! -L $rules_dst ]]; then
+    printf 'leaving repo-owned %s in place (not a symlink)\n' "$rules_dst" >&2
+  else
+    rel_rules="$(relpath "$rules_src" "$rules_dir")"
+    ln -sfn "$rel_rules" "$rules_dst"
+  fi
+fi
+
 printf 'Codex wired for %s\n' "$project_root"
 printf '  .agents/skills -> %s\n' "$rel_skills"
+if [[ -n $rel_config ]]; then
+  printf '  .codex/config.toml -> %s\n' "$rel_config"
+fi
+if [[ -n $rel_rules ]]; then
+  printf '  .codex/rules/bin.rules -> %s\n' "$rel_rules"
+fi

--- a/build/codex/rules/default.rules
+++ b/build/codex/rules/default.rules
@@ -1,0 +1,325 @@
+# Shared host-execution guardrails for repositories wired through
+# `make codex-init`. Routine workspace commands stay sandboxed; Codex's
+# user approval reviewer handles exceptional escalations.
+
+prefix_rule(
+    pattern = [
+        "make",
+        [
+            "push",
+            "push-docker",
+            "proto-push",
+            "release-docker",
+            "new-release",
+            "manifest-docker",
+            "sync",
+            "force",
+            "reset",
+            "purge",
+            "purge-local",
+            "purge-remote",
+            "delete",
+            "delete-version",
+            "start",
+            "stop",
+            "pr",
+            "review",
+            "ready",
+            "draft",
+            "merge",
+        ],
+    ],
+    decision = "prompt",
+    justification = "Remote-write, destructive, and external-service Make targets require explicit authorization.",
+    match = [
+        "make push",
+        "make proto-push",
+        "make reset",
+        "make review",
+        "make start",
+    ],
+    not_match = [
+        "make lint",
+        "make specs",
+        "make features",
+    ],
+)
+
+prefix_rule(
+    pattern = ["git", "push"],
+    decision = "prompt",
+    justification = "Pushing changes updates a remote repository.",
+    match = [
+        "git push",
+        "git push origin feature",
+        "git push --force-with-lease origin feature",
+    ],
+    not_match = [
+        "git fetch origin",
+        "git status",
+    ],
+)
+
+prefix_rule(
+    pattern = ["git", "push", ["--force", "-f"]],
+    decision = "forbidden",
+    justification = "Use guarded force-push behavior such as `--force-with-lease` instead.",
+    match = [
+        "git push --force origin feature",
+        "git push -f origin feature",
+    ],
+    not_match = [
+        "git push --force-with-lease origin feature",
+    ],
+)
+
+prefix_rule(
+    pattern = ["git", "reset", "--hard"],
+    decision = "prompt",
+    justification = "A hard reset can discard uncommitted work.",
+    match = [
+        "git reset --hard",
+        "git reset --hard HEAD~1",
+    ],
+    not_match = [
+        "git reset --soft HEAD~1",
+    ],
+)
+
+prefix_rule(
+    pattern = ["git", "clean", ["-f", "-fd", "-df", "-fx", "-fdx"]],
+    decision = "prompt",
+    justification = "Git clean permanently removes untracked files.",
+    match = [
+        "git clean -f",
+        "git clean -fd",
+        "git clean -fdx",
+    ],
+    not_match = [
+        "git clean -n",
+    ],
+)
+
+prefix_rule(
+    pattern = ["git", "rebase"],
+    decision = "prompt",
+    justification = "Rebasing rewrites local history and can require conflict resolution.",
+    match = [
+        "git rebase origin/master",
+        "git rebase --continue",
+    ],
+)
+
+prefix_rule(
+    pattern = ["git", "branch", "-D"],
+    decision = "prompt",
+    justification = "Force-deleting a branch can discard unmerged work.",
+    match = [
+        "git branch -D feature",
+    ],
+    not_match = [
+        "git branch -d feature",
+    ],
+)
+
+prefix_rule(
+    pattern = ["git", "checkout", "--"],
+    decision = "prompt",
+    justification = "Checking out paths can overwrite working-tree changes.",
+    match = [
+        "git checkout -- README.md",
+    ],
+    not_match = [
+        "git checkout feature",
+    ],
+)
+
+prefix_rule(
+    pattern = ["git", "restore"],
+    decision = "prompt",
+    justification = "Restoring paths can overwrite working-tree or index changes.",
+    match = [
+        "git restore README.md",
+        "git restore --staged README.md",
+    ],
+)
+
+prefix_rule(
+    pattern = ["gh", "pr", ["create", "merge", "close", "edit", "reopen", "ready", "review", "comment"]],
+    decision = "prompt",
+    justification = "This command changes pull-request state on GitHub.",
+    match = [
+        "gh pr create --draft",
+        "gh pr merge --auto --squash",
+        "gh pr review 123 --approve",
+    ],
+    not_match = [
+        "gh pr view 123",
+        "gh pr checks 123",
+    ],
+)
+
+prefix_rule(
+    pattern = ["gh", "issue", ["create", "close", "edit", "reopen", "comment"]],
+    decision = "prompt",
+    justification = "This command changes issue state on GitHub.",
+    match = [
+        "gh issue create --title bug",
+        "gh issue close 123",
+    ],
+    not_match = [
+        "gh issue view 123",
+        "gh issue list",
+    ],
+)
+
+prefix_rule(
+    pattern = ["gh", "release", ["create", "delete", "edit", "upload"]],
+    decision = "prompt",
+    justification = "This command changes published release state on GitHub.",
+    match = [
+        "gh release create v1.2.3",
+        "gh release delete v1.2.3",
+    ],
+    not_match = [
+        "gh release view v1.2.3",
+        "gh release list",
+    ],
+)
+
+prefix_rule(
+    pattern = ["gem", "push"],
+    decision = "prompt",
+    justification = "Publishing a gem updates a public or private registry.",
+    match = [
+        "gem push package.gem",
+    ],
+)
+
+prefix_rule(
+    pattern = ["npm", ["publish", "unpublish"]],
+    decision = "prompt",
+    justification = "Publishing or removing a package updates a registry.",
+    match = [
+        "npm publish",
+        "npm unpublish package@1.0.0",
+    ],
+    not_match = [
+        "npm test",
+    ],
+)
+
+prefix_rule(
+    pattern = ["rm", ["-rf", "-fr", "-r", "-R"]],
+    decision = "prompt",
+    justification = "Recursive deletion can permanently remove files.",
+    match = [
+        "rm -rf build",
+        "rm -R reports",
+    ],
+    not_match = [
+        "rm file.txt",
+    ],
+)
+
+prefix_rule(
+    pattern = ["rm", ["-rf", "-fr"], ["/", "~", "$HOME"]],
+    decision = "forbidden",
+    justification = "Refuse catastrophic root or home-directory deletion.",
+    match = [
+        "rm -rf /",
+        "rm -fr ~",
+        "rm -rf $HOME",
+    ],
+    not_match = [
+        "rm -rf build",
+    ],
+)
+
+prefix_rule(
+    pattern = ["docker", "system", "prune"],
+    decision = "prompt",
+    justification = "Docker system pruning can remove shared images, containers, and caches.",
+    match = [
+        "docker system prune",
+        "docker system prune --all",
+    ],
+)
+
+prefix_rule(
+    pattern = ["docker", ["rm", "rmi"]],
+    decision = "prompt",
+    justification = "Removing Docker containers or images changes shared host state.",
+    match = [
+        "docker rm container",
+        "docker rmi image",
+    ],
+)
+
+prefix_rule(
+    pattern = ["docker", "volume", "rm"],
+    decision = "prompt",
+    justification = "Removing Docker volumes can permanently delete data.",
+    match = [
+        "docker volume rm data",
+    ],
+)
+
+prefix_rule(
+    pattern = ["kubectl", ["apply", "create", "delete", "edit", "patch", "replace", "scale"]],
+    decision = "prompt",
+    justification = "This command changes Kubernetes cluster state.",
+    match = [
+        "kubectl apply -f deployment.yml",
+        "kubectl delete pod service-123",
+        "kubectl scale deployment service --replicas=3",
+    ],
+    not_match = [
+        "kubectl get pods",
+        "kubectl logs service-123",
+    ],
+)
+
+prefix_rule(
+    pattern = ["sudo"],
+    decision = "forbidden",
+    justification = "Run privileged commands manually after reviewing them.",
+    match = [
+        "sudo make install",
+        "sudo rm file.txt",
+    ],
+)
+
+prefix_rule(
+    pattern = [["mkfs", "mkfs.ext2", "mkfs.ext3", "mkfs.ext4", "mkfs.xfs", "mkfs.btrfs", "newfs"]],
+    decision = "forbidden",
+    justification = "Filesystem creation can destroy data; run it manually after reviewing the target device.",
+    match = [
+        "mkfs /dev/disk2",
+        "newfs /dev/disk2",
+    ],
+)
+
+prefix_rule(
+    pattern = ["diskutil", ["eraseDisk", "eraseVolume", "partitionDisk", "deleteVolume"]],
+    decision = "forbidden",
+    justification = "Disk erasure and partitioning can destroy data; run them manually after reviewing the target device.",
+    match = [
+        "diskutil eraseDisk APFS External /dev/disk2",
+        "diskutil partitionDisk /dev/disk2 GPT APFS Data 100%",
+    ],
+    not_match = [
+        "diskutil list",
+        "diskutil info /dev/disk2",
+    ],
+)
+
+prefix_rule(
+    pattern = ["dd"],
+    decision = "prompt",
+    justification = "Raw copying can overwrite devices or large files.",
+    match = [
+        "dd if=image.iso of=/dev/disk2",
+        "dd if=/dev/zero of=output.bin bs=1m count=1",
+    ],
+)

--- a/build/git/source-key
+++ b/build/git/source-key
@@ -18,7 +18,7 @@ else
   exit 1
 fi
 
-git ls-files -z . ':!:bin' ':!:bin/**' ':!:.agents' ':!:.agents/**' ':!:.claude' ':!:.claude/**' > "$files"
+git ls-files -z . ':!:bin' ':!:bin/**' ':!:.agents' ':!:.agents/**' ':!:.claude' ':!:.claude/**' ':!:.codex' ':!:.codex/**' > "$files"
 xargs -0 "${hash_command[@]}" < "$files" > "$hashes"
 
 key="$(cut -d" " -f1 "$hashes" | "${hash_command[@]}")"

--- a/build/make/codex.mak
+++ b/build/make/codex.mak
@@ -2,7 +2,7 @@
 
 BIN_ROOT ?= $(abspath $(dir $(lastword $(MAKEFILE_LIST)))../..)
 
-# Wire this repository for Codex using the shared bin skills.
-# Creates a `.agents/skills` symlink for repo-scoped `$skill` discovery.
+# Wire this repository for Codex using shared skills, permissions, and rules.
+# Creates `.agents/skills`, `.codex/config.toml`, and `.codex/rules/bin.rules` symlinks.
 codex-init:
 	@BIN_ROOT="$(BIN_ROOT)" "$(BIN_ROOT)/build/codex/init"

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -45,7 +45,7 @@ AI-assisted-by: [Claude Code](https://claude.com/claude-code)
 - Write the multiline Markdown `desc` to a temporary file with `mktemp`, then run the review target with the drafted subject and file path:
 
 ```bash
-make msg="unprefixed subject" desc_file="$desc_file" review
+make review msg="unprefixed subject" desc_file="$desc_file"
 ```
 
 - Pass `desc_file` as the path to the multiline Markdown summary; do not flatten the summary into a single line or pass Markdown through a quoted shell argument.

--- a/skills/review-pr/agents/openai.yaml
+++ b/skills/review-pr/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Review PR"
   short_description: "Prepare an approved review PR flow"
-  default_prompt: "Use $review-pr when I explicitly ask to commit, push, and open or update a review PR; maintain its active plan, use runtime goals only when authorized, use a fresh review gate for substantial changes, and include review-time documentation judgment through $doc-standards."
+  default_prompt: "Use $review-pr when I explicitly ask to commit, push, and open or update a review PR; maintain its active plan, use runtime goals only when authorized, use a fresh review gate for substantial changes, include review-time documentation judgment through $doc-standards, and put the guarded Make review target before its variable assignments."

--- a/skills/review-pr/references/output-format.md
+++ b/skills/review-pr/references/output-format.md
@@ -25,7 +25,7 @@ unprefixed subject
 
 ## Review Target
 
-- command: `make msg="..." desc_file="..." review`
+- command: `make review msg="..." desc_file="..."`
   result: passed
   pr: https://github.com/org/repo/pull/123
 

--- a/skills/review-pr/references/plan.md
+++ b/skills/review-pr/references/plan.md
@@ -65,6 +65,6 @@ repository root and keep `bin/` as shared guidance.
 12. Read `references/summary-format.md`.
 13. Draft the lowercase, unprefixed `msg` and multiline Markdown `desc`.
 14. Write `desc` to a temporary file.
-15. Run `make msg="..." desc_file="$desc_file" review`.
+15. Run `make review msg="..." desc_file="$desc_file"`.
 16. Read `references/output-format.md`.
 17. Report the result in the required output format.


### PR DESCRIPTION
## What

- Add a shared Codex permission profile that allows workspace development, Git metadata updates, and standard Go, RuboCop, and Trivy caches while denying credential files and sandboxed command network access.
- Add shared host-execution rules that classify remote writes and destructive operations for approval, forbid catastrophic commands, and are wired into consuming repositories by `make codex-init`.
- Self-wire this repository, exclude `.codex` agent wiring from source keys, document the shared behavior and compatibility boundary, and align `$review-pr` so its supported command matches the new guardrail.

## Why

- Repeated repository-specific approvals had accumulated into a large global allowlist, including broad host-execution permissions that bypassed the sandbox.
- A versioned project baseline keeps routine work autonomous across repositories while preserving explicit gates for remote writes, destructive actions, credentials, and network access.

## Testing

- `make dep` - passed
- `make clean-dep` - passed
- `make scripts-lint` - passed
- `make skills-lint` - passed
- `make docker-lint` - passed
- `make lint` - passed
- `make sec` - passed
- `make source-key` - passed
- `codex execpolicy check --pretty --rules .codex/rules/bin.rules -- make review 'msg=test subject' 'desc_file=/private/tmp/review.md'` - passed; the supported review command resolves to `prompt`
- `codex execpolicy check --pretty --rules .codex/rules/bin.rules -- git push --force origin feature` - passed; raw force-push resolves to `forbidden`
- `make -n review msg='test subject' desc_file=/private/tmp/review.md` - passed; preserved the commit, guarded push, and draft-PR recipe
- Isolated `build/codex/init` run - passed; all shared symlinks resolve and are readable
- Isolated `codex doctor --json` configuration load - passed; Codex 0.144.1 parsed the shared profile and reported the filesystem sandbox as restricted
- `markdownlint-cli2 README.md AGENTS.md skills/review-pr/SKILL.md skills/review-pr/references/plan.md skills/review-pr/references/output-format.md` - reports the pre-existing `README.md:1` MD041 warning; changed documentation has no additional errors

AI-assisted-by: [Codex](https://openai.com/codex/)
