### PR TITLE
feat(skills): add sibling-checkout and gh fallback to diagnose-issue evidence rules

### DIFF
--- a/skills/diagnose-issue/SKILL.md
+++ b/skills/diagnose-issue/SKILL.md
@@ -54,6 +54,17 @@ folder.
   timestamp evidence over broad health summaries.
 - If evidence is missing because credentials, CLIs, or mappings are unavailable,
   report that as a data gap and provide the next best local diagnostic step.
+- Before treating a related or upstream repository as unavailable, check
+  whether it exists as a sibling checkout (e.g. `../<repo-name>` relative to
+  the current repo root) and read it locally first. If no local checkout
+  exists, derive `<owner>` from the current repo's own origin remote (`git
+  remote get-url origin`, taking the account/org segment) and assume sibling
+  repositories share that owner unless local evidence says otherwise, then
+  fall back to read-only `gh` access before concluding the evidence is
+  unavailable: `gh repo clone <owner>/<repo> <scratch-dir> -- --depth 1` when
+  several files need exploring, or
+  `gh api repos/<owner>/<repo>/contents/<path>` to fetch one known file
+  directly. Only report a cross-repo data gap after both checks fail.
 
 ## References
 


### PR DESCRIPTION
## What

- Add a bullet to `diagnose-issue`'s Evidence Rules: before treating a related or upstream repository as unavailable, check for a sibling checkout (`../<repo-name>`) and read it locally first.
- If no local checkout exists, derive `<owner>` from the current repo's own `origin` remote and fall back to read-only `gh repo clone --depth 1` (for exploring several files) or `gh api repos/<owner>/<repo>/contents/<path>` (for one known file) before concluding the evidence is unavailable.
- Kept fully generic: no hardcoded repo or org names, since different consumers of this shared skill have different repo layouts.

## Why

- A real diagnosis in a consuming repo reported "no access to app X's CI" as a data gap when the answer was fully available one directory up: a sibling repo's Docker-based release image pinned an internal tool to a stale version, discoverable only by reading that sibling repo's files.
- Without this reminder, agents jump straight to reporting a cross-repo data gap instead of checking cheap, already-available local or read-only remote evidence, understating what the diagnosis actually covered.

## Testing

- `make skills-lint` - passed
- `$code-review` - no findings; documentation-only change, internally consistent with the existing read-only Evidence Rules constraint.
- Not run: no live diagnosis exercised this new bullet end-to-end, since it only changes agent-facing guidance text, not executable code.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
