### PR TITLE
feat(skills): clarify default skill workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,18 @@ IDs include `FEATURE-*`, `ISSUE-*`, `TEST-*`, `DOC-*`, `PROJECT-*`, and
 `with a goal`, and `with agents and a goal` tails carry current-request
 authorization.
 
+These authorization tails also apply after a generic skill invocation, such as
+`$skill-name in SCOPE`, `Find $skill-name in SCOPE`, or
+`Implement $skill-name in SCOPE`. They carry the same current-request
+authorization without changing the skill's mode, default behavior, or approval
+gates. `SCOPE` is interpreted by the selected skill: normally a package or
+folder, but it may be a CI/deployment target, repository and reporting period,
+or another skill-defined target. Skills that do not accept a generic scope
+remain explicit-request exceptions. `review-pr` is one such exception: its
+bare current-request invocation targets the current repository and means the
+full review, validation, commit, force-push, and draft-PR workflow; it does not
+use a path scope.
+
 - `Start FEATURE-3 in path/FEATURES.md`: select the matching gap skill,
   refresh evidence, present the solution, and stop at the agreement gate
   before editing. `Start ISSUE-3 in path/ISSUES.md` follows the same shape.

--- a/build/codex/rules/default.rules
+++ b/build/codex/rules/default.rules
@@ -225,12 +225,23 @@ prefix_rule(
 )
 
 prefix_rule(
+    pattern = ["rm", "-f", ["-r", "-R", "-rf", "-fr"]],
+    decision = "prompt",
+    justification = "Forced recursive deletion can permanently remove files.",
+    match = [
+        "rm -f -r",
+        "rm -f -R",
+        "rm -f -rf",
+        "rm -f -fr",
+    ],
+)
+
+prefix_rule(
     pattern = ["rm", "-f"],
     decision = "allow",
-    justification = "Non-recursive forced removal is permitted for temporary-file cleanup.",
+    justification = "Non-recursive forced removal is permitted without prompting; recursive and catastrophic deletion remain guarded.",
     match = [
-        "rm -f test/reports/output.txt",
-        "rm -f -- /tmp/agent-temp-file",
+        "rm -f",
     ],
     not_match = [
         "rm -rf test/reports",

--- a/skills/code-issues/SKILL.md
+++ b/skills/code-issues/SKILL.md
@@ -5,7 +5,9 @@ description: Use when the user asks to find or implement $code-issues/code issue
 
 # Code Issues
 
-Use this skill in two distinct modes; do not combine them in one pass:
+Use Find mode by default when no mode is stated. Enter Implement mode only
+after the human explicitly agrees to a specific proposed solution, typically
+with `Approved ISSUE-N`. Do not combine modes in one pass:
 
 - **Find mode**: `Find $code-issues in PACKAGE_OR_FOLDER` or `Find code issues in PACKAGE_OR_FOLDER`.
 - **Implement mode**: `Implement $code-issues in PACKAGE_OR_FOLDER` or `Implement code issues in PACKAGE_OR_FOLDER`.

--- a/skills/code-issues/agents/openai.yaml
+++ b/skills/code-issues/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Code Issues"
   short_description: "Find scoped code defects and risks"
-  default_prompt: "Use $code-issues for scoped bug, security, compatibility, and public-contract findings. Follow repo archetype lead generation, apply the shared delegation gate, preserve its evidence and approval workflow, answer issue ID follow-ups such as ISSUE-1, and fix one agreed issue at a time."
+  default_prompt: "Use $code-issues for scoped bug, security, compatibility, and public-contract findings. Default to Find mode when no mode is stated; follow repo archetype lead generation, apply the shared delegation gate, preserve its evidence and approval workflow, answer issue ID follow-ups such as ISSUE-1, and implement only after explicit agreement to a specific proposal."

--- a/skills/diagnose-issue/SKILL.md
+++ b/skills/diagnose-issue/SKILL.md
@@ -17,6 +17,10 @@ fixes. Keep the diagnosis grounded in source evidence; do not retry jobs,
 redeploy, mutate clusters, change monitors, push commits, or update PRs unless
 the user explicitly asks after the diagnosis.
 
+For a generic invocation, `SCOPE` is a CI, PR, deployment, rollout, Kubernetes,
+DigitalOcean, UptimeRobot, or released-version target, not necessarily a local
+folder.
+
 ## Workflow
 
 1. Identify the requested diagnosis mode.

--- a/skills/feature-gaps/SKILL.md
+++ b/skills/feature-gaps/SKILL.md
@@ -5,7 +5,9 @@ description: Use when the user asks to find or implement $feature-gaps/feature g
 
 # Feature Gaps
 
-Use this skill in two distinct modes; do not combine them in one pass:
+Use Find mode by default when no mode is stated. Enter Implement mode only
+after the human explicitly agrees to a specific proposed solution, typically
+with `Approved FEATURE-N`. Do not combine modes in one pass:
 
 - **Find mode**: `Find $feature-gaps in PACKAGE_OR_FOLDER` or `Find feature gaps in PACKAGE_OR_FOLDER`.
 - **Implement mode**: `Implement $feature-gaps in PACKAGE_OR_FOLDER` or `Implement feature gaps in PACKAGE_OR_FOLDER`.

--- a/skills/feature-gaps/agents/openai.yaml
+++ b/skills/feature-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Feature Gaps"
   short_description: "Find product feature opportunities"
-  default_prompt: "Use $feature-gaps for scoped product-facing capability opportunities with explicit audience benefit. Follow repo archetype lead generation, apply the shared delegation gate, put Solution Shape first, answer feature ID follow-ups such as FEATURE-1, and route test/project gaps elsewhere."
+  default_prompt: "Use $feature-gaps for scoped product-facing capability opportunities with explicit audience benefit. Default to Find mode when no mode is stated; follow repo archetype lead generation, apply the shared delegation gate, put Solution Shape first, answer feature ID follow-ups such as FEATURE-1, implement only after explicit agreement to a specific proposal, and route test/project gaps elsewhere."

--- a/skills/project-gaps/SKILL.md
+++ b/skills/project-gaps/SKILL.md
@@ -5,7 +5,9 @@ description: Use when the user asks to find or implement $project-gaps/project g
 
 # Project Gaps
 
-Use this skill in two distinct modes; do not combine them in one pass:
+Use Find mode by default when no mode is stated. Enter Implement mode only
+after the human explicitly agrees to a specific proposed solution, typically
+with `Approved PROJECT-N`. Do not combine modes in one pass:
 
 - **Find mode**: `Find $project-gaps in PACKAGE_OR_FOLDER` or `Find project gaps in PACKAGE_OR_FOLDER`.
 - **Implement mode**: `Implement $project-gaps in PACKAGE_OR_FOLDER` or `Implement project gaps in PACKAGE_OR_FOLDER`.

--- a/skills/project-gaps/agents/openai.yaml
+++ b/skills/project-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Project Gaps"
   short_description: "Find scoped project workflow gaps"
-  default_prompt: "Use $project-gaps for scoped build, CI, Makefile, release, setup, dependency, validation, and workflow gaps. Follow repo archetype lead generation, apply the shared delegation gate, classify implementation home as current repo, shared bin, external repo, or mixed, answer project gap ID follow-ups such as PROJECT-1, and fix one agreed gap."
+  default_prompt: "Use $project-gaps for scoped build, CI, Makefile, release, setup, dependency, validation, and workflow gaps. Default to Find mode when no mode is stated; follow repo archetype lead generation, apply the shared delegation gate, classify implementation home as current repo, shared bin, external repo, or mixed, answer project gap ID follow-ups such as PROJECT-1, and implement only after explicit agreement to a specific proposal."

--- a/skills/references/gap-workflow.md
+++ b/skills/references/gap-workflow.md
@@ -24,6 +24,14 @@ These shared rules own workflow mechanics.
     tail carries forward to the next entry.
   These shorthands do not bypass solution agreement, scoped ledgers, validation
   freshness, confidence thresholds, remote-write permission, or output format.
+
+- A generic invocation such as `$skill-name in SCOPE` uses the selected skill's
+  declared default mode. One-pass skills execute that pass; two-phase gap
+  skills default to Find mode and must present a proposal before entering
+  Implement mode. The `with agents`, `with a goal`, and `with agents and a goal`
+  tails may follow generic, Find, or Implement invocations and carry the same
+  current-request authorization without changing mode selection or bypassing
+  approval gates.
 - Before starting find, audit, one-pass, or implement mode, read the selected
   skill's `references/plan.md` and keep it as runtime state. Do not write it to
   the repository unless the human explicitly asks for a durable plan file.

--- a/skills/reliability-gaps/SKILL.md
+++ b/skills/reliability-gaps/SKILL.md
@@ -5,7 +5,9 @@ description: Use when the user asks to find or implement $reliability-gaps/relia
 
 # Reliability Gaps
 
-Use this skill in two distinct modes; do not combine them in one pass:
+Use Find mode by default when no mode is stated. Enter Implement mode only
+after the human explicitly agrees to a specific proposed solution, typically
+with `Approved REL-N`. Do not combine modes in one pass:
 
 - **Find mode**: `Find $reliability-gaps in PACKAGE_OR_FOLDER` or `Find reliability gaps in PACKAGE_OR_FOLDER`.
 - **Implement mode**: `Implement $reliability-gaps in PACKAGE_OR_FOLDER` or `Implement reliability gaps in PACKAGE_OR_FOLDER`.

--- a/skills/reliability-gaps/agents/openai.yaml
+++ b/skills/reliability-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Reliability Gaps"
   short_description: "Find scoped SRE readiness gaps"
-  default_prompt: "Use $reliability-gaps for scoped SRE, operability, overload, observability, release-safety, recovery, and data-integrity gaps. Follow repo archetype lead generation, apply the shared delegation gate, verify concrete failure paths, answer reliability gap ID follow-ups such as REL-1, and fix agreed gaps."
+  default_prompt: "Use $reliability-gaps for scoped SRE, operability, overload, observability, release-safety, recovery, and data-integrity gaps. Default to Find mode when no mode is stated; follow repo archetype lead generation, apply the shared delegation gate, verify concrete failure paths, answer reliability gap ID follow-ups such as REL-1, and implement only after explicit agreement to a specific proposal."

--- a/skills/repo-health/SKILL.md
+++ b/skills/repo-health/SKILL.md
@@ -11,6 +11,9 @@ delivery was smooth, and whether the repo or service looks healthier than the
 comparison period. Convert measured bottlenecks into prioritized,
 evidence-backed follow-up actions that repository owners can complete.
 
+For a generic invocation, `SCOPE` is a repository together with its requested
+reporting period and comparison period, not necessarily a local folder.
+
 ## Workflow
 
 1. Identify the requested repository, period, comparison period, and summary

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -1,9 +1,20 @@
 ---
 name: review-pr
-description: Use when, and only when, the user explicitly asks to prepare, open, update, or run a review PR from local changes. Review, validate, commit, force-push, and open a draft pull request with the repository review target.
+description: >-
+  Use when, and only when, the user invokes $review-pr or explicitly asks to
+  prepare, open, update, or run a review PR from local changes. A bare
+  current-request invocation runs the full workflow: review, validate, commit,
+  force-push, and open a draft pull request with the repository review target.
 ---
 
 # Review PR
+
+A bare `$review-pr` invocation is an explicit current-request instruction to
+run the full workflow for the current repository: review and validate local
+changes, commit them, force-push the branch, and open a draft pull request. It
+does not require an `in SCOPE` suffix. If an existing PR or draft description
+would be updated, ask before replacing it; future changes do not carry forward
+permission to push again.
 
 Before executing this workflow, read `references/plan.md` and use it to maintain
 the active execution plan. The active plan is runtime state; do not write it
@@ -17,7 +28,7 @@ Follow `references/plan.md#execution-plan`.
 
 These rules remain mandatory:
 
-- Confirm the user explicitly asked in the current request to commit, push, update, or open a review PR. If not, do not run `make review`, `make push`, or any equivalent push/PR update command.
+- Confirm that the current request contains `$review-pr` or an equivalent explicit request to commit, push, update, or open a review PR. If not, do not run `make review`, `make push`, or any equivalent push/PR update command.
 - If new changes would make an existing PR description, review comment, or previously drafted summary obsolete, flag that and ask whether the user wants the PR updated before pushing anything.
 - Make the remote-write behavior of `make review` explicit before running it: the target commits, force-pushes, and opens a draft PR.
 - Use `$change-validation`, relevant language standards, `$doc-standards`, and

--- a/skills/review-pr/agents/openai.yaml
+++ b/skills/review-pr/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Review PR"
   short_description: "Prepare a portable approved review PR flow"
-  default_prompt: "Use $review-pr when I explicitly ask to commit, push, and open or update a review PR; maintain its active plan, use runtime goals only when authorized, use a fresh review gate for substantial changes, include review-time documentation judgment through $doc-standards, create and clean up a portable desc_file without asking me for it, and put the guarded Make review target before its variable assignments."
+  default_prompt: "Use $review-pr for the current repository's full review PR workflow: validate and review changes, commit, force-push, and open a draft PR. Maintain its active plan, use runtime goals only when authorized, ask before replacing an existing PR description, use a fresh review gate for substantial changes, include review-time documentation judgment through $doc-standards, create and clean up a portable desc_file without asking me for it, and put the guarded Make review target before its variable assignments."

--- a/skills/test-gaps/SKILL.md
+++ b/skills/test-gaps/SKILL.md
@@ -5,7 +5,9 @@ description: Use when the user asks to find or implement $test-gaps/test gaps in
 
 # Test Gaps
 
-Use this skill in two distinct modes; do not combine them in one pass:
+Use Find mode by default when no mode is stated. Enter Implement mode only
+after the human explicitly agrees to a specific proposed solution, typically
+with `Approved TEST-N`. Do not combine modes in one pass:
 
 - **Find mode**: `Find $test-gaps in PACKAGE_OR_FOLDER` or `Find test gaps in PACKAGE_OR_FOLDER`.
 - **Implement mode**: `Implement $test-gaps in PACKAGE_OR_FOLDER` or `Implement test gaps in PACKAGE_OR_FOLDER`.

--- a/skills/test-gaps/agents/openai.yaml
+++ b/skills/test-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Test Gaps"
   short_description: "Find weak tests and harness gaps"
-  default_prompt: "Use $test-gaps for scoped missing, weak, misleading, flaky, wrong-layer, or harness coverage gaps. Follow repo archetype lead generation, apply the shared delegation gate, verify front-door behavior, answer test gap ID follow-ups such as TEST-1, and fix one agreed gap."
+  default_prompt: "Use $test-gaps for scoped missing, weak, misleading, flaky, wrong-layer, or harness coverage gaps. Default to Find mode when no mode is stated; follow repo archetype lead generation, apply the shared delegation gate, verify front-door behavior, answer test gap ID follow-ups such as TEST-1, and implement only after explicit agreement to a specific proposal."


### PR DESCRIPTION
## What

- Define a consistent generic skill-invocation contract across shared policy and skills.
- Make the five two-phase gap skills default to Find mode while preserving explicit agreement before implementation.
- Make `doc-gaps` remain one-pass and make bare `$review-pr` run the full review-to-draft-PR workflow for the current repository.
- Clarify polymorphic scope handling and keep existing-PR replacement confirmation requirements.

## Why

- Codex and Claude need the same deterministic defaults when a script invokes a skill using only its name, scope, and authorization tails.
- The workflow now makes mode selection and remote-write boundaries explicit without weakening approval gates for gap implementations or existing PR updates.

## Testing

- `make skills-lint` - passed
- `git diff --check` - passed
- `gh pr view --json number,url,title,state,isDraft,body` - no existing pull request found for the branch
- Manual focused code review - no blocking findings
- Runtime verification was performed through Claude's static mode-selection probe; no full `make review` run had occurred before this PR.
