### PR TITLE
feat(skills): defer command approvals to runtime configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,15 +217,14 @@ Runtime goals and sub-agents require current-request authorization and never
 bypass approval, validation, or confidence gates. Use `testing-standards`
 before adding, reviewing, refactoring, or planning tests.
 
-Before direct commands requiring SSH, GitHub, registry credentials, cloning,
-publishing, or remote state changes, make the requirement explicit and verify
-that the current request authorizes the effect; get permission when it does
-not. A repository Make target may perform those actions without a separate
-command prompt, but it does not expand the current request or bypass a selected
-skill's permission gates. For consuming repositories, read local instructions
-first, then the relevant `bin/skills/**` references; exclude unrelated `bin/**`
-content from searches and reason about shared Make behavior from the consumer
-root.
+Before direct commands that may use SSH, GitHub or registry credentials,
+cloning, publishing, or remote state, make the external effect explicit and
+rely on the active agent configuration for command approval behavior. A
+repository Make target may perform those actions without a separate command
+prompt, but it does not expand the current request's scope. For consuming
+repositories, read local instructions first, then the relevant `bin/skills/**`
+references; exclude unrelated `bin/**` content from searches and reason about
+shared Make behavior from the consumer root.
 
 ## Downstream repository defaults
 
@@ -331,7 +330,7 @@ Do not infer the test language from the implementation language alone.
   `make claude-init` (`build/claude/init`) wire the two assistants by symlinking
   `skills/` and the shared permission profiles into place; see
   `skills/project-workflow/references/agent-init.md` for the exact symlinks,
-  sandbox posture, permission gates, and trusted-repository caveats. Use those
+  sandbox posture, runtime approval guardrails, and trusted-repository caveats. Use those
   profiles only in trusted repositories, because Make targets inherit the user's
   host access and sandboxed commands can read credentials and use the network.
 - Treat skills as maintained artifacts and review them when project workflow,

--- a/README.md
+++ b/README.md
@@ -98,8 +98,9 @@ outside the sandbox without prompting. Direct cleanup inside writable sandbox
 roots is allowed, direct recognized remote and external-system changes require
 approval, and catastrophic commands are forbidden. Root `.env` and `.env.*`
 files remain protected, while nested dependency environment files and `.envrc`
-files are allowed for native dependency workflows. Explicit workflow permission
-gates in `AGENTS.md` remain in force.
+files are allowed for native dependency workflows. The active agent
+configuration provides runtime approval guardrails; `AGENTS.md` continues to
+define task scope and workflow authorization.
 
 > [!WARNING]
 > The shared profile is only for trusted repositories. Make targets run outside
@@ -162,8 +163,9 @@ forbidden. The unsandboxed escape hatch is disabled. The sandbox grants the
 standard Go, RuboCop, golangci-lint, and Trivy cache writes used by project
 commands, plus standard system temporary directories. Every `make` invocation
 is excluded from the sandbox and allowed without prompting. Built-in file edits
-stay scoped to the workspace, and explicit workflow permission gates in
-`AGENTS.md` remain in force.
+stay scoped to the workspace, and the active agent configuration provides
+runtime approval guardrails while `AGENTS.md` defines task scope and workflow
+authorization.
 
 > [!WARNING]
 > The shared baseline is only for trusted repositories. Make targets run outside

--- a/skills/change-validation/SKILL.md
+++ b/skills/change-validation/SKILL.md
@@ -11,7 +11,10 @@ description: Use when running or selecting validation after code, docs, Makefile
 2. Read `references/check-selection.md` when choosing between targeted tests, lint commands, make targets, CI mirrors, benchmarks, or security checks.
 3. Before running, retrying, replacing, or recommending validation commands, establish the execution environment: repository root, documented entrypoint, CI analogue, initialized user shell, and any macOS/Homebrew tool-path assumptions. Do not invent direct commands or bypass Make targets just because the agent shell cannot find the right tool.
 4. Run the repository's setup or dependency target first when validation depends on installed dependencies or generated/vendor state.
