### PR TITLE
feat(skills): allow vendored ca bundles in workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ catastrophic commands. Codex may therefore complete routine work without
 interrupting the user while retaining the explicit permission gates in
 `AGENTS.md`.
 
+Within the workspace, the profile denies `.env`, `.env.*`, and `.envrc` files
+at the repository root and in nested directories. It does not blanket-deny PEM
+files because dependencies can vendor public CA bundles in that format; trusted
+repository commands can therefore read and modify workspace PEM files like
+other workspace files.
+
 > [!WARNING]
 > The shared profile is for trusted repositories. Sandboxed commands can read
 > SSH, AWS, netrc, Docker, Kubernetes, and GitHub CLI credentials and can send
@@ -117,7 +123,8 @@ per-machine additions in `~/.codex/config.toml` and
 `~/.codex/rules/default.rules`; Codex also records accepted persistent command
 prefixes in that user rules file. Re-run `make codex-init` only when the shared
 paths move. Updates to the shared profile or rules propagate with the next
-`bin` submodule update.
+`bin` submodule update; start a new Codex session afterward so its sandbox uses
+the updated profile.
 
 Codex reads `AGENTS.md` separately for repository instructions. Downstream
 repositories should still point agents at the shared instructions instead of

--- a/build/codex/config.toml
+++ b/build/codex/config.toml
@@ -28,11 +28,9 @@ glob_scan_max_depth = 12
 ".env" = "deny"
 ".env.*" = "deny"
 ".envrc" = "deny"
-"*.pem" = "deny"
 "**/.env" = "deny"
 "**/.env.*" = "deny"
 "**/.envrc" = "deny"
-"**/*.pem" = "deny"
 
 [permissions.shared-development.network]
 enabled = true


### PR DESCRIPTION
## What

- Remove the workspace-root PEM deny rules from the shared Codex permission profile so trusted repository commands can use vendored public CA bundles.
- Preserve root and nested `.env`, `.env.*`, and `.envrc` denies without adding a host-execution workaround for `make features`.
- Document normal workspace access for PEM files and the need to start a new Codex session after updating the shared profile.

## Why

- Standort's `make features` cannot read gRPC's vendored `etc/roots.pem` while the shared profile blanket-denies PEM files, causing `Operation not permitted`.
- Treating every PEM file as a credential blocks supported dependency workflows; environment-file protections remain the targeted secret boundary.

## Testing

- `make dep` - passed
- `make clean-dep` - passed
- `make scripts-lint` - passed
- `make skills-lint` - passed
- `make docker-lint` - passed
- `make lint` - passed
- `make sec` - passed; Trivy reported no vulnerabilities
- `git diff --check` - passed
- `codex doctor --json` - passed config loading and parsing; it reported an unrelated local rollout-database parity warning
- No executable regression test was added because this repository has no established Codex permission-profile harness; Standort's downstream `make features` was not rerun from this checkout

AI-assisted-by: [Codex](https://openai.com/codex/)
