### PR TITLE
feat(codex): streamline trusted validation and review workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -653,12 +653,15 @@ Target-specific rules:
   untouched. The project must be trusted before Codex loads project config and
   rules, and permission profiles require Codex 0.138.0 or later. The shared
   profile makes workspace `.git` metadata writable for routine staging and
-  commits, grants read-only access to common host credential locations, and
-  allows outbound internet access. Use it only in trusted repositories because
-  sandboxed commands can transmit readable credentials. Remote and destructive
-  Git operations remain governed by the shared rules and explicit workflow
-  permission gates. Per-machine additions belong in `~/.codex/config.toml` and
-  `~/.codex/rules/`.
+  commits, grants write access to the standard Go, RuboCop, and Trivy caches plus
+  the macOS golangci-lint cache, grants read-only access to common host credential
+  locations, and allows outbound internet access. The shared rules allow `make
+  specs`, `make coverage`, `make fuzzes`, and `make benchmarks` to run outside
+  the sandbox without prompting. Use the profile only in trusted repositories
+  because sandboxed commands can transmit readable credentials and host-allowed
+  Make targets inherit the user's access. Remote and destructive Git operations
+  remain governed by the shared rules and explicit workflow permission gates.
+  Per-machine additions belong in `~/.codex/config.toml` and `~/.codex/rules/`.
   `build/claude/init` (via `make claude-init`)
   wires Claude Code by symlinking `.claude/skills` to `skills/`, symlinking
   `.claude/settings.json` to the shared `build/claude/settings.json`

--- a/README.md
+++ b/README.md
@@ -91,19 +91,22 @@ an existing real config can merge the shared settings explicitly.
 
 The permission profile requires Codex 0.138.0 or later. It allows normal edits
 inside the workspace, including Git metadata for routine staging and commits,
-permits the standard Go, RuboCop, and Trivy caches, grants read-only access to
-common host credential locations, and allows outbound internet access. The
-rules classify remote writes and destructive operations for approval and
-forbid catastrophic commands. Codex may therefore complete routine work
-without interrupting the user while retaining the explicit permission gates in
+permits the standard Go, RuboCop, and Trivy caches plus the macOS golangci-lint
+cache, grants read-only access to common host credential locations, and allows
+outbound internet access. The rules allow `make specs`, `make coverage`, `make
+fuzzes`, and `make benchmarks` to run outside the sandbox without prompting,
+classify remote writes and destructive operations for approval, and forbid
+catastrophic commands. Codex may therefore complete routine work without
+interrupting the user while retaining the explicit permission gates in
 `AGENTS.md`.
 
 > [!WARNING]
 > The shared profile is for trusted repositories. Sandboxed commands can read
 > SSH, AWS, netrc, Docker, Kubernetes, and GitHub CLI credentials and can send
 > data over the internet. Making `.git` writable also permits commands to change
-> repository metadata, configuration, and hooks. Review commands and dependency
-> scripts before authorizing workflows that use host credentials.
+> repository metadata, configuration, and hooks. The host-allowed Make targets
+> bypass the sandbox and inherit the user's access. Review commands, Makefiles,
+> and dependency scripts before running them with this profile.
 
 Legacy `sandbox_mode` settings and the `--sandbox` CLI flag take precedence over
 permission profiles. Remove those overrides when the shared profile should be

--- a/build/codex/config.toml
+++ b/build/codex/config.toml
@@ -19,6 +19,7 @@ glob_scan_max_depth = 12
 "~/.cache/rubocop_cache" = "write"
 "~/.cache/trivy" = "write"
 "~/Library/Caches/go-build" = "write"
+"~/Library/Caches/golangci-lint" = "write"
 "~/Library/Caches/trivy" = "write"
 "~/go/pkg/mod" = "write"
 

