### PR TITLE
feat(claude): require approval before make targets that touch pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,11 @@ commands to the workspace while making workspace Git metadata and the standard
 Go, RuboCop, golangci-lint, and Trivy caches writable. It grants read access to
 common host credential locations, permits outbound network access, and allows
 writes to standard system temporary directories. Every `make` invocation runs
-outside the sandbox without prompting. Direct cleanup inside writable sandbox
-roots is allowed, direct recognized remote and external-system changes require
-approval, and catastrophic commands are forbidden. Root `.env` and `.env.*`
+outside the sandbox without prompting, except `make pr`, `make draft`, `make
+merge`, `make ready`, and `make review`, which stay approval-gated because
+they create, merge, or force-push a pull request. Direct cleanup inside
+writable sandbox roots is allowed, direct recognized remote and external-system
+changes require approval, and catastrophic commands are forbidden. Root `.env` and `.env.*`
 files remain protected, while nested dependency environment files and `.envrc`
 files are allowed for native dependency workflows. The active agent
 configuration provides runtime approval guardrails; `AGENTS.md` continues to
@@ -117,8 +119,9 @@ per-machine additions in `~/.codex/config.toml` and
 `~/.codex/rules/default.rules`; Codex also records accepted persistent command
 prefixes in that user rules file. Re-run `make codex-init` only when the shared
 paths move. Updates to the shared profile or rules propagate with the next
-`bin` submodule update; start a new Codex session afterward so it uses the
-updated permissions.
+`bin` submodule update; fully restart the Codex CLI process afterward, since
+Codex loads rules at process startup and a new session or prompt within an
+already-running process does not pick up the change.
 
 Codex reads `AGENTS.md` separately for repository instructions. Downstream
 repositories should still point agents at the shared instructions instead of
@@ -162,10 +165,17 @@ and external-system changes require approval, and catastrophic commands are
 forbidden. The unsandboxed escape hatch is disabled. The sandbox grants the
 standard Go, RuboCop, golangci-lint, and Trivy cache writes used by project
 commands, plus standard system temporary directories. Every `make` invocation
-is excluded from the sandbox and allowed without prompting. Built-in file edits
-stay scoped to the workspace, and the active agent configuration provides
-runtime approval guardrails while `AGENTS.md` defines task scope and workflow
-authorization.
+is excluded from the sandbox and allowed without prompting, except `make pr`,
+`make draft`, `make merge`, `make ready`, and `make review`, which require
+approval because they create, merge, or force-push a pull request. Built-in
+file edits stay scoped to the workspace, and the active agent configuration
+provides runtime approval guardrails while `AGENTS.md` defines task scope and
+workflow authorization.
+
+Permission-baseline updates propagate with the next `bin` submodule update;
+fully restart the Claude Code process afterward, since `settings.json` is read
+at process startup and a new conversation within an already-running process
+does not pick up the change.
 
 > [!WARNING]
 > The shared baseline is only for trusted repositories. Make targets run outside

--- a/build/claude/settings.json
+++ b/build/claude/settings.json
@@ -57,6 +57,11 @@
     ],
     "ask": [
       "Bash(git push*)",
+      "Bash(make pr *)",
+      "Bash(make draft *)",
+      "Bash(make merge *)",
+      "Bash(make ready *)",
+      "Bash(make review *)",
       "Bash(gh pr create*)",
       "Bash(gh pr merge*)",
       "Bash(gh pr close*)",

--- a/build/codex/rules/default.rules
+++ b/build/codex/rules/default.rules
@@ -12,6 +12,18 @@ prefix_rule(
         "make lint",
         "make push",
         "make reset",
+    ],
+)
+
+prefix_rule(
+    pattern = ["make", ["pr", "draft", "merge", "ready", "review"]],
+    decision = "prompt",
+    justification = "These targets create, merge, or force-push a pull request on GitHub even though they run through make; the engine resolves overlapping rules by strictest decision, not declaration order.",
+    match = [
+        "make pr",
+        "make draft",
+        "make merge",
+        "make ready",
         "make review",
     ],
 )

