### PR TITLE
feat(skills): allow claude sandbox outbound network and system temp file access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,11 +363,18 @@ Do not infer the test language from the implementation language alone.
   approval, and catastrophic commands remain forbidden. The unsandboxed escape
   hatch is disabled. The sandbox grants the standard Go, RuboCop,
   golangci-lint, and Trivy cache writes needed by project commands plus standard
-  system temporary directories. Every `make` invocation is excluded from the
-  sandbox and allowed without prompting. Built-in file edits stay scoped to the
-  workspace. Use the baseline
+  system temporary directories, and allows unrestricted outbound network access
+  to match the Codex profile, with macOS `trustd` access enabled so Go-based
+  CLI tools (`gh`, `gcloud`, `terraform`) can verify TLS through the sandbox
+  network proxy. Every `make` invocation is excluded from the
+  sandbox and allowed without prompting. Built-in file reads and edits are
+  scoped to the workspace plus the standard system temporary directories
+  (`/tmp`, `/private/tmp`, `/var/tmp`, `/var/folders`), which are readable and
+  writable without prompting. Use the baseline
   only in trusted repositories because Make targets inherit the user's host
-  access, and the sandbox does not impose blanket secret-read restrictions.
+  access, outbound network access is unrestricted, enabling `trustd` widens the
+  exfiltration surface, and the sandbox does not impose blanket secret-read
+  restrictions.
   Per-repo or per-machine permission tweaks belong in the gitignored
   `.claude/settings.local.json`, which Claude Code merges over the baseline.
 - Treat skills as maintained artifacts and review them when project workflow,

--- a/build/claude/settings.json
+++ b/build/claude/settings.json
@@ -5,6 +5,12 @@
     "failIfUnavailable": true,
     "autoAllowBashIfSandboxed": false,
     "allowUnsandboxedCommands": false,
+    "network": {
+      "allowedDomains": [
+        "*"
+      ]
+    },
+    "enableWeakerNetworkIsolation": true,
     "excludedCommands": [
       "make",
       "make *"
@@ -33,6 +39,18 @@
       "Read(**)",
       "Edit(**)",
       "Write(**)",
+      "Read(//tmp/**)",
+      "Read(//private/tmp/**)",
+      "Read(//var/tmp/**)",
+      "Read(//var/folders/**)",
+      "Edit(//tmp/**)",
+      "Edit(//private/tmp/**)",
+      "Edit(//var/tmp/**)",
+      "Edit(//var/folders/**)",
+      "Write(//tmp/**)",
+      "Write(//private/tmp/**)",
+      "Write(//var/tmp/**)",
+      "Write(//var/folders/**)",
       "WebFetch",
       "WebSearch"
     ],


### PR DESCRIPTION
## What

- Grant the Claude Code sandbox baseline (`build/claude/settings.json`) unrestricted outbound network access via `sandbox.network.allowedDomains: ["*"]`, matching the Codex shared profile's `network.enabled = true`.
- Enable `sandbox.enableWeakerNetworkIsolation` so Go-based CLI tools (`gh`, `gcloud`, `terraform`) can verify TLS through the sandbox's terminating proxy instead of failing with `x509` certificate errors.
- Allow the built-in Read, Edit, and Write tools under the standard system temp roots (`/tmp`, `/private/tmp`, `/var/tmp`, `/var/folders`) with absolute `//` path rules, so session scratchpad and temp files no longer trigger permission prompts.
- Update `AGENTS.md` to document the outbound-network grant, the trustd/Go-TLS allowance, the temp read/write scope, and the widened exfiltration surface in the trusted-repositories-only caveat.
- Shared-baseline change: it propagates to every `./bin` consumer that symlinks the baseline; repos owning a real, non-symlink `settings.json` are unaffected.

## Why

- The Claude baseline previously granted no sandbox network access and only workspace-anchored file rules, so routine operations (network calls, reading/writing session temp files, Go-based CLI tools) prompted or failed on every run, unlike the Codex profile which already grants outbound network and temp access. This brings the two harnesses to parity and removes the recurring prompts.
- `allowedDomains: ["*"]` alone still left Go-TLS tools broken inside the sandbox (observed: `gh` failing with `x509: OSStatus -26276`); `enableWeakerNetworkIsolation` is the documented fix for that class of tool.
- Intentional security trade-off: this widens the sandbox to unrestricted outbound network plus macOS trustd access and temp read/write across all consumers. The baseline is already documented as trusted-repositories-only, and the `AGENTS.md` caveat now states the network and trustd exfiltration exposure explicitly.

## Testing

- `jq empty build/claude/settings.json` - passed (valid JSON)
- `make skills-lint` - passed (shared policy markers and agent policy)
- `make sec` - passed (Trivy: 0 vulnerabilities, 0 secrets; limited relevance to a permissions-config change)
- No automated test covers Claude Code permission semantics. The `//` absolute-path syntax was verified against an existing working scratchpad grant, and the `network` and `enableWeakerNetworkIsolation` shapes against the Claude Code settings JSON schema. Runtime behavior (network taking effect, `gh` TLS resolving) has not been verified in a reloaded session and should be confirmed after a restart or resume.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
