### PR TITLE
feat(skills): restore workflow guardrails

### DIFF
--- a/quality/skills/lint
+++ b/quality/skills/lint
@@ -87,6 +87,17 @@ require_gitignore_pattern() {
   fi
 }
 
+require_reference() {
+  local source="$1"
+  local reference="$2"
+  local resolved="${source%/*}/$reference"
+
+  if [[ ! -f "$resolved" ]]; then
+    printf 'missing relative reference in %s: %s\n' "$source" "$reference" >&2
+    missing=1
+  fi
+}
+
 if ! ruby quality/skills/metadata; then
   missing=1
 fi
@@ -262,6 +273,14 @@ require_pattern skills/references/gap-workflow.md "separate supported reproducti
 require_pattern skills/references/gap-workflow.md "supported-usage evidence, and a reproduction path"
 require_pattern skills/references/gap-workflow.md "without requiring migration"
 require_pattern skills/references/gap-workflow.md "Make every ledger entry understandable without opening source files"
+require_pattern skills/references/gap-workflow/find-audit.md "../gap-workflow.md"
+require_pattern skills/references/gap-workflow/find-audit.md "../gap-lead-generation.md"
+require_pattern skills/references/gap-workflow/implementation.md "../gap-workflow.md"
+require_pattern skills/references/gap-workflow/implementation.md "../long-running-work.md"
+require_reference skills/references/gap-workflow/find-audit.md "../gap-workflow.md"
+require_reference skills/references/gap-workflow/find-audit.md "../gap-lead-generation.md"
+require_reference skills/references/gap-workflow/implementation.md "../gap-workflow.md"
+require_reference skills/references/gap-workflow/implementation.md "../long-running-work.md"
 require_pattern skills/references/gap-workflow.md "gap-lead-generation.md"
 require_pattern skills/references/gap-workflow.md "lead inventory"
 require_pattern skills/references/gap-workflow.md "rejected, routed, deferred, and blocked lead"

--- a/skills/code-issues/SKILL.md
+++ b/skills/code-issues/SKILL.md
@@ -11,8 +11,11 @@ Use this skill in two distinct modes; do not combine them in one pass:
 - **Implement mode**: `Implement $code-issues in PACKAGE_OR_FOLDER` or `Implement code issues in PACKAGE_OR_FOLDER`.
 
 Before either mode, read `references/plan.md` and
-`../references/gap-workflow.md`; they own runtime state, ledger, delegation,
-scope, coverage, confidence, and approval gates.
+`../references/gap-workflow.md` and the mode-specific reference below own
+runtime state, ledger, delegation,
+scope, coverage, confidence, and approval gates. Before Find mode, also read
+`../references/gap-workflow/find-audit.md`; before Implement mode, also read
+`../references/gap-workflow/implementation.md`.
 
 ## Operating Stance
 
@@ -31,7 +34,7 @@ while prose disagrees, treat it as a documentation gap and update the docs.
 ## Find Mode
 
 Follow `references/plan.md#find-mode-plan` and the find/audit rules in
-`../references/gap-workflow.md`.
+`../references/gap-workflow/find-audit.md`.
 
 Read `references/find-rules.md`; those code-issue rules remain mandatory in
 Find mode.
@@ -53,7 +56,7 @@ entry warrants them.
 ## Implement Mode
 
 Follow `references/plan.md#implement-mode-plan` and the implementation rules in
-`../references/gap-workflow.md`.
+`../references/gap-workflow/implementation.md`.
 
 These code-issue implementation rules remain mandatory:
 
@@ -71,7 +74,9 @@ These code-issue implementation rules remain mandatory:
   recording candidates.
 - Read `references/ledger-format.md` before creating, updating, or interpreting
   `ISSUES.md`.
-- Read `../references/gap-workflow.md` for shared scoped-ledger, delegation, coverage, confidence, and approval gates.
+- Read `../references/gap-workflow.md` for shared scoped-ledger and delegation
+  gates; read `../references/gap-workflow/find-audit.md` for Find-mode rules and
+  `../references/gap-workflow/implementation.md` for Implement-mode rules.
 - Use `../references/decision-card.md` to present the agreement-gate proposal as a self-contained decision card.
 - Use `../references/gap-lead-generation.md` during Find mode to classify repo
   archetypes, generate high-risk leads, and account for rejected or routed

--- a/skills/doc-gaps/SKILL.md
+++ b/skills/doc-gaps/SKILL.md
@@ -11,8 +11,12 @@ Use one-pass mode by default; use audit-only mode only when explicitly asked:
 - **Audit-only mode**: `Audit-only $doc-gaps in PACKAGE_OR_FOLDER` or `Find doc gaps in PACKAGE_OR_FOLDER without editing`.
 
 Before either mode, read `references/plan.md` and
-`../references/gap-workflow.md`; they own runtime state, ledger, delegation,
-scope, coverage, confidence, and approval gates.
+`../references/gap-workflow.md` and the mode-specific reference below own
+runtime state, ledger, delegation,
+scope, coverage, confidence, and approval gates. Before one-pass or audit-only
+mode, also read `../references/gap-workflow/find-audit.md`.
+Before implementation of a scoped entry, also read
+`../references/gap-workflow/implementation.md`.
 
 ## Operating Stance
 
@@ -31,7 +35,7 @@ the repository implements.
 ## One-Pass Mode
 
 Follow `references/plan.md#one-pass-mode-plan` and the find/audit rules in
-`../references/gap-workflow.md`.
+`../references/gap-workflow/find-audit.md`.
 
 Read `references/one-pass-rules.md`; those doc-gap rules remain mandatory in
 one-pass mode. Before editing in one-pass mode, state the selected local
@@ -42,7 +46,7 @@ For unresolved-ledger fixes or any case where human approval is still required: 
 ## Audit-Only Mode
 
 Follow `references/plan.md#audit-only-mode-plan` and the find/audit rules in
-`../references/gap-workflow.md`.
+`../references/gap-workflow/find-audit.md`.
 
 Read `references/audit-rules.md`; those doc-gap rules remain mandatory in
 audit-only mode.
@@ -79,7 +83,9 @@ entry warrants them.
   recording candidates.
 - Read `references/ledger-format.md` before creating, updating, or interpreting
   `DOCS.md`.
-- Read `../references/gap-workflow.md` for shared scoped-ledger, delegation, coverage, confidence, and approval gates.
+- Read `../references/gap-workflow.md` for shared scoped-ledger and delegation
+  gates; read `../references/gap-workflow/find-audit.md` for one-pass/audit-only
+  rules and `../references/gap-workflow/implementation.md` for entry fixes.
 - Use `../references/decision-card.md` to present the agreement-gate proposal as a self-contained decision card for unresolved-ledger fixes.
 - Use `../references/gap-lead-generation.md` during one-pass and audit-only
   modes to classify repo archetypes, generate documentation leads, and account

--- a/skills/feature-gaps/SKILL.md
+++ b/skills/feature-gaps/SKILL.md
@@ -11,8 +11,11 @@ Use this skill in two distinct modes; do not combine them in one pass:
 - **Implement mode**: `Implement $feature-gaps in PACKAGE_OR_FOLDER` or `Implement feature gaps in PACKAGE_OR_FOLDER`.
 
 Before either mode, read `references/plan.md` and
-`../references/gap-workflow.md`; they own runtime state, ledger, delegation,
-scope, coverage, confidence, and approval gates.
+`../references/gap-workflow.md` and the mode-specific reference below own
+runtime state, ledger, delegation,
+scope, coverage, confidence, and approval gates. Before Find mode, also read
+`../references/gap-workflow/find-audit.md`; before Implement mode, also read
+`../references/gap-workflow/implementation.md`.
 
 ## Operating Stance
 
@@ -57,7 +60,7 @@ confidence or higher; otherwise gather more evidence or reject it.
 ## Find Mode
 
 Follow `references/plan.md#find-mode-plan` and the find/audit rules in
-`../references/gap-workflow.md`.
+`../references/gap-workflow/find-audit.md`.
 
 Read `references/find-rules.md`; those feature-gap rules remain mandatory in
 Find mode.
@@ -79,7 +82,7 @@ with `#### Proposal`, `**Keep.**`, `#### Alternatives Considered`, and
 ## Implement Mode
 
 Follow `references/plan.md#implement-mode-plan` and the implementation rules in
-`../references/gap-workflow.md`.
+`../references/gap-workflow/implementation.md`.
 
 ## Implementation Proposal Gate
 
@@ -144,7 +147,9 @@ These feature implementation rules remain mandatory:
   `FEATURES.md`.
 - Read `references/implementation-proposal.md` before asking for agreement to
   edit a feature.
