### PR TITLE
feat(ai): permit temporary file cleanup without prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ an existing real config can merge the shared settings explicitly.
 The permission profile requires Codex 0.138.0 or later. It selects the built-in
 `:danger-full-access` profile, so commands run without filesystem or network
 sandbox restrictions. Approval remains `on-request`; the shared rules require
-approval for recognized remote writes and destructive operations and forbid
-catastrophic commands. Explicit workflow permission gates in `AGENTS.md` also
-remain in force.
+approval for recognized remote writes and recursive destructive operations,
+allow direct non-recursive `rm -f` cleanup, and forbid catastrophic commands.
+Explicit workflow permission gates in `AGENTS.md` also remain in force.
 
 > [!WARNING]
 > The shared profile is only for trusted repositories. Every command, Make
@@ -155,11 +155,12 @@ The baseline sets `sandbox.enabled: false` to match the Codex
 sandbox. The `permissions` allow, ask, and deny arrays are the guardrails:
 `allow` lets Claude read, write, and run anything locally without prompts
 (`Bash(*)` plus unrestricted `Read`/`Edit`/`Write`), `ask` gates recognized
-remote writes and destructive operations, and `deny` forbids catastrophic
-commands. Like Codex `:danger-full-access`, the baseline applies no filesystem
-sandbox and no secret-read restrictions; only the named remote-write and
-destructive command shapes prompt or are refused. Explicit workflow permission
-gates in `AGENTS.md` also remain in force.
+remote writes and recursive destructive operations, and `deny` forbids
+catastrophic commands. Non-recursive `rm -f` cleanup is allowed. Like Codex
+`:danger-full-access`, the baseline applies no filesystem sandbox and no
+secret-read restrictions; only the named remote-write and destructive command
+shapes prompt or are refused. Explicit workflow permission gates in `AGENTS.md`
+also remain in force.
 
 > [!WARNING]
 > The shared baseline is only for trusted repositories. Every command, Make

--- a/build/codex/rules/default.rules
+++ b/build/codex/rules/default.rules
@@ -225,6 +225,20 @@ prefix_rule(
 )
 
 prefix_rule(
+    pattern = ["rm", "-f"],
+    decision = "allow",
+    justification = "Non-recursive forced removal is permitted for temporary-file cleanup.",
+    match = [
+        "rm -f test/reports/output.txt",
+        "rm -f -- /tmp/agent-temp-file",
+    ],
+    not_match = [
+        "rm -rf test/reports",
+        "rm -r test/reports",
+    ],
+)
+
+prefix_rule(
     pattern = ["rm", ["-rf", "-fr"], ["/", "~", "$HOME"]],
     decision = "forbidden",
     justification = "Refuse catastrophic root or home-directory deletion.",


### PR DESCRIPTION
## What

- Add a shared Codex rule that permits direct, non-recursive `rm -f` cleanup without an approval prompt.
- Clarify the shared Codex and Claude permission documentation: remote writes and recursive deletion remain gated, while Claude already allows non-recursive cleanup.

## Why

- Agents frequently remove temporary files they created. Removing the direct non-recursive prompt reduces interruption without weakening the recursive and catastrophic-deletion guardrails.

## Testing

- `codex execpolicy check --pretty --rules .codex/rules/bin.rules -- rm -f /tmp/agent-temp-file` - passed; confirmed the direct cleanup rule allows execution.
- `codex execpolicy check --pretty --rules .codex/rules/bin.rules -- rm -rf test/reports` and `rm -rf /` - passed; confirmed recursive deletion prompts and root deletion remains forbidden.
- `jq -e ... build/claude/settings.json` - passed; confirmed Claude's existing `Bash(*)` allow rule and recursive-delete prompts.
- `gmake scripts-lint` - passed.
- `gmake skills-lint` - passed.
- `git diff --check` - passed.
- Scope is intentionally limited to direct commands; shell-wrapped `rm -f` remains approval-gated.

AI-assisted-by: [Codex](https://openai.com/codex/)