-5. Ask for user permission before running validation commands that require SSH credentials, GitHub auth, registry auth, cloning, pushing, publishing, opening PRs, or updating remote state.
+5. Identify whether validation commands use network access, credentials, SSH,
+   registries, cloning, pushing, publishing, opening PRs, or remote state. Rely
+   on the active agent configuration for command approval behavior; do not add
+   a separate model-level permission request.
 6. Run the narrowest check that credibly exercises the changed behavior, then expand only when risk justifies it.
 7. Treat validation as valid only for the file state it tested. If files change while a validation command is still running or after it completes, report that result as stale and rerun the relevant checks after final edits.
 8. Notice wrappers that no-op because optional tools are missing, and do not report them as full validation.

--- a/skills/change-validation/references/check-selection.md
+++ b/skills/change-validation/references/check-selection.md
@@ -21,7 +21,10 @@ Use this reference when choosing which checks to run.
   layer or skips required setup.
 - Use CI configuration as a strong signal for which checks matter most.
 - Run the repository's setup target, such as `make dep`, when checks depend on installed dependencies, generated files, or vendored state.
-- Ask for permission before running checks that require SSH credentials, GitHub auth, registry auth, cloning, pushing, publishing, opening PRs, or updating remote state.
+- Identify checks that require SSH credentials, GitHub auth, registry auth,
+  cloning, pushing, publishing, opening PRs, or updating remote state. Rely on
+  the active agent configuration for command approval behavior; do not add a
+  separate model-level permission request.
 - Expand from targeted checks to broader checks only when the task or risk justifies it.
 - Never imply a check ran if the wrapper no-op'd because a dependency was missing.
 - Report network, credential, shell environment, `PATH`, or tool-version failures as environment or validation gaps rather than code failures.
@@ -100,7 +103,10 @@ For standalone validation reports, use exactly this Markdown structure and do no
 - If a repo exposes `dep`, `lint`, `specs`, `features`, `benchmarks`, `coverage`, or `sec`, prefer those names over ad hoc tool invocations.
 - For this shared `bin` repo itself, CI currently runs `make dep`, `make clean-dep`, `make scripts-lint`, `make skills-lint`, `make docker-lint`, `make lint`, and `make sec`.
 - Dependency setup, scanners, Docker commands, Buf commands, and Go module commands may require network access; identify that before relying on them.
-- Push, publish, release, Docker manifest push, Buf push, and PR open/update flows require explicit user permission.
+- Push, publish, release, Docker manifest push, Buf push, and PR open/update
+  flows update remote state. Run them only when the current request authorizes
+  that workflow, and rely on the active agent configuration for command
+  approval behavior.
 
 ## `./bin`-Specific Caution
 

--- a/skills/feature-gaps/SKILL.md
+++ b/skills/feature-gaps/SKILL.md
@@ -49,9 +49,10 @@ surface.
 Use external product or library research when it would materially improve the
 proposal and the runtime provides an allowed research tool. Prefer official
 docs, project repositories, release notes, and mature tool behavior over blog
-posts or generic trend lists. Ask for human permission before running commands
-that require network, SSH, GitHub auth, registry auth, remote writes, cloning,
-or other approval-gated access.
+posts or generic trend lists. Identify whether research commands use SSH,
+GitHub auth, registry auth, cloning, or remote writes. Rely on the active agent
+configuration for command approval behavior; do not add a separate model-level
+permission request.
 
 ## Acceptance Gate
 

--- a/skills/project-workflow/references/agent-init.md
+++ b/skills/project-workflow/references/agent-init.md
@@ -28,8 +28,9 @@ writable roots is prompt-free, direct remote and external-service commands
 remain approval-gated, and catastrophic commands remain forbidden. Root `.env`
 and `.env.*` files remain protected, while nested dependency environment files
 and `.envrc` files are allowed for native dependency workflows. The shared