-- Read `../references/gap-workflow.md` for shared scoped-ledger, delegation, coverage, confidence, and approval gates.
+- Read `../references/gap-workflow.md` for shared scoped-ledger and delegation
+  gates; read `../references/gap-workflow/find-audit.md` for Find-mode rules and
+  `../references/gap-workflow/implementation.md` for Implement-mode rules.
 - Use `../references/gap-lead-generation.md` during Find mode to classify repo
   archetypes, generate product-surface leads, and account for rejected or routed
   candidates.

--- a/skills/project-gaps/SKILL.md
+++ b/skills/project-gaps/SKILL.md
@@ -11,8 +11,11 @@ Use this skill in two distinct modes; do not combine them in one pass:
 - **Implement mode**: `Implement $project-gaps in PACKAGE_OR_FOLDER` or `Implement project gaps in PACKAGE_OR_FOLDER`.
 
 Before either mode, read `references/plan.md` and
-`../references/gap-workflow.md`; they own runtime state, ledger, delegation,
-scope, coverage, confidence, and approval gates.
+`../references/gap-workflow.md` and the mode-specific reference below own
+runtime state, ledger, delegation,
+scope, coverage, confidence, and approval gates. Before Find mode, also read
+`../references/gap-workflow/find-audit.md`; before Implement mode, also read
+`../references/gap-workflow/implementation.md`.
 
 ## Operating Stance
 
@@ -43,7 +46,7 @@ confidence or higher; otherwise gather more evidence or reject it.
 ## Find Mode
 
 Follow `references/plan.md#find-mode-plan` and the find/audit rules in
-`../references/gap-workflow.md`.
+`../references/gap-workflow/find-audit.md`.
 
 Read `references/find-rules.md`; those project-gap rules remain mandatory in
 Find mode.
@@ -70,7 +73,7 @@ and add `#### Situation Map`, `### Goals / Non-goals`, `### Open Questions`, and
 ## Implement Mode
 
 Follow `references/plan.md#implement-mode-plan` and the implementation rules in
-`../references/gap-workflow.md`.
+`../references/gap-workflow/implementation.md`.
 
 These project-gap implementation rules remain mandatory:
 
@@ -111,7 +114,9 @@ These project-gap implementation rules remain mandatory:
   candidate.
 - Read `references/ledger-format.md` before creating, updating, or interpreting
   `PROJECTS.md`.
-- Read `../references/gap-workflow.md` for shared scoped-ledger, delegation, coverage, confidence, and approval gates.
+- Read `../references/gap-workflow.md` for shared scoped-ledger and delegation
+  gates; read `../references/gap-workflow/find-audit.md` for Find-mode rules and
+  `../references/gap-workflow/implementation.md` for Implement-mode rules.
 - Use `../references/decision-card.md` to present the agreement-gate proposal as a self-contained decision card.
 - Use `../references/gap-lead-generation.md` during Find mode to classify repo
   archetypes, generate project-workflow leads, and account for rejected or

--- a/skills/references/gap-workflow.md
+++ b/skills/references/gap-workflow.md
@@ -9,568 +9,127 @@ These shared rules own workflow mechanics.
 - If no scope is provided, stop and ask for the package or folder.
 - Treat remembered commands as gap-workflow shorthand. `Start` begins the
   workflow, `Approved` accepts the presented solution, and `Done` confirms an
-  entry is verified; each takes the same optional tail (`in LEDGER_PATH` when
-  the ID is ambiguous, and `with agents`, `with a goal`, or
-  `with agents and a goal`):
-  - `Start ID` or `Start ID1/ID2 in LEDGER_PATH` selects the matching gap skill
-    from the ID prefix and enters implement mode for those IDs.
+  entry is verified. Each takes the optional tail `in LEDGER_PATH` when an ID
+  is ambiguous, and `with agents`, `with a goal`, or `with agents and a goal`:
+  - `Start ID` selects the matching gap skill and enters implement mode for the
+    entry. `Start ID1/ID2 in LEDGER_PATH` selects multiple entries.
   - `Start ID with agents` explicitly authorizes sub-agents for the current
     request.
-  - `Start ID with a goal` explicitly authorizes a runtime goal for the current
-    request when runtime goals are available and useful.
-  - `Start ID with agents and a goal` explicitly authorizes both sub-agents and
-    a runtime goal for the current request.
-  - `Approved ID` approves the presented solution for that entry and permits
-    implementation to continue under the selected skill.
-  - `Approved ID with agents` approves the presented solution and explicitly
-    authorizes sub-agents for the current implementation request. Use them for
-    disjoint implementation slices, validation support, or fresh review when
-    they materially improve throughput, coverage, confidence, or implementation
-    safety. The `with a goal` and `with agents and a goal` tails apply here too.
-  - `Done ID` confirms the entry is verified and complete; the selected skill
-    drops or revises that entry and continues with the next. Its tail
-    (`with agents`, `with a goal`, `with agents and a goal`) carries that
-    authorization forward to the next entry.
-  These shorthands do not bypass solution agreement, scoped ledger rules,
-  validation freshness, confidence thresholds, remote-write permission, or the
-  selected skill's output format.
-- Before starting a find, audit, one-pass, or implement mode, read the selected
-  skill's `references/plan.md` and maintain it as active runtime state. Do not
-  write the plan into the repository unless the human explicitly asks for a
-  durable plan file.
-- If the human asks for an explicit or broad no-finding confidence target, such as
-  "95% confidence", "99% closure", "max confidence", "full closure", "no
+  - `Start ID with a goal` explicitly authorizes a runtime goal when goals are
+    available and useful.
+  - `Start ID with agents and a goal` explicitly authorizes both.
+  - `Approved ID` approves the presented solution and permits implementation.
+    The `with agents`, `with a goal`, and `with agents and a goal` tails apply.
+  - `Done ID` confirms the entry is verified and complete. Its authorization
+    tail carries forward to the next entry.
+  These shorthands do not bypass solution agreement, scoped ledgers, validation
+  freshness, confidence thresholds, remote-write permission, or output format.
+- Before starting find, audit, one-pass, or implement mode, read the selected
+  skill's `references/plan.md` and keep it as runtime state. Do not write it to
+  the repository unless the human explicitly asks for a durable plan file.
+- If the human asks for an explicit or broad no-finding confidence target, such
+  as "95% confidence", "99% closure", "max confidence", "full closure", "no
   issues anywhere", or equivalent broad assurance, treat the run as a
-  **confidence closure audit**. A confidence closure audit is still the selected
-  skill's find/audit mode, but it may not close with a no-finding outcome until
-  the confidence closure requirements below are satisfied. Use the requested
-  percentage as the scope no-finding confidence threshold, subject to mandatory
-  repository confidence floors such as the 95% floor for broad no-finding claims.
-  When no explicit percentage is given, use the broad no-finding default threshold
-  of 95%. If the requested percentage is below the mandatory floor, apply the
-  mandatory floor and say the lower request cannot waive repository confidence
-  rules. Do not accept 100% as an achievable threshold for repository review; if
-  the human asks for 100% certainty, explain that the workflow can pursue a lower
-  explicit target or continue gathering evidence, but cannot truthfully close at
-  100%.
+  **confidence closure audit**. Use the requested percentage as the scope
+  no-finding confidence threshold, subject to mandatory repository confidence
+  floors such as the 95% floor for broad no-finding claims. When no explicit
+  percentage is given, use the broad no-finding default threshold of 95%. If the
+  requested percentage is below the mandatory floor, apply the mandatory floor
+  and say the lower request cannot waive repository confidence rules. Do not
+  accept 100% as an achievable threshold for repository review; if the human
+  asks for 100% certainty, explain that the workflow can pursue a lower explicit
+  target or continue gathering evidence, but cannot truthfully close at 100%.
 - Treat a confidence closure audit as **high-assurance closure** when the
   requested threshold is higher than the broad no-finding default threshold, or
   when the human asks for "max confidence", "full closure", "no issues
   anywhere", "no possible bugs", or equivalent broad assurance. High-assurance
   closure scales evidence to the requested threshold; do not hard-code one
   percentage as the only trigger for stronger review.
