### PR TITLE
feat(claude): add read permission for the go module cache

### DIFF
--- a/build/claude/settings.json
+++ b/build/claude/settings.json
@@ -43,6 +43,7 @@
       "Read(//private/tmp/**)",
       "Read(//var/tmp/**)",
       "Read(//var/folders/**)",
+      "Read(~/go/pkg/mod/**)",
       "Edit(//tmp/**)",
       "Edit(//private/tmp/**)",
       "Edit(//var/tmp/**)",


### PR DESCRIPTION
## What

- Add `Read(~/go/pkg/mod/**)` to `permissions.allow` in `build/claude/settings.json`, the shared Claude Code profile that downstream repos symlink to as `.claude/settings.json`.
- Reads under the Go module cache no longer trigger a permission prompt.

## Why

- `sandbox.filesystem.allowWrite` already lists `~/go/pkg/mod` for writes, but `permissions.allow` had no matching `Read` rule, so every read of Go dependency source under that path (a normal step during Go review or debugging) triggered an avoidable permission prompt.
- `build/codex/config.toml` already grants `"~/go/pkg/mod" = "write"`, and Codex's model treats write as implying read, so Codex never hit this gap. This change brings the Claude Code profile to parity with both Codex and Claude's own sandbox write grant.
- Read-only by design: this does not add Edit or Write rules for that path, and does not touch the separate, deliberate divergence where Codex grants host-credential reads (`~/.ssh`, `~/.aws`, `~/.config/gh`, etc.) and Claude does not.

## Testing

- `python3 -m json.tool build/claude/settings.json` - passed
- `make skills-lint` - passed
- Confirmed `.claude/settings.json` is a symlink to `../build/claude/settings.json`, so the canonical source was edited, not a copy.
- No dedicated schema or lint target validates `settings.json` permission-rule semantics; validation was scoped to JSON syntax plus the repository's existing skills/policy lint. Verified the `Read(~/...)` tilde syntax against Claude Code's official settings documentation, which documents `Read(~/.zshrc)` as a valid permission rule pattern.
