### PR TITLE
feat(skills): close silent model inheritance gap in delegated review

### DIFF
--- a/skills/code-issues/references/plan.md
+++ b/skills/code-issues/references/plan.md
@@ -12,21 +12,30 @@ state, code/security/compatibility evidence, and public contract evidence.
 
 1. Follow `../../references/gap-workflow.md#common-plan-mechanics` for shared
    find-mode sequencing. Apply the shared gap-workflow delegation gate before review work.
-2. Use `ISSUES.md` as the scoped ledger and `ISSUE-<number>` IDs.
-3. Run `$project-workflow` discovery and the shared audit preflight, including
+2. Before spawning slice reviewers, assign each an explicit model by risk
+   class: a cheaper tier for lower-judgment slices such as configuration
+   parsing, test-support/fixtures, and file-tracing, and the strongest tier
+   for high-judgment slices such as crypto/token, concurrency/proxy, and
+   security-sensitive code, unless the finder-plus-verifier exception in
+   `../../references/gap-workflow.md#delegation-and-permissions` applies.
+   Prefer a read-only agent type when one is available, because Find-mode
+   reviewers do not edit. Never leave a sub-agent's model unset; an unset
+   model silently inherits the session model.
+3. Use `ISSUES.md` as the scoped ledger and `ISSUE-<number>` IDs.
+4. Run `$project-workflow` discovery and the shared audit preflight, including
    applicable tools, service dependencies, validation ladder, and command
    failure classification.
-4. Read `../../references/gap-lead-generation.md`, classify the repository
+5. Read `../../references/gap-lead-generation.md`, classify the repository
    archetype, and build a lead inventory for code, compatibility, security,
    mapping, generated-contract, and supported-usage risks in scope.
-5. Inventory tests, public entrypoints, security-sensitive surfaces, supported
+6. Inventory tests, public entrypoints, security-sensitive surfaces, supported
    construction/wiring paths, generated/provider mappings, and repository policy
    exclusions relevant to the requested scope.
-6. Confirm each finding is a concrete code issue, security issue,
+7. Confirm each finding is a concrete code issue, security issue,
    compatibility break, or public contract violation. For prose mismatches,
    prove implementation is wrong with non-prose evidence; otherwise route to a
    documentation gap.
-7. Before a no-issue closeout, name the public APIs, constructors, exported
+8. Before a no-issue closeout, name the public APIs, constructors, exported
    helpers, supported DI or documented usage paths, real call sites,
    nil/error/edge behavior, tests or CI evidence, and policy exclusions
    checked, plus rejected, routed, deferred, and blocked leads. For
@@ -34,14 +43,14 @@ state, code/security/compatibility evidence, and public contract evidence.
    as parser/decoder behavior, serialization, boundary/default values,
    nil/error/panic paths, concurrency, resource limits, mapping drift, public
    API compatibility, and supported construction paths.
-8. If representative fuzz, property, race, stress, fixture, integration,
+9. If representative fuzz, property, race, stress, fixture, integration,
    analyzer, or generated freshness evidence is missing for a relevant class,
    report it as a confidence limiter or route it to the right workflow; do not
    record it as a code issue unless a concrete bug or violated contract is
    confirmed.
-9. If confirmed issues remain, write scoped `ISSUES.md`, present the ledger,
-   coverage state, proposed fix plan, and runnable follow-up scopes, then stop
-   before fixing.
+10. If confirmed issues remain, write scoped `ISSUES.md`, present the ledger,
+    coverage state, proposed fix plan, and runnable follow-up scopes, then stop
+    before fixing.
 
 ## Implement Mode Plan
 

--- a/skills/references/gap-workflow.md
+++ b/skills/references/gap-workflow.md
@@ -155,10 +155,16 @@ confirmed, fixed, or remaining entries to summarize.
   the sub-task: use a cheaper or faster model for mechanical, disjoint, or
   read-only sub-agents such as search, file discovery, and reproduction, and
   reserve the strongest model for synthesis, acceptance and confidence
-  judgment, and adversarial verification. This does not change when sub-agents
-  are authorized and does not lower any evidence, confidence, or challenge gate;
-  if a cheaper model cannot reach the required evidence, escalate the model
-  instead of accepting the weaker result.
+  judgment, and adversarial verification. In a finder-plus-verifier pattern,
+  where a strong orchestrator or a dedicated verifier independently
+  re-verifies each delegated finding, the delegated review finders may also
+  run one tier cheaper than the session model even when their sub-task is
+  judgment-heavy, such as a slice-scoped `$code-review` or `$security-audit`;
+  reserve the strongest tier for that final acceptance, confidence, and
+  adversarial-verification pass, not for every finder. This does not change
+  when sub-agents are authorized and does not lower any evidence, confidence,
+  or challenge gate; if a cheaper model cannot reach the required evidence,
+  escalate the model instead of accepting the weaker result.
 - When the active runtime supports per-agent model selection, set the model
   explicitly for mechanical, disjoint, or read-only sub-tasks such as lookup,
   file discovery, lead generation, and non-mutating reproduction; an unset


### PR DESCRIPTION
## What

- Extends the shared gap-workflow delegation guidance (`skills/references/gap-workflow.md`) with a finder-plus-verifier exception: delegated review finders may run one tier cheaper than the session model, even for judgment-heavy review work, when a strong orchestrator or dedicated verifier independently re-verifies each finding; the strongest tier is reserved for the final acceptance, confidence, and adversarial-verification pass, not every finder.
- Adds a concrete pre-delegation checklist step to `$code-issues`'s Find Mode Plan (`skills/code-issues/references/plan.md`) requiring explicit per-slice model assignment by risk class, a read-only agent type since Find-mode reviewers never edit, and never leaving a sub-agent's model unset. For high-judgment/security-sensitive slices, the step defers to the shared exception above via a link instead of restating it.
- Scoped intentionally to `code-issues` only; the other five gap skills that share `gap-workflow.md` (test-gaps, doc-gaps, feature-gaps, project-gaps, reliability-gaps) still rely on the generic shared bullet with no per-skill checklist mirror — this is a deliberate boundary, not an oversight, to avoid duplicating the same prose six times.
- No change to `skills/code-issues/references/find-rules.md` or `skills/code-issues/agents/openai.yaml`; both were checked and confirmed unaffected (no trigger, scope, prompt, or user-facing behavior change).

## Why

- A downstream `$code-issues` Find-mode run spawned six review sub-agents with no model set; all six silently inherited the parent session's most expensive model even though the orchestrator independently re-verified every finding afterward — exactly the case where a cheaper tier was safe to use.
- The prior shared guidance didn't address this finder-plus-verifier cost model, so operators had no documented basis for using a cheaper tier on judgment-heavy delegated review and defaulted to the expensive session model on every sub-agent. This closes that gap without lowering any evidence, confidence, challenge, or approval requirement — a cheaper model that can't meet the evidence bar must still escalate rather than accept a weaker result.

## Testing

- `make skills-lint` - passed
- `git diff --check` - passed
- Two independent Codex review rounds and one independent Claude sub-agent review (fresh-review gate) of this diff found no remaining issues. The second Codex round caught and fixed a real ambiguity where the new `plan.md` step's "strongest tier for security-sensitive slices" conflicted with the shared finder-plus-verifier exception; resolved by having the step defer to the shared exception via a link rather than duplicating it.
- Not yet verified against live agent behavior: this is a prose/instruction change, so whether a future `$code-issues` run actually sets an explicit model on its delegated sub-agents depends on that session reading and following this guidance. A live verification run is planned separately and is not a blocker for this PR.