-- Distinguish scope no-finding confidence from a literal "no possible bugs"
-  claim. The selected skill can close only on no remaining reportable findings
-  in the requested scope under the skill's evidence rules. If the human asks
-  about no possible bugs anywhere, report that as a separate residual
-  correctness-risk statement with explicit limits; do not use a clean
-  confidence-closure outcome as proof that unexercised state space, unsupported
-  construction, environment-specific behavior, or future dependency behavior is
-  bug-free.
-- Use runtime goals only when the human explicitly requests them or
-  higher-priority runtime instructions allow goal creation for this workflow.
-  Otherwise maintain the selected mode, requested scope, and state transitions
-  in the conversation or tool plan without creating a runtime goal.
-- For substantial, ambiguous, or multi-iteration implementation work, read
-  `long-running-work.md` before proposing or implementing the first slice, and
-  keep its progress artifact as runtime state only.
-  Do not write progress files, design docs, or orchestration artifacts into the
-  repository unless the human explicitly asks for a durable file.
-- Do not combine find and implement modes in one pass unless the selected skill
-  explicitly defines a one-pass mode.
-- Preserve stop gates as plan boundaries. Do not continue past a stop gate based
-  on silence or a broad request.
-- Treat validation as stale when files change after a command ran.
+- Distinguish scope no-finding confidence from a literal no-possible-bugs
+  claim. Close only on reportable findings under the selected skill's evidence
+  rules and state residual risks from unsupported paths, environments, future
+  dependencies, or unexercised state space.
+- Use runtime goals only when the human explicitly requests them or higher
+  priority runtime instructions allow them. Otherwise use conversation or the
+  tool plan for state.
+- For substantial, ambiguous, or multi-iteration work, read
+  `long-running-work.md` before the first slice and keep its progress artifact
+  in runtime state only. Do not combine find and implement modes unless the
+  selected skill defines a one-pass mode. Preserve stop gates as boundaries.
+- Treat validation as stale when files change after a command runs.
 
 ## Common Plan Mechanics
 
 Use these mechanics with the selected skill's `references/plan.md`. The plan
 names the domain-specific inventory surfaces, candidate tests, closeout
 questions, ledger filename, ID prefix, and implementation pairings.
+
+## Mode-Specific References
+
+- Before Find, one-pass, or audit-only work, also read
+  `gap-workflow/find-audit.md`. It owns inventory, validation, candidate
+  handling, coverage accounting, and closeout outcomes.
+- Before Implement work, also read `gap-workflow/implementation.md`. It owns
+  ledger re-checks, agreement gates, implementation sequencing, and fresh
+  review.
+
 Use `gap-lead-generation.md` during find, audit-only, and one-pass modes to
 classify repository archetypes, build a lead inventory, use comparable
 repositories or framework checklists when useful, and account for confirmed,
 rejected, routed, deferred, and blocked leads.
 
-For find, audit-only, and one-pass modes:
-
-1. Confirm the requested package or folder scope.
-2. Check the selected skill's scoped ledger policy. For normal find/audit modes,
-   stop if an existing scoped ledger blocks review. For one-pass modes that
-   allow reading a ledger, incorporate matching ledger entries and stop on
-   unrelated or ambiguous active work.
-3. Run `$project-workflow` discovery for entrypoints, CI, documented commands,
-   relevant public surfaces, and `./bin` wiring.
-4. Build a recursive inventory using the selected plan's domain-specific
-   surfaces and `gap-lead-generation.md` archetypes, then split it into bounded
-   review slices. Use depth only as a discovery aid, not as the review boundary.
-5. For broad scopes, choose highest-risk or highest-value slices first and
-   record `deep`, `skimmed`, `excluded`, and `deferred` coverage with exact
-   follow-up scopes. For confidence closure audits, every relevant slice must
-   route to `deep` or `excluded`; unfinished relevant slices keep the outcome
-   incomplete.
-6. Ask for required permission before a local reviewer or authorized agent runs
-   non-read-only, network, auth, remote-write, destructive, or otherwise
-   approval-gated commands.
-7. Apply the shared gap-workflow delegation gate before review work.
-8. Wait for review work to finish, update coverage for every planned slice, and
-   deduplicate or directly re-check conflicting candidates.
-9. Classify validation outcomes as repository finding, local environment issue,
-   missing tool, or inconclusive; use `finding-severity.md` for
-   confidence evidence. For confidence closure audits, include current CI or
-   equivalent repository-defined validation evidence before no-finding
-   closeout.
-10. If no confirmed entries remain, report the coverage state, do not create a
-    scoped ledger, and stop unless the selected one-pass mode has completed
-    edits. If coverage is incomplete, report the incomplete audit state and do
-    not present the requested scope as complete.
-11. If confirmed entries remain in find/audit modes, write the selected scoped
-    ledger with that skill's ID prefix, present the ledger and coverage state,
-    name runnable follow-up scopes, and stop before making fixes.
-
-For implement modes:
-
-1. Confirm scope and read the selected scoped ledger, or stop and ask whether to
-   run the matching find mode first.
-2. Run `$project-workflow` discovery for current entrypoints, CI, documented
-   commands, relevant public surfaces, and `./bin` wiring.
-3. Select the named entry ID or the next entry, then re-check the evidence
-   against current code, docs, tests, commands, and relevant generated or
-   workflow surfaces.
-4. If the entry is already resolved, stale, duplicated, outside scope, or owned
-   by another workflow, explain the routing and propose removing, moving, or
-   reclassifying it before editing.
-5. Present the current evidence, proposed solution, tradeoffs, and intended
-   validation as a decision card (see `../references/decision-card.md`) so the
-   human can agree, reject, or revise quickly. The card must restate enough
-   `What`, `Why`, and `How` to stand on its own; understanding the decision must
-   not depend on opening the ledger or source files. Stop until the human
-   explicitly agrees to that solution. A named fix, implement, or verify request
-   selects the entry and permits evidence refresh, but it is not approval to edit
-   unless it also agrees to the proposed solution. This remains true when the
-   request says "implement", names multiple related IDs, or authorizes agents.
-6. After agreement, state the local pattern, dominant relevant harness or
-   validation path, planned validation, and any needed deviation. Stop before
-   deviating from the selected skill, repository pattern, or documented
-   workflow.
-7. Implement only the agreed entry with the smallest clear change, using the
-   paired standards and validation skills named by the selected plan.
-8. Validate through repository Make targets or documented entrypoints, then ask
-   the human to verify with the selected `Done ID-<number>` phrase.
-9. Stop until confirmation. After confirmation, remove or revise the entry and
-   continue with the next entry, or delete the scoped ledger when all entries
-   are confirmed resolved.
-
 ## Scoped Ledgers
 
 - Before creating or updating a scoped ledger, ensure the consuming repository
   root `.gitignore` exists and contains that ledger filename as a standalone
-  pattern. If the pattern is missing, add it.
-- Checking whether a scoped ledger exists or reading an existing scoped ledger
-  must not modify `.gitignore`.
+  pattern. Checking or reading an existing ledger must not modify `.gitignore`.
 - Use the selected skill's ledger filename in the requested package or folder,
-  such as `PACKAGE_OR_FOLDER/ISSUES.md`, `TESTS.md`, `DOCS.md`,
-  `FEATURES.md`, `PROJECTS.md`, or `RELIABILITY.md`.
-- In find or audit-only modes, if the scoped ledger already exists, stop unless
-  the selected skill explicitly allows reading or refreshing that ledger.
-- In implement mode, read the scoped ledger first and treat it as the working
-  ledger. If it does not exist, stop and ask whether to run the matching find
-  mode first for that scope.
-- Read existing entries written in the previous `Context` / `Evidence` /
-  `Proposal` mini-RFC shape without requiring migration. Rewrite an entry to the
-  current `What` / `Why` / `How` shape only when creating or otherwise updating
-  that entry.
-- Record durable findings or proposals only in the scoped ledger defined by the
-  selected skill.
-- Assign IDs using the selected skill's prefix, such as `ISSUE-N`, `TEST-N`,
-  `DOC-N`, `FEATURE-N`, `PROJECT-N`, or `REL-N`.
+  such as `PACKAGE_OR_FOLDER/ISSUES.md`, `TESTS.md`, `DOCS.md`, `FEATURES.md`,
+  `PROJECTS.md`, or `RELIABILITY.md`.
+- In find or audit-only modes, stop when an existing scoped ledger blocks review
+  unless the selected skill explicitly allows reading or refreshing it. In
+  implement mode, read it first; if it does not exist, ask whether to run find
+  mode first.
+- Read entries in the previous `Context` / `Evidence` / `Proposal` shape
+  without requiring migration. Rewrite them to the current `What` / `Why` /
+  `How` shape only when creating or updating that entry.
+- Record durable findings or proposals only in the selected scoped ledger and
+  assign IDs using its prefix, such as `ISSUE-N`, `TEST-N`, `DOC-N`,
+  `FEATURE-N`, `PROJECT-N`, or `REL-N`.
 
 ## Delegation And Permissions
 
 - Use sub-agents only when the active runtime provides them and the current user
   request explicitly asks for sub-agents, delegation, or parallel agent work.
-- When sub-agents are authorized, use them for any skill combination when they
-  materially improve coverage, confidence, throughput, independent validation,
-  forward-testing, or disjoint implementation, or when they are required by the
-  selected skill.
+- When sub-agents are authorized, use them for disjoint implementation,
+  independent validation, forward-testing, or fresh review when they
+  materially improve coverage, confidence, throughput, or implementation safety,
+  or when the selected skill requires them.
 - If the current request does not authorize sub-agents, perform local review
   only when the selected skill does not require delegation and the requested
