### PR TITLE
feat(claude): disable the bash sandbox in the permissions baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -666,9 +666,16 @@ Target-specific rules:
   permissions baseline (unless the repo owns a real, non-symlink
   `settings.json`), and importing `AGENTS.md` from `CLAUDE.md`; the symlinks
   target shared paths, so updating skills or the permissions baseline needs no
-  downstream re-wiring, only a `git submodule update`. Per-repo or per-machine
-  permission tweaks belong in the gitignored `.claude/settings.local.json`,
-  which Claude Code merges over the baseline.
+  downstream re-wiring, only a `git submodule update`. The baseline sets
+  `sandbox.enabled: false` to match the Codex `:danger-full-access` posture, so
+  commands run without Claude Code's bash sandbox; the `permissions`
+  allow/ask/deny arrays are the guardrails (equivalent to the Codex
+  `default.rules`), where `allow` keeps routine dev commands prompt-free, `ask`
+  gates recognized remote writes and destructive operations, and `deny` forbids
+  catastrophic commands. Use the baseline only in trusted repositories because
+  every command and hook inherits the user's host access. Per-repo or
+  per-machine permission tweaks belong in the gitignored
+  `.claude/settings.local.json`, which Claude Code merges over the baseline.
 - Treat skills as maintained artifacts and review them when project workflow,
   tooling, model behavior, or team conventions change.
 - Treat external skills like third-party dependencies. Use `security-audit` with

--- a/README.md
+++ b/README.md
@@ -149,6 +149,22 @@ one-time workspace trust prompt. Invoke a skill as a slash command, for example
 `/code-review`. Re-run `make claude-init` only when the shared skills directory
 moves; adding a new skill or updating the permissions baseline needs no
 downstream change because the symlinks target shared paths that follow `bin`.
+
+The baseline sets `sandbox.enabled: false` to match the Codex
+`:danger-full-access` posture, so commands run without Claude Code's bash
+sandbox. The `permissions` allow, ask, and deny arrays are the guardrails:
+`allow` keeps routine dev commands prompt-free, `ask` gates recognized remote
+writes and destructive operations, and `deny` forbids catastrophic commands.
+Explicit workflow permission gates in `AGENTS.md` also remain in force.
+
+> [!WARNING]
+> The shared baseline is only for trusted repositories. Every command, Make
+> target, hook, and dependency script inherits the user's host access: it can
+> read or modify files outside the workspace, access credentials, and send data
+> over the internet. The permissions arrays cover named risky command shapes;
+> they are not a filesystem or network sandbox. Review executable repository
+> content before running it with this baseline.
+
 Put per-repository or per-machine permission tweaks in the gitignored
 `.claude/settings.local.json`, which Claude Code merges over the baseline.
 Wiring the `*-template` repositories once pre-wires every repository generated

--- a/build/claude/settings.json
+++ b/build/claude/settings.json
@@ -1,5 +1,8 @@
 {
   "defaultMode": "acceptEdits",
+  "sandbox": {
+    "enabled": false
+  },
   "permissions": {
     "allow": [
       "Bash(zsh -lic *)",
@@ -154,10 +157,22 @@
       "Bash(gh pr merge*)",
       "Bash(gh pr close*)",
       "Bash(gh pr edit*)",
+      "Bash(gh pr reopen*)",
+      "Bash(gh pr ready*)",
+      "Bash(gh pr review*)",
+      "Bash(gh pr comment*)",
       "Bash(gh issue create*)",
+      "Bash(gh issue close*)",
+      "Bash(gh issue edit*)",
+      "Bash(gh issue reopen*)",
+      "Bash(gh issue comment*)",
       "Bash(gh release create*)",
+      "Bash(gh release delete*)",
+      "Bash(gh release edit*)",
+      "Bash(gh release upload*)",
       "Bash(gem push*)",
       "Bash(npm publish*)",
+      "Bash(dd *)",
       "Bash(rm -rf *)",
       "Bash(rm -fr *)",
       "Bash(rm -r *)",
@@ -183,6 +198,10 @@
       "Bash(git push -f *)",
       "Bash(mkfs*)",
       "Bash(dd *of=/dev/*)",
+      "Bash(diskutil eraseDisk*)",
+      "Bash(diskutil eraseVolume*)",
+      "Bash(diskutil partitionDisk*)",
+      "Bash(diskutil deleteVolume*)",
       "Read(**/.env)",
       "Read(**/.env.*)",
       "Read(**/.envrc)",


### PR DESCRIPTION
## What

- The shared Claude Code permissions baseline (`build/claude/settings.json`)
  now sets `sandbox.enabled: false`, matching the Codex `:danger-full-access`
  posture, so permitted routine dev commands no longer trigger "run outside the
  sandbox" prompts.
- The `permissions` allow/ask/deny arrays are unchanged as the guardrails;
  ask/deny gained the entries needed to stay in lockstep with the Codex
  `default.rules`: `dd *`, the remaining `gh pr/issue/release` write verbs, and
  `diskutil` erase/partition/delete denials.
- Documented the posture in `AGENTS.md` (the `build/claude/init` paragraph) and
  `README.md` (Claude Code section, with a trusted-repositories WARNING
  mirroring the Codex one).
- Additive only: no existing allow/ask/deny entries were removed. Downstream
  repos that symlink `.claude/settings.json` pick this up on
  `git submodule update` with no re-wiring.

## Why

- Under its default bash sandbox, Claude Code repeatedly prompted to "run
  outside the sandbox" for already-permitted commands that write to the Go
  build/module cache (`~/Library/Caches/go-build`, `~/go/pkg/mod`) or reach
  localhost test sidecars; Codex never hit this because it runs full-access.
  Aligning the two baselines removes that friction while keeping the deny/ask
  guardrails as the real controls.
- Disabling the sandbox grants full host access, so the change carries the same
  trusted-repositories-only warning as the Codex profile — now documented in
  both `AGENTS.md` and `README.md` so operators wiring `make claude-init` are
  warned before adopting it.

## Testing

- `make skills-lint` - passed (CI gate for `AGENTS.md` policy markers)
- `markdownlint-cli2 README.md AGENTS.md` - passed for this change; the only
  reported error is a pre-existing `MD041` badge-on-line-1 in `README.md` that
  predates this diff and is not a CI gate.
- `jq . build/claude/settings.json` - passed (valid JSON; `sandbox` key present,
  allow/ask/deny arrays intact and additive).
- No test harness exists for permission/sandbox config, consistent with the
  Codex `config.toml`/`default.rules`; verification is lint + JSON validity +
  additive-diff review. Runtime prompt-suppression behavior is a Claude Code
  environment effect not exercised here.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
