### PR TITLE
feat(skills): dedupe feature-gap acceptance criteria and require explicit sub-agent model selection

### DIFF
--- a/skills/feature-gaps/references/find-rules.md
+++ b/skills/feature-gaps/references/find-rules.md
@@ -26,28 +26,20 @@ These rules remain mandatory:
   and `$project-workflow` to route test-harness, build, CI, Makefile, release,
   validation, command-discovery, or repository-workflow candidates away from
   `FEATURES.md` before returning feature proposals.
-- Confirm each candidate feature against the acceptance gate, code, generated
+- Confirm each candidate feature against `acceptance-gate.md`, code, generated
   surfaces, framework wrappers, shared helpers, vendored dependency behavior
   when delegated, docs, tests, examples, command behavior, current
-  architecture, and available comparable-tool evidence before recording it. Try
-  to disprove the candidate by asking whether the workflow is already
-  supported, whether the repository owns the behavior, whether the likely
-  audience exists, whether existing product surfaces already cover enough of the
-  workflow, whether the residual gap is still meaningful after that coverage,
-  whether the operation is common enough for the audience, and whether the
-  feature can be added incrementally using local patterns.
+  architecture, and available comparable-tool evidence before recording it.
+  Use the gate's questions to try to disprove the candidate before recording
+  it.
 - When sub-agents are authorized and candidate volume justifies delegation,
   assign at least one disprover slice when practical. The disprover should look
   for existing APIs, commands, endpoints, health/metrics, generated contracts,
   docs, examples, tests, shared helpers, framework behavior, or workflow routing
   that already covers each proposed feature, and should try to route weak leads
   to another gap workflow or optional follow-up.
-- Record feature gaps only when the proposal names the audience, current
-  product workflow limitation, existing coverage, residual gap, practical
-  audience benefit, common-operation evidence, repository-owned product surface,
-  evidence of user, operator, service-author, package-consumer, CLI, API, or
-  library value, fit with existing patterns, smallest plausible implementation
-  path, compatibility risk, and validation path.
+- Record feature gaps only when the proposal satisfies every item in
+  `acceptance-gate.md`.
 - Do not record confirmed bugs, security issues, compatibility breaks,
   reliability gaps, missing tests, test-harness quality issues, stale docs,
   project workflow gaps, or unclear naming as feature gaps. Route them to

--- a/skills/references/gap-workflow.md
+++ b/skills/references/gap-workflow.md
@@ -159,6 +159,14 @@ confirmed, fixed, or remaining entries to summarize.
   are authorized and does not lower any evidence, confidence, or challenge gate;
   if a cheaper model cannot reach the required evidence, escalate the model
   instead of accepting the weaker result.
+- When the active runtime supports per-agent model selection, set the model
+  explicitly for mechanical, disjoint, or read-only sub-tasks such as lookup,
+  file discovery, lead generation, and non-mutating reproduction; an unset
+  model silently inherits the parent session's model and defeats this
+  section's cost intent. When a lighter read-only agent type is available and
+  sufficient, prefer it over a full-toolset general-purpose agent. This
+  changes only agent selection; it never relaxes scope, evidence,
+  reproduction, confidence, challenge, or approval requirements.
 - Brief each sub-agent with the minimum references and context its sub-task
   needs, including all mandatory instructions and current evidence for that
   slice, rather than the full skill reference chain, so parallel sub-agents


### PR DESCRIPTION
## What

- `skills/feature-gaps/references/find-rules.md` no longer restates the full acceptance-gate criteria list; its two candidate-confirmation bullets now point to `acceptance-gate.md` as the single source, with every criterion (audience, current limitation, existing coverage, residual gap, benefit, common operation, repository ownership, evidence, repository fit, smallest useful version, compatibility/maintenance, validation path) still fully present there.
- `skills/references/gap-workflow.md`'s shared Delegation And Permissions section, used by all six gap skills (code-issues, test-gaps, doc-gaps, project-gaps, reliability-gaps, feature-gaps), adds an instruction to explicitly set a sub-agent's model for mechanical, disjoint, or read-only sub-tasks and to prefer a lighter read-only agent type over a full-toolset general-purpose agent, conditioned on the runtime supporting per-agent model selection. The new bullet states explicitly that it never relaxes scope, evidence, reproduction, confidence, challenge, or approval requirements.
- No executable code changed; both edits are to Markdown skill-reference files only.

## Why

- The duplicated acceptance criteria in `find-rules.md` and `acceptance-gate.md` could drift out of sync as either file changed independently; consolidating to one source removes that maintenance risk.
- A measured audit of local Claude Code transcripts found 92/92 sampled sub-agent (`Agent` tool) calls inside code-issues/feature-gaps sessions left the model unset, silently inheriting the parent session's most expensive default model tier, and 85% used the full-toolset `general-purpose` agent type even for read-only lookup/reproduction work. The existing delegation guidance already recommended cheaper models for this kind of sub-task but wasn't specific enough to change behavior; this makes the instruction concrete and actionable across all six gap skills that share this reference, not just the two audited here.

## Testing

- `make skills-lint` - passed
- No Ruby, Go, shell, or Docker files changed, so `make lint`, `make scripts-lint`, and `make docker-lint` do not apply to this change.
- Independently verified in two rounds by Codex: confirmed every removed `find-rules.md` criterion remains covered in `acceptance-gate.md`, confirmed the `gap-workflow.md` change is purely additive with no existing evidence/confidence/challenge/approval requirement removed or altered, caught and required fixing a broken sibling-file reference path and an unconditional model-selection wording issue in the first round, and confirmed both fixes on a second pass with 97% final confidence and no remaining concerns.
- Gap: this change only affects future agent behavior (instruction text, not code), so there is no automated test that exercises whether sub-agents actually set a model override going forward; that can only be confirmed by auditing future session transcripts the same way the original gap was found.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
