### PR TITLE
feat(codex): use full host access in trusted repositories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -649,19 +649,16 @@ Target-specific rules:
   invocation differs, cover both. `build/codex/init` (via `make codex-init`)
   wires Codex by symlinking `.agents/skills` to `skills/`, `.codex/config.toml`
   to the shared permission profile, and `.codex/rules/bin.rules` to the shared
-  host-execution guardrails; repo-owned real config and rule files are left
+  execution guardrails; repo-owned real config and rule files are left
   untouched. The project must be trusted before Codex loads project config and
   rules, and permission profiles require Codex 0.138.0 or later. The shared
-  profile makes workspace `.git` metadata writable for routine staging and
-  commits, grants write access to the standard Go, RuboCop, and Trivy caches plus
-  the macOS golangci-lint cache, grants read-only access to common host credential
-  locations, and allows outbound internet access. The shared rules allow `make
-  specs`, `make features`, `make coverage`, `make fuzzes`, and `make benchmarks`
-  to run outside the sandbox without prompting. Use the profile only in trusted
-  repositories
-  because sandboxed commands can transmit readable credentials and host-allowed
-  Make targets inherit the user's access. Remote and destructive Git operations
-  remain governed by the shared rules and explicit workflow permission gates.
+  profile selects `:danger-full-access`, so commands run without filesystem or
+  network sandbox restrictions. Approval remains `on-request`; shared rules
+  require approval for recognized remote writes and destructive operations and
+  forbid catastrophic commands. Use the profile only in trusted repositories
+  because every command, hook, and dependency script inherits the user's host
+  access. The shared rules and explicit workflow permission gates remain in
+  force, but the rules are not a filesystem or network sandbox.
   Per-machine additions belong in `~/.codex/config.toml` and `~/.codex/rules/`.
   `build/claude/init` (via `make claude-init`)
   wires Claude Code by symlinking `.claude/skills` to `skills/`, symlinking

--- a/README.md
+++ b/README.md
@@ -83,37 +83,26 @@ make codex-init
 
 This creates a `.agents/skills` symlink to `bin/skills`, a `.codex/config.toml`
 symlink to the shared permission profile in `bin/build/codex/config.toml`, and a
-`.codex/rules/bin.rules` symlink to the shared host-execution guardrails. A
+`.codex/rules/bin.rules` symlink to the shared execution guardrails. A
 repository-owned real config or rule file is left untouched. Every later clone
 can invoke shared skills with `$`, for example `$code-review`, and receives the
 shared permissions after the one-time project trust prompt. Repositories with
 an existing real config can merge the shared settings explicitly.
 
-The permission profile requires Codex 0.138.0 or later. It allows normal edits
-inside the workspace, including Git metadata for routine staging and commits,
-permits the standard Go, RuboCop, and Trivy caches plus the macOS golangci-lint
-cache, grants read-only access to common host credential locations, and allows
-outbound internet access. The rules allow `make specs`, `make features`, `make
-coverage`, `make fuzzes`, and `make benchmarks` to run outside the sandbox
-without prompting,
-classify remote writes and destructive operations for approval, and forbid
-catastrophic commands. Codex may therefore complete routine work without
-interrupting the user while retaining the explicit permission gates in
-`AGENTS.md`.
-
-Within the workspace, the profile denies `.env`, `.env.*`, and `.envrc` files
-at the repository root and in nested directories. It does not blanket-deny PEM
-files because dependencies can vendor public CA bundles in that format; trusted
-repository commands can therefore read and modify workspace PEM files like
-other workspace files.
+The permission profile requires Codex 0.138.0 or later. It selects the built-in
+`:danger-full-access` profile, so commands run without filesystem or network
+sandbox restrictions. Approval remains `on-request`; the shared rules require
+approval for recognized remote writes and destructive operations and forbid
+catastrophic commands. Explicit workflow permission gates in `AGENTS.md` also
+remain in force.
 
 > [!WARNING]
-> The shared profile is for trusted repositories. Sandboxed commands can read
-> SSH, AWS, netrc, Docker, Kubernetes, and GitHub CLI credentials and can send
-> data over the internet. Making `.git` writable also permits commands to change
-> repository metadata, configuration, and hooks. The host-allowed Make targets
-> bypass the sandbox and inherit the user's access. Review commands, Makefiles,
-> and dependency scripts before running them with this profile.
+> The shared profile is only for trusted repositories. Every command, Make
+> target, hook, and dependency script inherits the user's host access: it can
+> read or modify files outside the workspace, access credentials, and send data
+> over the internet. The shared rules cover named risky command shapes; they are
+> not a filesystem or network sandbox. Review executable repository content
+> before running it with this profile.
 
 Legacy `sandbox_mode` settings and the `--sandbox` CLI flag take precedence over
 permission profiles. Remove those overrides when the shared profile should be
@@ -124,8 +113,8 @@ per-machine additions in `~/.codex/config.toml` and
 `~/.codex/rules/default.rules`; Codex also records accepted persistent command
 prefixes in that user rules file. Re-run `make codex-init` only when the shared
 paths move. Updates to the shared profile or rules propagate with the next
-`bin` submodule update; start a new Codex session afterward so its sandbox uses
-the updated profile.
+`bin` submodule update; start a new Codex session afterward so it uses the
+updated permissions.
 
 Codex reads `AGENTS.md` separately for repository instructions. Downstream
 repositories should still point agents at the shared instructions instead of