-  review can still reach the required evidence and confidence threshold without
-  it. If credible completion depends on delegation, stop at the delegation gate
-  and ask for explicit current-request sub-agent authorization.
-- If sub-agents are authorized but unavailable, forbidden, or denied by the
+  review can still reach its evidence and confidence threshold. If credible
+  completion depends on delegation, stop and ask for explicit current-request
+  sub-agent authorization. This is the current-request sub-agent authorization
+  gate; do not infer it from a remembered command or a prior turn.
+- If authorized sub-agents are unavailable, forbidden, or denied by the
   runtime, perform local review only when the selected skill does not require
-  delegation and the requested review can still reach the required evidence and
-  confidence threshold without it. If credible completion depends on
-  delegation, stop at the delegation gate and state the blocked delegation
-  requirement plus runtime limitation.
+  delegation and confidence can still be reached. Otherwise state the blocked
+  delegation requirement plus runtime limitation.
 - Do not silently downgrade to local-only review or present a single-agent
   substitute as equivalent.
-- Ask for human permission before a local reviewer or authorized agent runs
-  commands that require approval, such as network, SSH, GitHub auth, registry
-  auth, cloning, destructive operations, remote writes, or non-read-only
-  validation.
+- Ask for permission before local reviewers or authorized agents run network,
+  auth, SSH, registry, cloning, destructive, remote-write, or non-read-only
+  validation commands.
 
-## Scope Inventory And Slicing
+## Candidate Integrity
 
-- Exclude generated files and folders, vendored dependencies, caches, build
-  output, generated API docs, and generated lockfile churn unless the requested
-  scope is explicitly about them.
-- In downstream repositories that vendor this project as `./bin`, treat
-  `bin/**` as vendored shared tooling unless the requested scope is explicitly
-  about shared `bin` tooling, Makefile includes, skills, or submodule wiring.
-  Exclude `bin/**` from recursive review and inventory by default; inspect only
-  included `bin/build/make/*.mak` fragments or selected `bin/skills/**`
-  guidance needed as evidence. Route upstream-only shared-tooling findings to a
-  separate `bin`-scoped run instead of writing them into the consuming
-  repository's scoped ledger.
-- Before assigning review agents or starting local review, build a recursive
-  scope inventory for the requested package or folder. Include relevant file
-  count, first-level subfolders, nested packages, dominant languages, public
-  entrypoints, generated/vendor/build/cache exclusions, docs, examples, tests,
-  validation entrypoints, and the selected skill's domain-specific surfaces.
-- When the requested scope has repository-defined package, module, component,
-  command, service, or area discovery, record coverage accounting from that
-  discovery path: count or inventory summary; excluded paths such as `bin/**`,
-  vendored dependencies, generated folders, caches, build output, and
-  explicitly out-of-scope subtrees; major reviewed groups named in the
-  repository's own terminology; and any slices intentionally skipped with the
-  concrete reason.
-- Do not assign broad recursive subtrees merely because they are first-level
-  subfolders. When a subtree contains many independent owners, workflows,
-  responsibilities, packages, products, or audiences, split it into smaller
-  behavior-owned, documentation-owned, workflow-owned, or audience-owned slices.
-- Use depth only as a discovery aid, not as the review boundary.
-- If the requested scope is too broad to review credibly in one pass, review
-  the highest-risk or highest-value slices first and record explicit coverage:
-  reviewed deeply, skimmed, excluded, and deferred.
-- Do not present a broad requested scope as fully reviewed when any relevant
-  slice was only skimmed or deferred. Name those slices in the final coverage
-  notes and provide runnable follow-up scopes for deferred review.
-- For confidence closure audits, plan the inventory so every relevant slice has a
-  route to `deep` or `excluded`. Do not intentionally leave relevant slices as
-  `skimmed` or `deferred` at closeout. If the scope is too large to finish in
-  the current run, keep the outcome incomplete and name the exact remaining
-  slices instead of lowering the standard.
-
-## Audit Preflight And Validation Ladder
-
-- Before a long find or audit pass, run a tool and environment preflight through
-  `$project-workflow` and `$change-validation`: repository root, documented
-  entrypoints, CI analogue, initialized user shell, and applicable tool
-  availability or version checks. For toolchain-heavy audits, check required
-  language runtimes, analyzers, linters, schema or generation tools, security
-  scanners, sidecars, and service dependencies only when the repository's Make
-  targets, CI, scripts, or tests actually require them.
-- Preflight is evidence planning, not a reason to bypass repository Make
-  targets. Prefer the repository-defined target that owns each tool or service.
-- Run checks normally first. If a failure is clearly sandbox, cache-permission,
-  localhost listener, network, credential, service-dependency, or user-shell
-  environment related, retry only through the runtime's approved escalation or
-  initialized-shell path.
-- After a repository-defined command, Make target, dominant test harness, or
-  skill-required workflow fails, do not switch to an ad hoc command, different
-  validation layer, or alternate workflow merely to make progress. First
-  classify the failure using the validation categories below; then retry only
-  through the initialized-shell or approved escalation path, or report the
-  blocker.
-- Classify every failed or skipped validation command as exactly one of:
-  repository finding, local environment issue, missing tool, or inconclusive.
-  Do not treat a target failure in the sandbox as a repository finding unless
-  repository-owned code, config, or workflow evidence proves it.
-- Do not lower confidence for a sandbox-only failure when the same command
-  passes through an approved outside-sandbox or initialized-shell path on the
-  same file state. Do lower or cap confidence when validation remains blocked,
-  missing, no-op, or inconclusive.
-- Preserve analyzer nuance in audit notes when relevant: analyzers may no-op or
-  report no matched packages, modules, files, or components in a restricted
-  sandbox or stale tool context; integration tests may need localhost listener
-  permissions or service dependencies; dependency, security, or generation
-  tools may need network access or cache writes outside the workspace; and a
-  target failing in the sandbox is not automatically a repository finding.
-- Prefer fast, reproducible local evidence before relying on broad CI. For
-  changed or suspect executable behavior, use the narrowest supported
-  repository-defined command or dominant-harness selector that exercises the
-  affected package, file, command, scenario, example, or test name. Broaden to
-  suite, lint, security, or CI-equivalent checks only when the change crosses
-  boundaries, affects shared infrastructure, or needs higher confidence.
-- CI can raise confidence only when the relevant current run or equivalent
-  repository-defined local command is observed and classified. The fact that CI
-  exists or will run later is not reproduction evidence for a ledger finding.
-- For confidence closure audits, collect current validation evidence from the
-  repository-owned CI analogue before any no-finding closeout. Prefer the latest
-  successful CI result for the exact commit when it is available; otherwise run
-  or explicitly classify the repository-defined equivalent targets. The mere
-  existence of CI is not validation evidence.
-- For high-assurance closure, add evidence planning before closeout. Identify
-  which bug classes are materially relevant to the requested scope and what
-  current evidence exercises them, such as parser/decoder fuzzing or property
-  tests, serialization round trips, boundary/default fixtures, race or stress
-  tests for concurrent state, lifecycle start/stop repetition, dependency
-  outage or fault-injection scenarios, generated-contract freshness checks,
-  security scanners, and integration tests with required sidecars. Missing
-  evidence is not itself a finding unless the selected skill says so, but it
-  must appear as a confidence limiter or be routed to the appropriate workflow
-  such as `$test-gaps` or `$project-gaps`.
-
-## Candidate Handling
-
-- For delegated review, require each assigned agent to return confirmed
-  candidates in the selected skill's ledger format, without final IDs unless
-  useful locally. Also require rejected leads with rejection reasons, risky
-  files or surfaces that still deserve review, and exact follow-up scopes. A
-  delegated "nothing found" response without coverage, rejected-lead, and
-  follow-up-scope evidence is not enough to close a broad audit slice.
-- For confidence closure audits over broad repository, package-tree, or
-  multi-component scopes, use independent delegated review when the runtime
-  provides agents and the current request authorizes them. Assign disjoint
-  behavior-owned or risk-owned slices, require each agent to report coverage,
-  rejected leads, validation, and follow-up scopes, and perform a final local
-  challenge pass across the combined result. If agents are unavailable or not
-  authorized and delegation is needed for credible closure, stop at the
-  delegation gate or report the blocked requirement instead of presenting a
-  confidence closure result.
-- For high-assurance closure with authorized agents, assign at least one
-  adversarial reviewer when practical. That reviewer should try to falsify the
-  no-finding conclusion, look for unsupported confidence leaps, unreviewed bug
-  classes, missing supported-usage evidence, and unresolved counterexamples.
-  Resolve the adversarial review explicitly before closeout. Do not pass
-  intended conclusions, rejected-lead rationale, or proposed confidence numbers
-  to the adversarial reviewer unless the validation task specifically requires
-  that context.
-- Use `../references/finding-severity.md` to discard low-confidence candidates
-  before assigning severity or confidence when the selected skill records
-  findings.
-- Before deep review, create a lead inventory for each planned slice using the
-  selected skill's plan and `gap-lead-generation.md`. Lead inventory is a recall
-  tool only: it does not lower the selected skill's confidence, ownership,
-  reproduction, validation, or approval gates.
-- Treat comparable repository and external-framework evidence as lead
-  generation only. Before recording a candidate derived from GitHub owner
-  inventory, local checkout mapping, sibling repositories, or external
-  frameworks, reproduce the current repository-owned limitation through the
-  selected skill's normal evidence path.
-- Before recording a candidate, run an existing-surface challenge. List the
-  authoritative repository surfaces that could already satisfy the proposed
-  need, such as public APIs, commands, endpoints, generated contracts, runtime
-  health or metrics, shared helpers, framework behavior, configuration
-  defaults, docs, examples, tests, and supported consumer workflows. Reject or
-  route the candidate when the correct surface already covers the workflow.
-- For candidates that survive the existing-surface challenge, state the
-  residual gap: "Even with <existing surface>, the audience still cannot
-  <specific supported action/outcome>." If that sentence is weak, vague, or
-  mostly describes optional convenience, keep the lead below the selected
-  skill's ledger threshold and report it as rejected, routed, or deferred.
-- Confirm each candidate against current code, docs, examples, tests, command
-  behavior, CI config, generated contracts, and public interfaces relevant to
-  the selected skill before recording, fixing, or dismissing it.
 - Reproduce each candidate before recording it as a confirmed ledger entry or
