### PR TITLE
feat(ai): exclude environment files from Go vendoring

### DIFF
--- a/build/go/vendor
+++ b/build/go/vendor
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Regenerate vendor without copying environment files from dependencies.
+
+set -eo pipefail
+
+vendor_temp="$(mktemp -d "${TMPDIR:-/tmp}/go-vendor.XXXXXX")"
+trap 'rm -rf "$vendor_temp"' EXIT
+
+go mod vendor -o "$vendor_temp"
+
+if [[ -L vendor ]]; then
+  rm -f vendor
+fi
+
+if [[ -d vendor ]]; then
+  find vendor \( -name '.env' -o -name '.env.*' \) -prune -o \( -type f -o -type l \) -exec rm -f {} +
+else
+  mkdir -p vendor
+fi
+
+while IFS= read -r -d '' source; do
+  relative="${source#"$vendor_temp"/}"
+  destination="vendor/$relative"
+  mkdir -p "$(dirname "$destination")"
+  cp -p "$source" "$destination"
+done < <(find "$vendor_temp" \( -name '.env' -o -name '.env.*' \) -prune -o -type f -print0)

--- a/build/make/_service.mak
+++ b/build/make/_service.mak
@@ -26,7 +26,7 @@ tidy:
 	@go mod tidy
 
 vendor:
-	@go mod vendor
+	@$(BIN_ROOT)/build/go/vendor
 
 # Run fieldalignment; .gofa may list comma-separated packages, default ./...
 field-alignment:

--- a/build/make/go.mak
+++ b/build/make/go.mak
@@ -23,7 +23,7 @@ tidy:
 	@go mod tidy
 
 vendor:
-	@go mod vendor
+	@$(BIN_ROOT)/build/go/vendor
 
 get:
 	@go get "$$module"


### PR DESCRIPTION
## What

- Route Go vendor regeneration through a shared helper for both standalone Go projects and service make fragments.

- Stage Go's generated vendor tree outside the repository, omit `.env` and `.env.*` files from the copied tree, preserve pre-existing environment files, and replace a top-level vendor symlink before writing.

- Keep the change limited to shared bin workflow files; no consuming application code or dependency files are changed.

## Why

- `go mod vendor` can encounter dependency environment files such as `github.com/arl/statsviz/internal/static/.env.development`, which cannot be written under the workspace's `.env` protection.

- The shared dependency workflow now regenerates usable vendor trees without weakening environment-file protection or introducing dependency environment files into repositories.

## Testing

- `make scripts-lint` - passed.

- `make dep` - passed in a temporary secret-excluding go-service consumer copy linked to this bin checkout; generated `vendor/modules.txt` and no `.env*` files.

- `make lint` - passed with 0 issues.

- `make sec` - passed; govulncheck found no reachable code vulnerabilities and Trivy reported zero vulnerabilities or secrets. It also reported the existing non-reachable GO-2026-5932 module advisory for `golang.org/x/crypto/openpgp`.

- `make specs` - passed with 2,298 tests.

- Manual edge checks confirmed pre-existing `.env.development` preservation and safe replacement of a top-level vendor symlink without writing through it.

- The checked-in `/Users/alejandro/code/go-service` checkout was non-writable, so it was not modified; the same supported downstream targets ran successfully in the isolated consumer copy.