@@ -191,7 +180,7 @@ Dockerfile lint targets depend on `shellcheck` and `hadolint`;
 - `build/codex/init`: one-time Codex wiring for a consuming repository (run via
   `make codex-init`).
 - `build/codex/config.toml` and `build/codex/rules/default.rules`: shared Codex
-  permission profile and host-execution guardrails.
+  permission profile and execution guardrails.
 - `build/claude/init`: one-time Claude Code wiring for a consuming repository
   (run via `make claude-init`).
 - `build/docker/go/Dockerfile`: shared Go service Dockerfile template.

--- a/build/codex/config.toml
+++ b/build/codex/config.toml
@@ -1,36 +1,4 @@
 # Shared Codex permissions for repositories wired through `make codex-init`.
 approval_policy = "on-request"
 approvals_reviewer = "user"
-default_permissions = "shared-development"
-
-[permissions.shared-development]
-description = "Autonomous workspace development with host credentials and internet access."
-extends = ":workspace"
-
-[permissions.shared-development.filesystem]
-glob_scan_max_depth = 12
-"~/.ssh" = "read"
-"~/.aws" = "read"
-"~/.netrc" = "read"
-"~/.docker/config.json" = "read"
-"~/.kube/config" = "read"
-"~/.config/gh" = "read"
-"~/.cache/go-build" = "write"
-"~/.cache/rubocop_cache" = "write"
-"~/.cache/trivy" = "write"
-"~/Library/Caches/go-build" = "write"
-"~/Library/Caches/golangci-lint" = "write"
-"~/Library/Caches/trivy" = "write"
-"~/go/pkg/mod" = "write"
-
-[permissions.shared-development.filesystem.":workspace_roots"]
-".git" = "write"
-".env" = "deny"
-".env.*" = "deny"
-".envrc" = "deny"
-"**/.env" = "deny"
-"**/.env.*" = "deny"
-"**/.envrc" = "deny"
-
-[permissions.shared-development.network]
-enabled = true
+default_permissions = ":danger-full-access"

--- a/build/codex/init
+++ b/build/codex/init
@@ -3,7 +3,7 @@
 #
 # Creates a .agents/skills symlink for shared skills, a .codex/config.toml
 # symlink for the shared permission profile, and a .codex/rules/bin.rules
-# symlink for shared host-execution guardrails. Safe to run repeatedly;
+# symlink for shared execution guardrails. Safe to run repeatedly;
 # repo-owned real config and rule files are never overwritten.
 
 set -eo pipefail

--- a/build/codex/rules/default.rules
+++ b/build/codex/rules/default.rules
@@ -1,28 +1,6 @@
-# Shared host-execution guardrails for repositories wired through
-# `make codex-init`. Routine workspace commands stay sandboxed; remote-write,
+# Shared execution guardrails for repositories wired through `make codex-init`.
+# Commands run without sandbox restrictions by default; remote-write,
 # destructive, and external-service commands remain approval-gated.
-
-prefix_rule(
-    pattern = [
-        "make",
-        ["specs", "features", "coverage", "fuzzes", "benchmarks"],
-    ],
-    decision = "allow",
-    justification = "Supported spec, feature, coverage, fuzz, and benchmark targets may run outside the sandbox without prompting.",
-    match = [
-        "make specs",
-        "make specs package=internal/foo",
-        "make features",
-        "make coverage",
-        "make fuzzes package=internal/foo name=FuzzDecode",
-        "make benchmarks",
-    ],
-    not_match = [
-        "make fuzz",
-        "make benchmark",
-        "make specs-lint",
-    ],
-)
 
 prefix_rule(
     pattern = [


### PR DESCRIPTION
## What

- Select the built-in `:danger-full-access` permission profile for trusted repositories and remove the custom filesystem, network, and validation-target sandbox exceptions it replaces.
- Update the shared rules, bootstrap comments, agent guidance, and README to describe unrestricted host access, retained approval gates, compatibility overrides, and the resulting trust boundary.

## Why

- Trusted repository workflows need predictable access to developer tools, caches, credentials, and networks without accumulating one-off sandbox exceptions as supported commands evolve.
- The explicit full-access profile makes that operational contract clear while preserving user-reviewed remote writes, destructive-operation prompts, catastrophic-command prohibitions, and repository workflow gates.

## Testing

- `make dep` - passed; Gem dependencies were already satisfied.
- `make clean-dep` - passed.
- `make scripts-lint` - passed.
- `make skills-lint` - passed.
- `make docker-lint` - passed.
- `make lint` - passed; RuboCop inspected six files with no offenses.
- `make sec` - passed; Trivy found no vulnerabilities.
- `make codex-init` - passed; refreshed the supported local symlink wiring without changing tracked files.
- `git diff --check` - passed.
- `codex --strict-config doctor --json` - passed config loading on Codex 0.144.1 and reported the unrestricted filesystem profile with `OnRequest` approval; an unrelated local rollout-database inventory warning remains.
- `codex execpolicy check --pretty --rules build/codex/rules/default.rules ...` - passed for the guarded review prompt, ordinary unclassified test target, raw force-push prohibition, and catastrophic deletion prohibition.
- No executable regression test was added because the repository has no established Codex permission-profile or approval-prompt harness; validation used the live symlinked config, Codex diagnostics, policy evaluation, and repository CI targets.

AI-assisted-by: [Codex](https://openai.com/codex/)
