### PR TITLE
feat(skills): correct stale circleci endpoint, metric, and command facts in references

### DIFF
--- a/skills/change-validation/references/check-selection.md
+++ b/skills/change-validation/references/check-selection.md
@@ -101,7 +101,7 @@ For standalone validation reports, use exactly this Markdown structure and do no
 - If the repository exposes named test entry points, use the one that matches the affected behavior instead of inventing a different test vocabulary.
 - If the repository exposes benchmark or coverage targets that are relevant to the change, prefer those entry points over ad hoc commands.
 - If a repo exposes `dep`, `lint`, `specs`, `features`, `benchmarks`, `coverage`, or `sec`, prefer those names over ad hoc tool invocations.
-- For this shared `bin` repo itself, CI currently runs `make dep`, `make clean-dep`, `make scripts-lint`, `make skills-lint`, `make docker-lint`, `make lint`, and `make sec`.
+- For this shared `bin` repo itself, CI's build validation steps run `make dep`, `make clean-dep`, `make scripts-lint`, `make skills-lint`, `make docker-lint`, `make lint`, and `make sec`.
 - Dependency setup, scanners, Docker commands, Buf commands, and Go module commands may require network access; identify that before relying on them.
 - Push, publish, release, Docker manifest push, Buf push, and PR open/update
   flows update remote state. Run them only when the current request authorizes

--- a/skills/project-workflow/references/make-fragments.md
+++ b/skills/project-workflow/references/make-fragments.md
@@ -42,7 +42,7 @@ Use this reference after you have identified which shared `bin/build/make/*.mak`
 ### `buf.mak`
 
 - Especially relevant targets: `lint`, `fix-lint`, `format`, `generate`, `stale`, `breaking`, `push`, `update-all-dep`.
-- `breaking` compares against `https://github.com/alexfalkowski/$(NAME).git#branch=master`, so branch and remote assumptions matter.
+- `breaking` compares against `https://github.com/alexfalkowski/$(NAME).git#branch=master,subdir=api`, so branch, remote, and subdir assumptions matter.
 - `generate`, `stale`, and `push` depend on the consuming repository's Buf configuration.
 - `stale` runs `buf generate` from the Buf module directory that included the fragment, then runs `git diff --exit-code`; Git checks the whole worktree, so generated outputs outside that child directory are still detected.
 - `push` updates remote state. Run it only when the current request authorizes

--- a/skills/repo-health/SKILL.md
+++ b/skills/repo-health/SKILL.md
@@ -21,7 +21,8 @@ reporting period and comparison period, not necessarily a local folder.
    - Default to the current working repository when the user does not name one.
    - Default to weekly summary for the last complete 7 days when no period is
      provided.
-   - Use the local timezone unless the user specifies another timezone.
+   - Use the local timezone (via `TZ`) unless the user specifies another; the
+     collector falls back to `Europe/Berlin` when `TZ` is unset.
    - Compare weekly summaries with the preceding 7 days; compare daily summaries
      with the preceding 24 hours or preceding calendar day, matching the
      requested window.

--- a/skills/repo-health/references/sources.md
+++ b/skills/repo-health/references/sources.md
@@ -143,13 +143,15 @@ Useful read-only API pattern:
    failures.
 5. Calculate workflow duration from `created_at` to `stopped_at`.
 6. Check flaky tests with
-   `/api/v2/insights/gh/<owner>/<repo>/flaky-tests?branch=<branch>`.
+   `/api/v2/insights/gh/<owner>/<repo>/flaky-tests` (branch-agnostic; the
+   endpoint takes no branch parameter).
 7. For service repos, collect job-level data with
    `/api/v2/workflow/<workflow-id>/job` and report deploy health from jobs named
    `deploy` rather than inferring deploys from tags alone.
 