-rules and explicit workflow permission gates remain in force. Per-machine
-additions belong in `~/.codex/config.toml` and `~/.codex/rules/`.
+rules provide runtime approval guardrails, while `AGENTS.md` defines task scope
+and workflow authorization. Per-machine additions belong in
+`~/.codex/config.toml` and `~/.codex/rules/`.
 
 ## Claude Code (`build/claude/init`, via `make claude-init`)
 

--- a/skills/project-workflow/references/downstream-defaults.md
+++ b/skills/project-workflow/references/downstream-defaults.md
@@ -85,8 +85,9 @@ Target-specific rules:
   `PATH`; do not flag the local no-op unless CI lacks the tool, the task is
   about strict local lint parity, or the repository decided missing local
   `golangci-lint` must fail.
-- `proto-push` updates remote state and requires explicit current-request
-  permission.
+- `proto-push` updates remote state. Run it only when the current request
+  authorizes that workflow, and rely on the active agent configuration for
+  command approval behavior.
 - `proto-breaking` derives the GitHub repository name from the checkout
   directory basename. Do not require a local `NAME := <repo>` override for
   canonical checkouts.

--- a/skills/project-workflow/references/make-fragments.md
+++ b/skills/project-workflow/references/make-fragments.md
@@ -45,7 +45,9 @@ Use this reference after you have identified which shared `bin/build/make/*.mak`
 - `breaking` compares against `https://github.com/alexfalkowski/$(NAME).git#branch=master`, so branch and remote assumptions matter.
 - `generate`, `stale`, and `push` depend on the consuming repository's Buf configuration.
 - `stale` runs `buf generate` from the Buf module directory that included the fragment, then runs `git diff --exit-code`; Git checks the whole worktree, so generated outputs outside that child directory are still detected.
-- `push` updates remote state and requires explicit user permission.
+- `push` updates remote state. Run it only when the current request authorizes
+  that workflow, and rely on the active agent configuration for command
+  approval behavior.
 
 ### `http.mak`, `grpc.mak`, And `client.mak`
 
@@ -54,14 +56,18 @@ Use this reference after you have identified which shared `bin/build/make/*.mak`
 - `features` and `benchmarks` depend on downstream test/build layout and wrappers under `BIN_ROOT/quality/ruby/...`.
 - `specs`, coverage, and report cleanup assume downstream `test/reports/` paths.
 - Docker and certificate helper targets depend on external CLIs such as Docker, `mkcert`, `dot`, and `air` depending on the target.
-- Docker push, manifest, release, and registry-publishing targets update remote state and require explicit user permission.
+- Docker push, manifest, release, and registry-publishing targets update remote
+  state. Run them only when the current request authorizes that workflow, and
+  rely on the active agent configuration for command approval behavior.
 
 ### `git.mak`
 
 - Common helpers cover branch creation, sync, commit/PR flows, destructive cleanup, and submodule commands.
 - Treat these as convenience wrappers, not default actions.
 - Do not use targets that rewrite history, delete branches, discard changes, or push remotely unless the user explicitly asks.
-- `push`, `force`, `draft`, `pr`, `merge`, `review`, and `ready` update remote GitHub state and require explicit current-request permission.
+- `push`, `force`, `draft`, `pr`, `merge`, `review`, and `ready` update remote
+  GitHub state. Run them only when the current request authorizes that workflow,
+  and rely on the active agent configuration for command approval behavior.
 
 ## Practical Inference Rules
 

--- a/skills/references/gap-workflow.md
+++ b/skills/references/gap-workflow.md
@@ -151,9 +151,10 @@ confirmed, fixed, or remaining entries to summarize.
   delegation requirement plus runtime limitation.
 - Do not silently downgrade to local-only review or present a single-agent
   substitute as equivalent.
-- Ask for permission before local reviewers or authorized agents run network,
-  auth, SSH, registry, cloning, destructive, remote-write, or non-read-only
-  validation commands.
+- Identify whether review commands use authentication, SSH, registries,
+  cloning, pushing, publishing, remote writes, or destructive effects. Rely on
+  the active agent configuration for command approval behavior; do not add a
+  separate model-level permission request.
 
 ## Candidate Integrity
 