--- a/build/codex/rules/default.rules
+++ b/build/codex/rules/default.rules
@@ -5,6 +5,28 @@
 prefix_rule(
     pattern = [
         "make",
+        ["specs", "coverage", "fuzzes", "benchmarks"],
+    ],
+    decision = "allow",
+    justification = "Supported test, coverage, fuzz, and benchmark targets may run outside the sandbox without prompting.",
+    match = [
+        "make specs",
+        "make specs package=internal/foo",
+        "make coverage",
+        "make fuzzes package=internal/foo name=FuzzDecode",
+        "make benchmarks",
+    ],
+    not_match = [
+        "make features",
+        "make fuzz",
+        "make benchmark",
+        "make specs-lint",
+    ],
+)
+
+prefix_rule(
+    pattern = [
+        "make",
         [
             "push",
             "push-docker",

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -42,13 +42,24 @@ AI-assisted-by: [Codex](https://openai.com/codex/)
 AI-assisted-by: [Claude Code](https://claude.com/claude-code)
 ```
 
-- Write the multiline Markdown `desc` to a temporary file with `mktemp`, then run the review target with the drafted subject and file path:
+- Create the temporary `desc_file` yourself; never ask the user to provide its
+  path or populate it. Run this portable command and capture the returned path:
 
 ```bash
-make review msg="unprefixed subject" desc_file="$desc_file"
+mktemp "${TMPDIR:-/tmp}/review-pr.XXXXXX"
 ```
 
-- Pass `desc_file` as the path to the multiline Markdown summary; do not flatten the summary into a single line or pass Markdown through a quoted shell argument.
+- Write the multiline Markdown `desc` to that file, then substitute the returned
+  path directly into the review command so the guarded Make target remains the
+  command prefix:
+
+```bash
+make review msg="unprefixed subject" desc_file="/returned/path/review-pr.ABC123"
+```
+
+- Remove the temporary file after `make review`, including when the review
+  command fails. Do not flatten the summary into a single line or pass Markdown
+  through a quoted shell argument.
 - Read `references/output-format.md`, then report the result using that exact
   structure.
 

--- a/skills/review-pr/agents/openai.yaml
+++ b/skills/review-pr/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Review PR"
-  short_description: "Prepare an approved review PR flow"
-  default_prompt: "Use $review-pr when I explicitly ask to commit, push, and open or update a review PR; maintain its active plan, use runtime goals only when authorized, use a fresh review gate for substantial changes, include review-time documentation judgment through $doc-standards, and put the guarded Make review target before its variable assignments."
+  short_description: "Prepare a portable approved review PR flow"
+  default_prompt: "Use $review-pr when I explicitly ask to commit, push, and open or update a review PR; maintain its active plan, use runtime goals only when authorized, use a fresh review gate for substantial changes, include review-time documentation judgment through $doc-standards, create and clean up a portable desc_file without asking me for it, and put the guarded Make review target before its variable assignments."

--- a/skills/review-pr/references/plan.md
+++ b/skills/review-pr/references/plan.md
@@ -64,7 +64,11 @@ repository root and keep `bin/` as shared guidance.
     PR with unresolved findings documented.
 12. Read `references/summary-format.md`.
 13. Draft the lowercase, unprefixed `msg` and multiline Markdown `desc`.
-14. Write `desc` to a temporary file.
-15. Run `make review msg="..." desc_file="$desc_file"`.
-16. Read `references/output-format.md`.
-17. Report the result in the required output format.
+14. Create `desc_file` yourself with
+    `mktemp "${TMPDIR:-/tmp}/review-pr.XXXXXX"`; never ask the user for the path
+    or file contents. Capture the returned path and write `desc` to it.
+15. Substitute the returned path directly into
+    `make review msg="..." desc_file="/returned/path/review-pr.ABC123"`.
+16. Remove `desc_file`, including when `make review` fails.
+17. Read `references/output-format.md`.
+18. Report the result in the required output format.


### PR DESCRIPTION
## What

- Allow `make specs`, `make coverage`, `make fuzzes`, and `make benchmarks` to run outside the sandbox without prompting while keeping neighboring targets and remote-write operations under their existing policy.
- Grant the macOS golangci-lint cache write access and document the resulting trusted-repository boundary.
- Make the review PR workflow create, use, and clean up its own portable multiline description file without asking the user, with matching skill metadata and plan guidance.

## Why

- Supported validation workflows need host execution and their normal caches without recurring approval prompts, while destructive and remote operations still need explicit protection.
- Review PR creation should remain portable and noninteractive without flattening Markdown summaries or depending on a user-provided temporary file.

## Testing

- `make dep` - passed
- `make clean-dep` - passed
- `make scripts-lint` - passed
- `make skills-lint` - passed
- `make docker-lint` - passed
- `make lint` - passed
- `make sec` - passed; Trivy reported no critical vulnerabilities.
- `git diff --check` - passed
- `codex execpolicy check --pretty --rules build/codex/rules/default.rules -- ...` - passed for all requested allow rules, neighboring non-matches, the guarded review prompt, and the raw force-push prohibition.
- `codex --strict-config doctor --summary --no-color --ascii` - passed configuration loading; it reported an unrelated pre-existing rollout/state inventory warning.

AI-assisted-by: [Codex](https://openai.com/codex/)