-Use a successful completed workflow count as the denominator for success rate
-only after excluding running, on-hold, and not-run workflows.
+Use the completed workflow count — workflows with a `stopped_at` timestamp,
+excluding `running`, `on_hold`, and `not_run` — as the denominator for success
+rate; the numerator is the count with status `success`.
 Report releases/tags separately from successful deploy jobs when both exist.
 When `max_auto_reruns` is configured, state that CircleCI workflow totals are
 API-visible completed workflow records after rerun behavior, not necessarily
@@ -191,7 +193,7 @@ Common environment variables:
 
 - `UPTIMEROBOT_API_KEY`
 - `UPTIMEROBOT_MONITOR_IDS`
-- `UPTIMEROBOT_STATUS_PAGE_URL`
+- `UPTIMEROBOT_STATUS_PAGE_URL` (manual status-page source; not read by the collector)
 
 Prefer sources in this order:
 

--- a/skills/repo-health/scripts/collect.rb
+++ b/skills/repo-health/scripts/collect.rb
@@ -239,7 +239,7 @@ class RepoHealthCollector
     pipelines = circleci_pipelines(owner_repo, branch, token)
     workflows = circleci_workflows(pipelines, token)
     jobs = @include_jobs || mode == 'service' ? circleci_jobs(workflows, token) : []
-    flaky = circleci_get("/insights/gh/#{owner_repo}/flaky-tests?branch=#{url_query(branch)}", token)
+    flaky = circleci_get("/insights/gh/#{owner_repo}/flaky-tests", token)
     trend = period_windows.map { |window| circleci_period(workflows, jobs, window.fetch(:start), window.fetch(:end)) }
 
     {


### PR DESCRIPTION
## What

- Correct stale, wrong, or misleading concrete facts in four command-referencing skills' references, surfaced by a staleness audit and an independent Codex review.
- `repo-health`: stop sending an unsupported `?branch=` query parameter to CircleCI's flaky-tests endpoint (the endpoint is branch-agnostic and ignored it), and document it as such; the change is behavior-neutral against the live API.
- `repo-health`: fix the success-rate denominator prose in `sources.md` so it matches the collector and `metrics.md` — completed workflows (with a `stopped_at` timestamp, excluding `running`, `on_hold`, `not_run`) as the denominator, with `success` as the numerator.
- `repo-health`: state the `TZ`→`Europe/Berlin` fallback in `SKILL.md` (the collector does not use the OS-local zone when `TZ` is unset), and mark `UPTIMEROBOT_STATUS_PAGE_URL` as a manual status-page source not read by the collector.
- `project-workflow`: complete the buf `breaking` comparison URL with the behavior-critical `,subdir=api` present in `build/make/buf.mak`.
- `change-validation`: scope the shared-`bin` CI list to "build validation steps" since CI also runs non-validation goals (`source-key`, `sync push`).
- Intentional non-goals: no skill rules were removed; `.source-key` as a downstream cache input and the undocumented `--target`/`--pipeline-id` diagnose flags were both investigated and confirmed correct, so they are left unchanged.

## Why

- These skills document the exact commands, endpoints, and thresholds agents act on, so a stale or wrong fact silently misleads rather than failing loudly. The flaky-tests `?branch=` implied per-branch scoping that CircleCI never applied (verified against the live API v2 docs), the denominator prose contradicted the implemented calculation, the buf URL omitted the subdir the target actually compares, and the timezone note promised behavior the collector does not deliver. Fixing them keeps the agent-facing reference contract trustworthy.

## Testing

- `ruby -c skills/repo-health/scripts/collect.rb` - passed
- `make skills-lint` - passed
- `make lint` - passed (6 files, no offenses)
- Independent review: Codex reviewed the full diff across two rounds plus a final confirmation (resolved, 97%); the flaky-tests branch-agnostic behavior was verified against CircleCI's live API v2 documentation.
- Not run: the collectors were not executed against live CircleCI, DigitalOcean, UptimeRobot, or Kubernetes because credentials and network to those services are unavailable here; that would validate connectivity, not documentation accuracy. CI runs the standard `bin` validation steps.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