-  presenting it as a proposed finding. Use the smallest supported path that
-  demonstrates the issue or gap: a repository command, test, fixture, API call,
-  documented workflow, config path, command help lookup, reader action, CI path,
-  code-path trace, or negative search across the authoritative surface. For
-  absence-based gaps, reproduce the limitation by showing the supported user,
-  maintainer, or operator action that currently fails, is unsupported, or cannot
-  be completed from the existing surface.
-- When an executable command can demonstrate the candidate through the dominant
-  harness or repository entrypoint, prefer that command over a static trace.
-  Use a non-executable trace, lookup, or negative search only for documentary,
-  structural, unsupported-mode, or absence-based candidates where no supported
-  command can demonstrate the gap.
-- Record the reproduction path in the candidate and ledger entry. The path must
-  name what was run or inspected, the observed result, and why that result
-  demonstrates the repository-owned issue, gap, or limitation. A reproduction
-  path can be non-executable only when the selected skill's surface is
-  inherently documentary or structural; in that case, record the exact lookup,
-  trace, negative search, or authoritative surface comparison that reproduces
-  the gap.
-- Make every ledger entry understandable without opening source files. State a
-  plain-language claim and observed result before its source locator. Prefer a
-  stable symbol, command, target, test, scenario, config key, API, or heading;
-  use a line number only as an optional locator. Include a short relevant excerpt
-  or observed output when the reader would otherwise need to infer the claim
-  from source.
+  presenting it as a proposed finding. Use the smallest supported path. Record the reproduction path in the candidate and ledger entry.
+- For reusable libraries, helpers, or shared tooling, high-confidence review
+  requires current code evidence, supported-usage evidence, and a reproduction path.
+  Package-local fakes, synthetic tests, manual construction, and unsupported
+  downstream patterns remain leads only.
 - If reproduction is blocked by sandbox limits, missing tools, credentials,
-  network, optional services, or ambiguous setup, classify the blocker through
-  `$change-validation` and do not record the candidate as confirmed unless a
-  separate supported reproduction path proves it. Report the evidence gap or
-  deferred follow-up instead of raising confidence to the ledger threshold.
-- A suggested validation command is not itself reproduction. Before recording a
-  ledger entry, either run or inspect the smallest supported reproducer and
-  record the observed result, or keep the candidate below the confidence
-  threshold with the blocker named.
-- For reusable library, helper, or shared-tooling scopes, inspect supported
-  usage evidence before recording or accepting a high-confidence issue, gap, or
-  proposal: a real consumer, executable example, integration test, module wiring
-  path, documented contract, CI workflow, or comparable usage path that can
-  trigger the candidate or show the audience/action at risk. Treat package-local
-  fakes, synthetic tests, manual construction, and unsupported downstream
-  patterns as leads only.
-- When a candidate points to a third-party dependency, framework, tool, image,
-  or project-owned upstream library defect, separate the defect from the
-  repository-owned response before recording it. Record a scoped finding or
-  proposal only when the selected scope owns the adapter behavior, dependency
-  upgrade, pin, replacement, workaround, validation coverage, upstream issue
-  tracking, or other project workflow response. If another project-owned
-  library owns the broken behavior, route the candidate to that library's agent
-  or ledger and keep the current scope only as supported usage evidence.
-- When prose, comments, examples, or docs contradict implementation, require
-  non-prose evidence before treating implementation as wrong or routing the
-  candidate to code, security, reliability, or test workflows. If current code,
-  tests, runtime behavior, generated contracts, CI, or history support the
-  implementation, route stale prose to `$doc-gaps`.
-- Dismiss candidates already covered by the correct authoritative surface,
-  below the selected skill's threshold, duplicative, out of scope, or owned by a
-  different workflow. When useful, state the authoritative surface or workflow
-  that owns the concern.
-- Treat optional follow-ups, speculative improvements, and leads that need
-  production evidence or a separate product/security/reliability design as
-  closeout notes only. Do not create a scoped ledger solely to store optional
-  follow-ups when no confirmed entries survive the selected skill's evidence
-  gate.
-- For local review as well as delegated review, preserve rejected, routed,
-  deferred, and blocked lead notes. A quiet audit without these notes is not
-  enough evidence for broad no-finding confidence.
-
-## Find And Audit Outcomes
-
-- Use exactly one of these outcomes for find or audit closeout:
-  `Findings recorded`; `No findings and validation clean`;
-  `No findings, but validation incomplete because X`; or
-  `Audit incomplete: no confirmed findings so far`.
-- Distinguish finding confidence from audit completion confidence:
-  `Finding confidence` is confidence that each recorded finding is real and
-  repository-owned; `Coverage confidence` is confidence that reviewed slices
-  were checked adequately; `Scope no-finding confidence` is confidence that no
-  reportable finding remains in the requested scope. Broad no-finding closeouts
-  must report all three values, using `n/a` for finding confidence when no
-  findings were recorded.
-- For broad repository, package-tree, or multi-component scopes, do not use
-  `No findings and validation clean` or `No findings, but validation incomplete
-  because X` unless scope no-finding confidence is at least 95% and every
-  relevant planned slice is deep-reviewed or explicitly excluded. If any
-  relevant slice is skimmed, deferred, or blocked, the final outcome must be
-  `Audit incomplete: no confirmed findings so far`.
-- For confidence closure audits, do not use any no-finding closeout until all of
-  these are true:
-  - every relevant slice is `deep` or `excluded`;
-  - current CI or equivalent repository-defined validation evidence is clean, or
-    any unavailable check is classified and does not weaken the audited claim;
-  - every delegated slice result has coverage, rejected-lead, validation, and
-    follow-up-scope evidence;
-  - all candidates have been reproduced and either recorded, rejected, or routed
-    to the correct workflow;
-  - a final challenge pass names the strongest remaining counterexamples and
-    explains why they do not drop scope no-finding confidence below the requested
-    confidence threshold.
-- For high-assurance closure, do not use any no-finding closeout until an
-  assurance matrix or equivalent compact accounting names the materially
-  relevant bug classes, current evidence, missing assurance, and any confidence
-  cap. If missing fuzz, race, stress, property, sidecar, scanner, or integration
-  evidence would make the requested confidence misleading, lower the confidence
-  or close with incomplete validation instead of stretching the number.
-- If no findings survive in reviewed slices but deferred slices remain,
-  continue to the next highest-risk deferred slice when the turn, tools, and
-  permissions allow. Do not stop merely because the first reviewed slices
-  produced no ledger entries.
-- For broad scopes, include a durable coverage table before any no-finding or
-  incomplete closeout:
-
-  ```markdown
-  | Slice | Status | Evidence | Validation | Confidence | Next scope |
-  | --- | --- | --- | --- | --- | --- |
-  ```
-
-  `Status` must be one of `deep`, `skimmed`, `deferred`, `blocked`, or
-  `excluded`. `Next scope` must be an exact runnable package, folder, command,
-  or explicit `n/a`.
-- For high-assurance closure, include or summarize this assurance accounting:
-
-  ```markdown
-  | Bug Class | Relevant Surface | Evidence | Missing Assurance | Confidence Cap |
-  | --- | --- | --- | --- | --- |
-  ```
-
-  Keep it compact. Use `n/a` only when the bug class is not materially relevant
-  to the requested scope, and say why in the evidence cell.
-- If no confirmed gaps or proposals remain and the requested scope satisfies the
-  selected outcome's confidence and coverage requirements, report that result
-  with a no-finding closeout and do not create a scoped ledger. The closeout
-  must include reviewed files or slices; package count or inventory summary
-  when applicable; supported usage, call sites, commands, tests, or CI evidence
-  checked; validation commands and their classified results; excluded or
-  deferred files; rejected, routed, deferred, and blocked lead accounting;
-  repository policy exclusions or suppressions applied; the confidence fields
-  above; and the remaining limits on that confidence. Do not present "nothing
-  found" as a broad assurance without this evidence.
-- If confirmed gaps or proposals remain, write them to the scoped ledger before
-  making changes unless the selected skill explicitly defines a one-pass fix
-  mode. Record only high-confidence, actionable findings with file/line,
-  command, config, runtime, supported-usage evidence, and a reproduction path.
-  Do not record speculative exclusions, unsupported paths, unreproduced
-  candidates, or examples already ruled out by `AGENTS.md` or the selected
-  skill.
-- Stop after presenting the ledger and plan in find/audit modes when the
-  selected skill requires a separate implementation pass.
-
-## Implementation Gates
-
-- Work through scoped ledger entries sequentially by ID unless the human
-  explicitly names a different entry.
-- Before proposing a fix for each entry, re-check current code, docs, tests,
-  config, CI, command behavior, and nearby patterns. Treat ledgers as stale:
-  dismiss or revise entries that are already addressed, duplicated, invalid, or
-  owned by another workflow.
-- Stop after proposing a solution. Do not edit files, update the scoped ledger,
-  or start validation until the human explicitly agrees to that entry's
-  solution.
-- A request that names an entry and asks to fix, implement, or verify it is
-  permission to select that entry, re-check current evidence, and present or
-  refresh the proposal. It is not approval to edit unless the request also
-  explicitly agrees to the proposed solution. When the request names multiple
-  related entries, present the combined or per-entry solution and stop before
-  editing the first entry.
-- Ask questions when behavior, compatibility, documentation location, test
-  layer, implementation home, validation, operator workflow, or user intent is
-  ambiguous enough that a correct change cannot be inferred from local context.
-- After the human agrees and before editing, state the selected local pattern,
-  dominant relevant test harness or validation path, planned validation command,
-  and any deviation from `AGENTS.md` or selected skills. If a deviation is
-  needed, stop and ask before editing.
-- When the execution checklist includes `Expected red`, confirm the dominant
-  harness can actually execute before behavior-changing edits, then paste the
-  observed red (exact command + failing output) before making implementation
-  edits; the reported `Green` MUST be that same command passing. If the harness
-  is not runnable, STOP: make it runnable and observe the red, or explicitly
-  request agreement to proceed test-after with the reason. Silent test-after and
-  reporting a red/green cycle without pasted command output are prohibited.
-- For substantial, ambiguous, or multi-iteration implementation work, use
-  `long-running-work.md` after the agreement gate. Confirm the reference was
-  read for the current task, maintain the progress artifact in runtime state,
-  ask only blocking questions after research, and work in thin validated
-  slices. This does not authorize combining find and implement modes or editing
-  outside the agreed entry.
-- When the current implementation request authorizes agents, use sub-agents for
-  disjoint slices, validation support, or fresh review when they can materially
-  improve throughput, coverage, confidence, or implementation safety. Keep one
-  active ledger entry owner and do not let parallel work bypass the selected
-  skill's validation, review, or human confirmation gates.
-- Implement only the agreed entry with the smallest clear change using existing
-  local patterns.
-- Before accepting substantial implementation work as complete, apply the fresh
-  review gate from `long-running-work.md`. Use an independent reviewer when
-  sub-agents are explicitly authorized and available; otherwise perform a named
-  local challenge pass and do not present it as equivalent to independent
-  review. If agents were authorized and available but this independent review
-  did not run, do not report the implementation complete at or above 90%
-  confidence.
-- During automatic continuations while waiting for approval or a `Done ID`
-  confirmation, do not repeat the full proposal or result. State the
-  current waiting gate once, concisely.
-- Do not move to the next entry until the human confirms the current entry with
-  `Done ID`.
-- After the human confirms an entry with `Done ID`, remove or revise that entry
-  in the scoped ledger. If an entry is deemed invalid, remove it only after
-  explaining why and getting human agreement.
-- Once all entries are resolved and confirmed done by the human, delete the
-  scoped ledger.
+  network, optional services, or ambiguous setup, do not record the candidate as confirmed unless a separate supported reproduction path proves it.
+- Make every ledger entry understandable without opening source files. State
+  the plain-language claim and observed result before the source locator.