--- a/skills/references/gap-workflow/find-audit.md
+++ b/skills/references/gap-workflow/find-audit.md
@@ -21,9 +21,10 @@ For find, audit-only, and one-pass modes:
    `deep`, `skimmed`, `excluded`, and `deferred` coverage with exact follow-up
    scopes. A confidence closure audit may close only when every relevant slice
    is `deep` or `excluded`.
-6. Ask permission before local reviewers or authorized agents run non-read-only,
-   network, auth, remote-write, destructive, or otherwise approval-gated
-   commands.
+6. Identify whether review commands use authentication, SSH, registries,
+   cloning, pushing, publishing, remote writes, or destructive effects. Rely on
+   the active agent configuration for command approval behavior; do not add a
+   separate model-level permission request.
 7. Apply the shared gap-workflow delegation gate before review work.
 8. Wait for review work, update coverage for every slice, and deduplicate or
    directly re-check conflicting candidates.

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -32,7 +32,10 @@ to documentation instead.
    - `references/skills.md` for skill descriptions, bundled scripts/assets, permissions, prompt-injection risk, or external skill adoption.
    - `references/shared.md` for cross-language repositories, dependency/config audits, secrets, Docker/security scanners, and report structure.
 3. Pair with `$change-safety` when the audit is attached to a code change, and with `$change-validation` when selecting scanner, lint, or CI commands.
-4. Ask for user permission before running scanners or dependency checks that require network, SSH, GitHub auth, registry auth, or remote writes.
+4. Identify whether scanners or dependency checks require network, SSH, GitHub
+   auth, registry auth, or remote writes. Rely on the active agent
+   configuration for command approval behavior; do not add a separate
+   model-level permission request.
 5. Inspect concrete data/control flow before reporting a risk. Prefer file and line references over general advice.
 6. When a candidate depends on prose contradicting implementation, first prove the implementation is insecure or wrong with non-prose evidence. If current code, tests, runtime behavior, scanner output, or history support the implementation, do not report a security finding; use `$doc-gaps` for the stale prose.
 7. Report exploitable findings first.

--- a/skills/security-audit/references/shared.md
+++ b/skills/security-audit/references/shared.md
@@ -44,7 +44,10 @@ For each security-sensitive slice, trace concrete sources to concrete sinks:
 ## Validation
 
 - Prefer repository-defined targets before ad hoc scanners.
-- Ask for permission before running scanners or dependency checks that need network, SSH, GitHub auth, registry auth, or remote writes.
+- Identify scanners or dependency checks that need network, SSH, GitHub auth,
+  registry auth, or remote writes. Rely on the active agent configuration for
+  command approval behavior; do not add a separate model-level permission
+  request.
 - In this repository, relevant checks include:
   - `make sec` for Trivy repository scanning.
   - `make scripts-lint` for ShellCheck coverage of shared scripts.


### PR DESCRIPTION
## What

- Remove model-level command permission prompts from shared validation, gap, feature, security, and workflow guidance, deferring runtime approval behavior to the active Claude or Codex configuration.
- Preserve current-request task scope and workflow authorization boundaries, and align the README and project-workflow references with the config-owned approval model.

## Why

- Prevent agents from pausing for read-only network-backed validation because of duplicated skill-level approval gates, while keeping runtime guardrails and explicit scope boundaries clear for downstream repositories.

## Testing

- `make skills-lint` - passed; skill metadata and shared policy markers validated.
- `git diff --check` - passed; no whitespace errors.
- `make sec` - passed; Trivy reported zero vulnerabilities in `Gemfile.lock` and no secrets.
- Claude Code reviewed the current symlinked policy/config wiring and found no stale command-level permission wording.
- `make lint` and `make scripts-lint` were not run because this change only touches Markdown policy/configuration guidance and skill references; `make skills-lint` is the targeted repository check.
