### PR TITLE
feat(skills): guide sub-agent model tier and context by sub-task

### DIFF
--- a/skills/references/gap-workflow.md
+++ b/skills/references/gap-workflow.md
@@ -151,6 +151,18 @@ confirmed, fixed, or remaining entries to summarize.
   delegation requirement plus runtime limitation.
 - Do not silently downgrade to local-only review or present a single-agent
   substitute as equivalent.
+- When the runtime supports per-sub-agent model selection, match the model to
+  the sub-task: use a cheaper or faster model for mechanical, disjoint, or
+  read-only sub-agents such as search, file discovery, and reproduction, and
+  reserve the strongest model for synthesis, acceptance and confidence
+  judgment, and adversarial verification. This does not change when sub-agents
+  are authorized and does not lower any evidence, confidence, or challenge gate;
+  if a cheaper model cannot reach the required evidence, escalate the model
+  instead of accepting the weaker result.
+- Brief each sub-agent with the minimum references and context its sub-task
+  needs, including all mandatory instructions and current evidence for that
+  slice, rather than the full skill reference chain, so parallel sub-agents
+  stay cheaper.
 - Identify whether review commands use authentication, SSH, registries,
   cloning, pushing, publishing, remote writes, or destructive effects. Rely on
   the active agent configuration for command approval behavior; do not add a


### PR DESCRIPTION
## What

- Add two rules to the shared gap-workflow delegation policy governing how authorized sub-agents are run: match the model tier to the sub-task (cheaper/faster model for mechanical, disjoint, or read-only sub-agents; strongest model reserved for synthesis, the acceptance/confidence gate, and adversarial verification), and brief each sub-agent with the minimum references and context its slice needs while still carrying all mandatory instructions and current evidence.
- Scope is intentionally narrow: this reference is read only by the six gap skills (code-issues, doc-gaps, feature-gaps, project-gaps, reliability-gaps, test-gaps), so the policy does not touch review-pr, code-review, or security-audit sub-agents. The change is additive prose with no public command, configuration, or API surface, and consumers that vendor `./bin` are unaffected until they bump the pinned submodule.
- The rules explicitly do not change when sub-agents are authorized and do not lower any evidence, confidence, or challenge gate; a cheaper model that cannot reach the required evidence must be escalated rather than accepted.

## Why

Claude Code `/status` usage insights showed sub-agent-heavy sessions dominate token usage and concentrate in the gap skills, where every authorized sub-agent currently inherits the top model tier and can carry the full reference chain regardless of how mechanical its task is. This policy directs cheaper tiers and leaner context for the low-value work while preserving strong-model judgment where correctness matters. It is deliberately an enabler, not a cost reduction on its own: the savings only materialize once the runtime tiered-agent definitions exist (`.claude/agents/*.md` model, Codex `.codex/agents/*.toml`) and escalations are measured against `/status`, which is tracked as a follow-up.

## Testing

- `make skills-lint` - passed
- `git diff --check` - passed (no whitespace errors)
- No executable test covers a workflow policy document; the change was independently reviewed by Codex across correctness, gate safety, tool-agnosticism, runtime feasibility, chokepoint selection, downstream compatibility, and validation (verdict: safe to commit).

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