--- a/skills/references/gap-workflow/find-audit.md
+++ b/skills/references/gap-workflow/find-audit.md
@@ -1,0 +1,222 @@
+# Gap Workflow: Find And Audit
+
+Read `../gap-workflow.md` first. This reference contains mechanics that apply only
+while finding, auditing, or running a skill's one-pass mode.
+
+## Review Mechanics
+
+For find, audit-only, and one-pass modes:
+
+1. Confirm the requested package or folder scope.
+2. Check the selected skill's scoped-ledger policy. In normal find/audit modes,
+   stop if an existing scoped ledger blocks review. In one-pass modes that
+   allow reading a ledger, incorporate matching entries and stop on unrelated
+   or ambiguous active work.
+3. Run `$project-workflow` discovery for entrypoints, CI, documented commands,
+   relevant public surfaces, and `./bin` wiring.
+4. Use the selected plan and `../gap-lead-generation.md` to build a recursive
+   inventory and bounded review slices. Use depth only as a discovery aid, not
+   as the review boundary.
+5. For broad scopes, prioritize high-risk or high-value slices and record
+   `deep`, `skimmed`, `excluded`, and `deferred` coverage with exact follow-up
+   scopes. A confidence closure audit may close only when every relevant slice
+   is `deep` or `excluded`.
+6. Ask permission before local reviewers or authorized agents run non-read-only,
+   network, auth, remote-write, destructive, or otherwise approval-gated
+   commands.
+7. Apply the shared gap-workflow delegation gate before review work.
+8. Wait for review work, update coverage for every slice, and deduplicate or
+   directly re-check conflicting candidates.
+9. Classify validation as a repository finding, local environment issue,
+   missing tool, or inconclusive result. For confidence closure, include
+   current CI or equivalent repository-defined validation evidence before
+   closing with no findings.
+
+## Scope Inventory And Slicing
+
+- Exclude generated files and folders, vendored dependencies, caches, build
+  output, generated API docs, and generated lockfile churn unless explicitly in
+  scope.
+- In downstream repositories that vendor this project as `./bin`, exclude
+  `bin/**` from recursive review by default. Inspect only included
+  `bin/build/make/*.mak` fragments or selected `bin/skills/**` guidance needed
+  as evidence, and route upstream-only findings to a separate bin-scoped run.
+- Inventory relevant file counts, first-level folders, nested packages,
+  languages, public entrypoints, generated/vendor/build/cache exclusions, docs,
+  examples, tests, validation entrypoints, and domain-specific surfaces.
+- When the repository has package, module, component, command, service, or
+  area discovery, account for its major groups and explicitly named excluded or
+  skipped slices.
+- Do not assign broad recursive subtrees merely because they are first-level
+  folders. Split independent owners, workflows, responsibilities, packages,
+  products, or audiences into behavior-, documentation-, workflow-, or
+  audience-owned slices.
+- Do not present a broad scope as fully reviewed while a relevant slice is only
+  skimmed, deferred, or blocked. Name the exact follow-up scope. Confidence
+  closure requires every relevant slice to be deep-reviewed or explicitly
+  excluded.
+
+## Audit Preflight And Validation Ladder
+
+- Before a long audit, run tool and environment preflight through
+  `$project-workflow` and `$change-validation`: repository root, documented
+  entrypoints, CI analogue, initialized user shell, and applicable tool
+  availability. Check runtimes, analyzers, linters, scanners, generation tools,
+  sidecars, or services only when repository workflow needs them.
+- Preflight plans evidence; it does not replace repository Make targets. Run
+  checks normally first. If a failure is clearly sandbox, cache-permission,
+  localhost, network, credential, service, or shell-environment related, retry
+  only through the approved escalation or initialized-shell path.
+- After a repository-defined command, Make target, dominant harness, or
+  skill-required workflow fails, classify it before considering any retry. Do
+  not switch to an ad hoc command, validation layer, or alternate workflow just
+  to obtain a result.
+- Classify every failure or skip as exactly one of: repository finding, local
+  environment issue, missing tool, or inconclusive. A sandbox failure is not a
+  repository finding without repository-owned code, config, or workflow
+  evidence.
+- Preserve analyzer nuance: a tool may no-op for missing packages, modules,
+  files, or components; integration checks may need listeners or services; and
+  dependency, security, or generation checks may need network or cache writes.
+- Prefer fast, reproducible local evidence from the smallest supported command
+  or dominant harness. Broaden to suite, lint, security, or CI-equivalent
+  checks when the scope crosses boundaries, affects shared infrastructure, or
+  needs higher confidence.
+- CI raises confidence only when a current run or equivalent repository-defined
+  command is observed and classified. Its existence or a future run is not
+  reproduction evidence. Confidence closure requires current CI or an
+  equivalent clean validation, with unavailable checks explicitly classified.
+- For high-assurance closure, account for relevant bug classes and missing
+  assurance such as property/fuzz tests, round trips, boundary/default cases,
+  race/stress tests, lifecycle repetition, fault injection, generated-contract
+  freshness, security scanners, or sidecar integration. Missing evidence lowers
+  confidence or routes to `$test-gaps` or `$project-gaps`; it is not silently
+  converted into a finding.
+
+## Candidate Handling
+
+- Delegated reviewers must return candidates in the selected ledger format,
+  rejected leads with reasons, risky surfaces still needing review, validation,
+  and exact follow-up scopes. A delegated "nothing found" without coverage,
+  rejected-lead, and follow-up evidence cannot close a broad slice.
+- For broad confidence closure, use independent delegated review when agents
+  are available and authorized. Assign disjoint behavior- or risk-owned slices,
+  require coverage, rejected leads, validation, and follow-up scopes, and run a
+  final local challenge pass. If delegation is needed but unavailable or not
+  authorized, stop at the delegation gate instead of presenting closure.
+- For high-assurance closure with authorized agents, use an adversarial review
+  when practical. It should try to falsify the no-finding conclusion, confidence
+  leaps, unreviewed bug classes, missing supported usage, and counterexamples.
+  Do not pass intended conclusions, rejected-lead rationale, or proposed
+  confidence numbers to the adversarial reviewer unless the validation task
+  specifically requires that context.
+- Use `../finding-severity.md` to discard low-confidence candidates before
+  assigning severity or confidence. Build a lead inventory with the selected
+  plan and `../gap-lead-generation.md`; it is a recall aid and never lowers
+  ownership, reproduction, validation, confidence, or approval gates.
+- Treat comparable repositories, local checkout mappings, sibling repositories,
+  and external frameworks as lead generation only. Reproduce any candidate
+  through the selected skill's normal evidence path before recording it.
+- Challenge every candidate against authoritative existing surfaces: public
+  APIs, commands, endpoints, generated contracts, health/metrics, helpers,
+  framework behavior, config defaults, docs, examples, tests, and supported
+  consumer workflows. Reject or route it when an existing surface already
+  satisfies the workflow. Otherwise state the residual gap as: "Even with
+  <existing surface>, the audience still cannot <specific supported
+  action/outcome>."
+- Confirm candidates against current code, docs, examples, tests, CI,
+  generated contracts, public interfaces, and command behavior. Reproduce each
+  candidate before recording it as a confirmed ledger entry or presenting it as
+  a proposed finding. Prefer an executable dominant-harness or repository
+  entrypoint; use a non-executable trace, lookup, or negative search only for
+  documentary, structural, unsupported-mode, or absence-based candidates.
+- Record what was run or inspected, the observed result, and why it proves the
+  repository-owned issue or limitation. For absence-based gaps, name the
+  supported user, maintainer, or operator action that currently fails or cannot
+  be completed.
+- If reproduction is blocked by sandbox limits, tools, credentials, network,
+  optional services, or ambiguous setup, classify the blocker and keep the
+  candidate below the recording threshold unless a separate supported path
+  proves it.
+- A suggested validation command is not itself reproduction. Either run or
+  inspect the smallest supported reproducer and record its observed result, or
+  name the blocker and keep the candidate below threshold.
+- For reusable libraries, helpers, or shared tooling, inspect a real consumer,
+  example, integration test, module wiring path, documented contract, CI
+  workflow, or comparable supported usage before recording a high-confidence
+  candidate. Local fakes, synthetic tests, manual construction, and unsupported
+  downstream patterns are leads only.
+- Separate third-party, framework, tool, image, or project-owned upstream
+  defects from the repository-owned response. Record only an adapter, upgrade,
+  pin, replacement, workaround, validation, tracking, or other response owned
+  by the selected scope; route another project-owned library's defect to its
+  agent or ledger.
+- When prose, comments, examples, or docs contradict implementation, require
+  non-prose evidence before routing the candidate to code, security,
+  reliability, or test workflows. If code, tests, runtime, generated
+  contracts, CI, or history support implementation, route stale prose to
+  `$doc-gaps`.
+- Dismiss candidates already covered by the authoritative surface, below
+  threshold, duplicative, out of scope, or owned by another workflow. Preserve
+  rejected, routed, deferred, and blocked lead notes for local and delegated
+  review. A quiet audit without these notes is not enough evidence for broad
+  no-finding confidence.
+- Treat optional follow-ups, speculative improvements, and leads that need
+  production evidence or a separate product, security, or reliability design
+  as closeout notes only. Do not create a scoped ledger solely to store
+  optional follow-ups when no confirmed entries survive the selected skill's
+  evidence gate.
+
+## Find And Audit Outcomes
+
+Use exactly one closeout outcome:
+
+- `Findings recorded`
+- `No findings and validation clean`
+- `No findings, but validation incomplete because X`
+- `Audit incomplete: no confirmed findings so far`
+
+Distinguish finding confidence (each finding is real and repository-owned),
+coverage confidence (reviewed slices were checked adequately), and scope
+no-finding confidence (no reportable finding remains in scope). Broad no-finding
+closeouts must report all three, using `n/a` for finding confidence when there
+are no findings.
+
+- For broad repository, package-tree, or multi-component scopes, use a
+  no-finding outcome only at 95% scope no-finding confidence with every relevant
+  slice deep-reviewed or explicitly excluded. Otherwise use the incomplete
+  outcome.
+- Confidence closure additionally requires current clean validation,
+  coverage/rejected-lead/validation/follow-up evidence for each delegated slice,
+  every candidate reproduced or rejected/routed, and a final challenge pass
+  that names the strongest counterexamples and why they do not lower the
+  requested threshold.
+- High-assurance closure also requires compact accounting of relevant bug
+  classes, evidence, missing assurance, and any confidence cap.
+- If no findings survive but deferred slices remain, continue to the next
+  highest-risk slice when tools, permissions, and the turn allow. Do not close
+  merely because the first slices were clean.
+
+For broad scopes, include this coverage table before a no-finding or incomplete
+closeout:
+
+```markdown
+| Slice | Status | Evidence | Validation | Confidence | Next scope |
+| --- | --- | --- | --- | --- | --- |
+```
+
+`Status` is `deep`, `skimmed`, `deferred`, `blocked`, or `excluded`, and `Next
+scope` is an exact runnable package, folder, command, or `n/a`. For
+high-assurance closure, also summarize:
+
+```markdown
+| Bug Class | Relevant Surface | Evidence | Missing Assurance | Confidence Cap |
+| --- | --- | --- | --- | --- |
+```
+
+If no confirmed gaps remain and coverage and validation satisfy the selected
+outcome, report the reviewed slices, inventory, supported usage, commands,
+tests/CI, validation classifications, exclusions/deferred work, rejected/
+routed/deferred/blocked leads, policy exclusions, confidence fields, and limits
+on that confidence. If confirmed entries remain, write the selected scoped
+ledger before fixes and stop after presenting the ledger and coverage state.

