### PR TITLE
feat(codex): run feature tests outside the sandbox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -656,8 +656,9 @@ Target-specific rules:
   commits, grants write access to the standard Go, RuboCop, and Trivy caches plus
   the macOS golangci-lint cache, grants read-only access to common host credential
   locations, and allows outbound internet access. The shared rules allow `make
-  specs`, `make coverage`, `make fuzzes`, and `make benchmarks` to run outside
-  the sandbox without prompting. Use the profile only in trusted repositories
+  specs`, `make features`, `make coverage`, `make fuzzes`, and `make benchmarks`
+  to run outside the sandbox without prompting. Use the profile only in trusted
+  repositories
   because sandboxed commands can transmit readable credentials and host-allowed
   Make targets inherit the user's access. Remote and destructive Git operations
   remain governed by the shared rules and explicit workflow permission gates.

--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ The permission profile requires Codex 0.138.0 or later. It allows normal edits
 inside the workspace, including Git metadata for routine staging and commits,
 permits the standard Go, RuboCop, and Trivy caches plus the macOS golangci-lint
 cache, grants read-only access to common host credential locations, and allows
-outbound internet access. The rules allow `make specs`, `make coverage`, `make
-fuzzes`, and `make benchmarks` to run outside the sandbox without prompting,
+outbound internet access. The rules allow `make specs`, `make features`, `make
+coverage`, `make fuzzes`, and `make benchmarks` to run outside the sandbox
+without prompting,
 classify remote writes and destructive operations for approval, and forbid
 catastrophic commands. Codex may therefore complete routine work without
 interrupting the user while retaining the explicit permission gates in

--- a/build/codex/rules/default.rules
+++ b/build/codex/rules/default.rules
@@ -5,19 +5,19 @@
 prefix_rule(
     pattern = [
         "make",
-        ["specs", "coverage", "fuzzes", "benchmarks"],
+        ["specs", "features", "coverage", "fuzzes", "benchmarks"],
     ],
     decision = "allow",
-    justification = "Supported test, coverage, fuzz, and benchmark targets may run outside the sandbox without prompting.",
+    justification = "Supported spec, feature, coverage, fuzz, and benchmark targets may run outside the sandbox without prompting.",
     match = [
         "make specs",
         "make specs package=internal/foo",
+        "make features",
         "make coverage",
         "make fuzzes package=internal/foo name=FuzzDecode",
         "make benchmarks",
     ],
     not_match = [
-        "make features",
         "make fuzz",
         "make benchmark",
         "make specs-lint",


### PR DESCRIPTION
## What

- Allow `make features` to use the shared host-execution path alongside the existing spec, coverage, fuzz, and benchmark targets.
- Keep unlisted Make targets on their existing sandbox or approval paths and document the updated host-allowed set in `README.md` and `AGENTS.md`.

## Why

- On macOS, sandboxed feature runs can deny netstat's `IFDATA_SUPPLEMENTAL` query, causing gopsutil to panic and the service to exit before the feature harness completes.
- Giving the supported feature target the same scoped execution policy as the other test targets restores the downstream workflow without disabling metrics or sandboxing globally.

## Testing

- `codex execpolicy check --pretty --rules build/codex/rules/default.rules -- make features` - passed
- `codex execpolicy check --pretty --rules build/codex/rules/default.rules -- make features feature=test/features/location.feature` - passed
- `codex execpolicy check --pretty --rules build/codex/rules/default.rules -- make features-extra` - passed; no rule matched
- `make dep` - passed
- `make clean-dep` - passed
- `make scripts-lint` - passed
- `make skills-lint` - passed
- `make docker-lint` - passed
- `make lint` - passed
- `make sec` - passed
- Downstream `standort` verification after its module update and a new Codex session was not run; it is deferred until after merge.

AI-assisted-by: [Codex](https://openai.com/codex/)