--- a/skills/project-workflow/references/agent-init.md
+++ b/skills/project-workflow/references/agent-init.md
@@ -23,9 +23,12 @@ The shared profile extends `:workspace`, makes workspace Git metadata and
 standard Go, RuboCop, golangci-lint, and Trivy caches writable, grants read
 access to common host credential locations, allows writes to standard system
 temporary directories, and allows outbound network access. Every `make`
-invocation is allowed outside the sandbox without prompting; cleanup inside
-writable roots is prompt-free, direct remote and external-service commands
-remain approval-gated, and catastrophic commands remain forbidden. Root `.env`
+invocation is allowed outside the sandbox without prompting, except `make
+pr`, `make draft`, `make merge`, `make ready`, and `make review`, which
+remain approval-gated because they create, merge, or force-push a pull
+request; cleanup inside writable roots is prompt-free, direct remote and
+external-service commands remain approval-gated, and catastrophic commands
+remain forbidden. Root `.env`
 and `.env.*` files remain protected, while nested dependency environment files
 and `.envrc` files are allowed for native dependency workflows. The shared
 rules provide runtime approval guardrails, while `AGENTS.md` defines task scope
@@ -52,7 +55,9 @@ commands plus standard system temporary directories, and allows unrestricted
 outbound network access to match the Codex profile, with macOS `trustd` access
 enabled so Go-based CLI tools (`gh`, `gcloud`, `terraform`) can verify TLS
 through the sandbox network proxy. Every `make` invocation is excluded from the
-sandbox and allowed without prompting. Built-in file reads and edits are scoped
+sandbox and allowed without prompting, except `make pr`, `make draft`, `make
+merge`, `make ready`, and `make review`, which require approval because they
+create, merge, or force-push a pull request. Built-in file reads and edits are scoped
 to the workspace plus the standard system temporary directories (`/tmp`,
 `/private/tmp`, `/var/tmp`, `/var/folders`), which are readable and writable
 without prompting. Per-repo or per-machine permission tweaks belong in the


### PR DESCRIPTION
## What

- Add an approval gate for `make pr`, `make draft`, `make merge`, `make ready`, and `make review` on both the Claude Code (`build/claude/settings.json`) and Codex (`build/codex/rules/default.rules`) permission profiles, since these targets create, merge, or force-push a pull request even though `make` itself runs unsandboxed and unprompted.
- Write the Claude Code `ask` patterns with a trailing wildcard (`Bash(make review *)`, etc.) so the rule also matches real invocations that pass arguments, such as `make review cleanup_desc_file=true msg="..." desc_file="..."`, not just the bare form; a literal pattern with no wildcard only matches that exact command string.
- Update `README.md` and `skills/project-workflow/references/agent-init.md` to document the exception, and correct the propagation guidance: a full CLI process restart is required for permission and rule changes to take effect, not just a new session or conversation inside an already-running process.

## Why

- Every `make` invocation previously ran outside the sandbox and without prompting on both tools, which silently bypassed the `ask`/`prompt` rules already in place for `gh pr create`/`gh pr merge`, because those commands run inside a Makefile recipe rather than directly. That let `make ready`/`make review`/`make merge` complete a commit, force-push, and PR merge with no human confirmation.
- Without this gate, an unattended or scheduled agent run, or a prompt-injected instruction, could reach a real GitHub merge with nobody in the loop; the gate fails safe there, since there is no one to answer the prompt.
- The propagation-timing correction reflects a real gap found while verifying this change: the fix appeared to silently fail in an already-running session and only worked after a full process restart, so the docs now say that explicitly instead of the previous "start a new session" wording, which undersold what's actually required.

## Testing

- `python3 -c "import json; json.load(open('build/claude/settings.json'))"` - passed (settings.json stays valid JSON).
- `make skills-lint` - passed.
- Manually verified end-to-end in fresh, fully-restarted sessions of both Claude Code and Codex: `make merge` and `make ready` now prompt for approval before executing, while `make lint` and `make status` continue to run without a prompt.
- No repository-defined linter validates `build/codex/rules/default.rules` syntax; correctness was confirmed via live runtime behavior in Codex (its own `codex execpolicy check` output and the actual approval prompt), not a repository check.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