--- a/skills/references/gap-workflow/implementation.md
+++ b/skills/references/gap-workflow/implementation.md
@@ -1,0 +1,75 @@
+# Gap Workflow: Implementation
+
+Read `../gap-workflow.md` first. This reference contains mechanics that apply only
+while implementing an agreed gap-ledger entry.
+
+## Implement Mechanics
+
+1. Confirm scope and read the selected scoped ledger, or stop and ask whether to
+   run the matching find mode first.
+2. Run `$project-workflow` discovery for current entrypoints, CI, documented
+   commands, relevant public surfaces, and `./bin` wiring.
+3. Select the named entry or next entry and re-check its evidence against
+   current code, docs, tests, commands, and generated/workflow surfaces.
+4. If it is resolved, stale, duplicated, out of scope, or owned elsewhere,
+   explain the routing and propose removing, moving, or reclassifying it before
+   editing.
+5. Present evidence, solution, tradeoffs, and validation as a self-contained
+   decision card using `../decision-card.md`. It must restate enough `What`,
+   `Why`, and `How` that the human need not open the ledger or source files.
+   Stop until the human explicitly agrees. A named fix, implement, or verify
+   request selects an entry and permits evidence refresh, but is not approval to
+   edit unless it also agrees to the proposed solution.
+6. After agreement, state the local pattern, dominant harness or validation
+   path, planned validation, and any deviation. Stop before deviating from
+   repository instructions, the selected skill, or local workflow.
+7. Implement only the agreed entry with the smallest clear change, using paired
+   standards and validation skills from the selected plan.
+8. Validate through repository Make targets or documented entrypoints, then ask
+   the human to verify with `Done ID`.
+9. Stop until confirmation. After confirmation, remove or revise the entry and
+   continue with the next, or delete the scoped ledger when all entries are
+   confirmed resolved.
+
+## Implementation Gates
+
+- Work through scoped entries sequentially by ID unless the human names a
+  different entry.
+- Before proposing a fix, re-check current code, docs, tests, config, CI,
+  command behavior, and nearby patterns. Treat ledgers as stale and dismiss or
+  revise entries that are resolved, duplicated, invalid, or owned elsewhere.
+- Stop after proposing a solution. Do not edit files, update the ledger, or
+  start validation until the human explicitly agrees to that solution. A request
+  naming multiple entries does not permit editing the first one.
+- Ask when behavior, compatibility, documentation location, test layer,
+  implementation home, validation, operator workflow, or intent is too
+  ambiguous to infer safely.
+- After agreement, state the selected local pattern, dominant relevant harness
+  or validation path, planned command, and any deviation. If a deviation is
+  needed, stop and ask before editing.
+- When an execution checklist includes `Expected red`, confirm the harness can
+  run and paste the exact failing command/output before behavior edits. The
+  reported `Green` must use that same command and pass. If the harness is not
+  runnable, stop and either make it runnable or request agreement for named
+  test-after work. Silent test-after and invented red/green reports are
+  prohibited.
+- For substantial, ambiguous, or multi-iteration work, use
+  `../long-running-work.md` after the agreement gate. Keep progress in runtime
+  state, work in thin validated slices, and do not use it to combine modes,
+  bypass approval, or edit outside scope.
+- When the current request authorizes agents, use them for disjoint slices,
+  validation support, or fresh review when they materially improve throughput,
+  coverage, confidence, or implementation safety. Keep one active entry owner
+  and preserve all validation, review, and human-confirmation gates.
+- Implement only the agreed entry using existing local patterns.
+- Before accepting substantial work as complete, run the fresh review gate from
+  `../long-running-work.md`. Without authorized agents, perform a named local
+  challenge pass and do not call it independent review. If agents were
+  authorized and available but independent review did not run, do not report
+  completion at or above 90% confidence.
+- During automatic continuations while waiting for approval or `Done ID`, state
+  the waiting gate once without repeating the full proposal.
+- Do not move to the next entry until the human confirms `Done ID`. After that
+  confirmation, remove or revise the entry; remove it only after explaining an
+  invalidation and getting agreement. Delete the scoped ledger when all entries
+  are confirmed done.

