### PR TITLE
feat(skills): allow authenticated sandbox workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -653,9 +653,12 @@ Target-specific rules:
   untouched. The project must be trusted before Codex loads project config and
   rules, and permission profiles require Codex 0.138.0 or later. The shared
   profile makes workspace `.git` metadata writable for routine staging and
-  commits; remote and destructive Git operations remain governed by the shared
-  rules and explicit workflow permission gates. Per-machine additions belong
-  in `~/.codex/config.toml` and `~/.codex/rules/`.
+  commits, grants read-only access to common host credential locations, and
+  allows outbound internet access. Use it only in trusted repositories because
+  sandboxed commands can transmit readable credentials. Remote and destructive
+  Git operations remain governed by the shared rules and explicit workflow
+  permission gates. Per-machine additions belong in `~/.codex/config.toml` and
+  `~/.codex/rules/`.
   `build/claude/init` (via `make claude-init`)
   wires Claude Code by symlinking `.claude/skills` to `skills/`, symlinking
   `.claude/settings.json` to the shared `build/claude/settings.json`

--- a/README.md
+++ b/README.md
@@ -91,15 +91,19 @@ an existing real config can merge the shared settings explicitly.
 
 The permission profile requires Codex 0.138.0 or later. It allows normal edits
 inside the workspace, including Git metadata for routine staging and commits,
-permits the standard Go, RuboCop, and Trivy caches, denies common credential
-files to sandboxed commands, blocks sandboxed command network access by
-default, and sends legitimate escalation requests to the user for approval.
-Making `.git` writable also permits sandboxed commands to
-change repository metadata, configuration, and hooks; use the profile only in
-trusted repositories. The rules classify remote writes and destructive
-operations for approval and forbid catastrophic commands. Codex may therefore
-complete routine work without interrupting the user while retaining the
-explicit permission gates in `AGENTS.md`.
+permits the standard Go, RuboCop, and Trivy caches, grants read-only access to
+common host credential locations, and allows outbound internet access. The
+rules classify remote writes and destructive operations for approval and
+forbid catastrophic commands. Codex may therefore complete routine work
+without interrupting the user while retaining the explicit permission gates in
+`AGENTS.md`.
+
+> [!WARNING]
+> The shared profile is for trusted repositories. Sandboxed commands can read
+> SSH, AWS, netrc, Docker, Kubernetes, and GitHub CLI credentials and can send
+> data over the internet. Making `.git` writable also permits commands to change
+> repository metadata, configuration, and hooks. Review commands and dependency
+> scripts before authorizing workflows that use host credentials.
 
 Legacy `sandbox_mode` settings and the `--sandbox` CLI flag take precedence over
 permission profiles. Remove those overrides when the shared profile should be

--- a/build/codex/config.toml
+++ b/build/codex/config.toml
@@ -4,17 +4,17 @@ approvals_reviewer = "user"
 default_permissions = "shared-development"
 
 [permissions.shared-development]
-description = "Autonomous workspace development with credential files denied."
+description = "Autonomous workspace development with host credentials and internet access."
 extends = ":workspace"
 
 [permissions.shared-development.filesystem]
 glob_scan_max_depth = 12
-"~/.ssh" = "deny"
-"~/.aws" = "deny"
-"~/.netrc" = "deny"
-"~/.docker/config.json" = "deny"
-"~/.kube/config" = "deny"
-"~/.config/gh" = "deny"
+"~/.ssh" = "read"
+"~/.aws" = "read"
+"~/.netrc" = "read"
+"~/.docker/config.json" = "read"
+"~/.kube/config" = "read"
+"~/.config/gh" = "read"
 "~/.cache/go-build" = "write"
 "~/.cache/rubocop_cache" = "write"
 "~/.cache/trivy" = "write"
@@ -34,4 +34,4 @@ glob_scan_max_depth = 12
 "**/*.pem" = "deny"
 
 [permissions.shared-development.network]
-enabled = false
+enabled = true

--- a/build/codex/rules/default.rules
+++ b/build/codex/rules/default.rules
@@ -1,6 +1,6 @@
 # Shared host-execution guardrails for repositories wired through
-# `make codex-init`. Routine workspace commands stay sandboxed; Codex's
-# user approval reviewer handles exceptional escalations.
+# `make codex-init`. Routine workspace commands stay sandboxed; remote-write,
+# destructive, and external-service commands remain approval-gated.
 
 prefix_rule(
     pattern = [


### PR DESCRIPTION
## What

- Allow sandboxed commands in trusted repositories to read common host credential locations and use outbound internet access.
- Keep workspace `.env`, `.envrc`, and PEM files denied while documenting the expanded trust boundary and credential-exfiltration risk.
- Align the shared rules commentary and agent guidance with the authenticated sandbox workflow.

## Why

- Authenticated Git, GitHub, dependency, scanner, and service workflows need both network access and their existing host credentials to run without repeated sandbox escalations.
- This intentionally broadens the shared profile for trusted repositories: arbitrary sandboxed commands can transmit readable credentials, so repository commands and dependency scripts must be reviewed before authorization.

## Testing

- `git ls-remote origin HEAD` - passed; confirmed remote network access.
- `gh auth status` - passed; confirmed the active GitHub CLI account and HTTPS Git protocol.
- `make skills-lint` - passed.
- `git diff --check` - passed.
- `make sec` - passed; Trivy refreshed its database and reported no critical dependency vulnerabilities or secrets.
- `codex execpolicy check --rules build/codex/rules/default.rules ...` - passed; the rule file loaded and preserved prompt/forbidden decisions for guarded and raw remote-write commands.
- `codex doctor --json` - passed for config loading and the effective restricted-filesystem, enabled-network sandbox; it also reported an unrelated local rollout database warning.
- `markdownlint-cli2 README.md AGENTS.md` - reported only the pre-existing `README.md:1` MD041 warning; changed documentation added no lint errors.

AI-assisted-by: [Codex](https://openai.com/codex/)