--- a/skills/reliability-gaps/SKILL.md
+++ b/skills/reliability-gaps/SKILL.md
@@ -11,8 +11,11 @@ Use this skill in two distinct modes; do not combine them in one pass:
 - **Implement mode**: `Implement $reliability-gaps in PACKAGE_OR_FOLDER` or `Implement reliability gaps in PACKAGE_OR_FOLDER`.
 
 Before either mode, read `references/plan.md` and
-`../references/gap-workflow.md`; they own runtime state, ledger, delegation,
-scope, coverage, confidence, and approval gates.
+`../references/gap-workflow.md` and the mode-specific reference below own
+runtime state, ledger, delegation,
+scope, coverage, confidence, and approval gates. Before Find mode, also read
+`../references/gap-workflow/find-audit.md`; before Implement mode, also read
+`../references/gap-workflow/implementation.md`.
 
 ## Operating Stance
 
@@ -40,7 +43,7 @@ implementation, route the mismatch to `$doc-gaps` instead.
 ## Find Mode
 
 Follow `references/plan.md#find-mode-plan` and the find/audit rules in
-`../references/gap-workflow.md`.
+`../references/gap-workflow/find-audit.md`.
 
 Read `references/find-rules.md`; those reliability-gap rules remain mandatory
 in Find mode.
@@ -62,7 +65,7 @@ entry warrants them.
 ## Implement Mode
 
 Follow `references/plan.md#implement-mode-plan` and the implementation rules in
-`../references/gap-workflow.md`.
+`../references/gap-workflow/implementation.md`.
 
 These reliability implementation rules remain mandatory:
 
@@ -82,7 +85,9 @@ These reliability implementation rules remain mandatory:
   recording candidates.
 - Read `references/ledger-format.md` before creating, updating, or interpreting
   `RELIABILITY.md`.
-- Read `../references/gap-workflow.md` for shared scoped-ledger, delegation, coverage, confidence, and approval gates.
+- Read `../references/gap-workflow.md` for shared scoped-ledger and delegation
+  gates; read `../references/gap-workflow/find-audit.md` for Find-mode rules and
+  `../references/gap-workflow/implementation.md` for Implement-mode rules.
 - Use `../references/decision-card.md` to present the agreement-gate proposal as a self-contained decision card.
 - Use `../references/gap-lead-generation.md` during Find mode to classify repo
   archetypes, generate reliability leads, and account for rejected or routed

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -63,8 +63,11 @@ make review msg="unprefixed subject" desc_file="/returned/path/review-pr.ABC123"
 ```
 
 - Remove the temporary file after `make review`, including when the review
-  command fails. Do not flatten the summary into a single line or pass Markdown
-  through a quoted shell argument.
+  command fails. Use a direct `rm -f -- /returned/path/review-pr.ABC123`
+  invocation after substituting the captured path; do not wrap cleanup in
+  `zsh -lic`, `sh -c`, or another shell command because the shared Codex rule
+  allows direct non-recursive `rm -f` only. Do not flatten the summary into a
+  single line or pass Markdown through a quoted shell argument.
 - Read `references/output-format.md`, then report the result using that exact
   structure.
 

--- a/skills/test-gaps/SKILL.md
+++ b/skills/test-gaps/SKILL.md
@@ -11,8 +11,11 @@ Use this skill in two distinct modes; do not combine them in one pass:
 - **Implement mode**: `Implement $test-gaps in PACKAGE_OR_FOLDER` or `Implement test gaps in PACKAGE_OR_FOLDER`.
 
 Before either mode, read `references/plan.md` and
-`../references/gap-workflow.md`; they own runtime state, ledger, delegation,
-scope, coverage, confidence, and approval gates.
+`../references/gap-workflow.md` and the mode-specific reference below own
+runtime state, ledger, delegation,
+scope, coverage, confidence, and approval gates. Before Find mode, also read
+`../references/gap-workflow/find-audit.md`; before Implement mode, also read
+`../references/gap-workflow/implementation.md`.
 
 ## Operating Stance
 
@@ -43,7 +46,7 @@ improvements to `$project-gaps`.
 ## Find Mode
 
 Follow `references/plan.md#find-mode-plan` and the find/audit rules in
-`../references/gap-workflow.md`.
+`../references/gap-workflow/find-audit.md`.
 
 Read `references/find-rules.md`; those test-gap rules remain mandatory in Find
 mode.
@@ -65,7 +68,7 @@ entry warrants them.
 ## Implement Mode
 
 Follow `references/plan.md#implement-mode-plan` and the implementation rules in
-`../references/gap-workflow.md`.
+`../references/gap-workflow/implementation.md`.
 
 These test-gap implementation rules remain mandatory:
 
@@ -85,7 +88,9 @@ These test-gap implementation rules remain mandatory:
   recording candidates.
 - Read `references/ledger-format.md` before creating, updating, or interpreting
   `TESTS.md`.
-- Read `../references/gap-workflow.md` for shared scoped-ledger, delegation, coverage, confidence, and approval gates.
+- Read `../references/gap-workflow.md` for shared scoped-ledger and delegation
+  gates; read `../references/gap-workflow/find-audit.md` for Find-mode rules and
+  `../references/gap-workflow/implementation.md` for Implement-mode rules.
 - Use `../references/decision-card.md` to present the agreement-gate proposal as a self-contained decision card.
 - Use `../references/gap-lead-generation.md` during Find mode to classify repo
   archetypes, generate test-coverage leads, and account for rejected or routed


### PR DESCRIPTION
## What

- Split shared gap-workflow guidance into a compact core plus mode-specific Find/audit and Implement references, and update all six gap skills to load the relevant reference.
- Restore the original confidence, ledger, reproduction, adversarial-review, and non-executable-trace guardrails identified during review.
- Add targeted relative-reference checks to skills lint so the corrected split paths are verified on disk.

## Why

- Reduce repeated context loading for gap workflows without weakening the policy gates that govern evidence, confidence, delegation, approval, and implementation safety. The reference checks prevent another split from silently leaving a broken path that literal-marker checks cannot detect.

## Testing

- `zsh -lic 'make skills-lint'` - passed.
- `git diff --check` - passed; new split files also produced no whitespace diagnostics.
- Claude review confirmed all seven prior findings are fixed with no new findings at 96% confidence.
- No executable product tests were run; this change is shared skill and policy guidance. Reference validation is intentionally targeted to the paths previously found broken; a general sweep remains a possible follow-up.
