### PR TITLE
feat(claude): warn against manually backgrounding long-lived sandboxed processes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,6 +286,15 @@ Do not infer the test language from the implementation language alone.
 - After a repository-defined command fails, classify the failure before retrying.
   Do not replace a failed target with an ad hoc command, alternate layer, or
   alternate tool just to make progress.
+- Do not manually background a long-lived process with a bare `&`/`nohup`
+  expecting to stop it from a later command; each assistant's sandbox handles
+  signal delivery differently, and a mishandled one can leak or interfere
+  with subsequent runs. If the active assistant exposes a documented,
+  verified tracked background-task mechanism, use it; otherwise keep process
+  startup, use, and cleanup within one tool call — see
+  `skills/project-workflow/references/agent-init.md` for the exact per-assistant
+  behavior.
+
 ## Local contracts
 
 - Public shared surfaces live in `build/make/`, `build/docker/`, `build/go/`,

--- a/skills/project-workflow/references/agent-init.md
+++ b/skills/project-workflow/references/agent-init.md
@@ -67,3 +67,50 @@ to the workspace plus the standard system temporary directories (`/tmp`,
 without prompting. Per-repo or per-machine permission tweaks belong in the
 gitignored `.claude/settings.local.json`, which Claude Code merges over the
 baseline.
+
+## Background process lifecycle and signal handling
+
+Manually backgrounding a long-lived process (a bare `&`/`nohup`, for example
+to debug a dev or test server) that outlives the tool call that started it
+behaves differently under each assistant's sandbox; do not assume one
+generalizes to the other.
+
+### Claude Code
+
+The sandbox denies real signal delivery from a bare Bash command against any
+process that outlived the tool call that spawned it, even one owned by the
+same user — `kill`, `kill -0`, `kill -9`, and `kill -1` all fail with
+"operation not permitted"; there is no cross-call existence check either.
+Signals only work within the same tool call, against the current shell or a
+child it just spawned. A process backgrounded with a bare `&`/`nohup`
+therefore cannot be inspected or stopped once the tool call that started it
+returns: it leaks, holds its port, and blocks subsequent runs until a human
+kills it from outside the sandbox. Use the Bash tool's `run_in_background`
+option instead, and stop the resulting task with the matching background-task
+stop tool keyed by that task's ID; this does not hit the signal restriction.
+One test spawning a parent process with a grandchild TCP listener observed
+the stop call killing both, but that is a single observation, not a confirmed
+guarantee across sandbox versions or configurations.
+
+### Codex
+
+Repeated probes in this runtime observed a tool-call-boundary difference:
+`kill`/`kill -0` against a self-backgrounded process succeeds in the same
+tool call that spawned it, while a later, separate tool call received
+"operation not permitted" for both the recorded PID and its process group.
+This is observed runtime behavior, not a confirmed general Codex property; it
+may vary by version, sandbox configuration, or runtime, so treat cross-call
+signal delivery as unreliable. A pidfile plus process group is not a safe
+substitute: `setsid` may be unavailable, and a nonzero `kill -0` result alone
+cannot establish cleanup in a later call, since it can mean "operation not
+permitted" rather than "no such process." Same-call cleanup can remove a
+parent and ordinary forked children that remain in an explicitly managed
+process group when the cleanup mechanism is verified to signal that group,
+but does not guarantee cleanup of a descendant that creates its own session
+or process group (for example via `setsid`). The
+`exec_command`/`unified_exec` tool has no documented parameter to background a
+command and later terminate it. The CLI-level `/ps` and `/stop` commands are
+documented, but are not confirmed working or descendant-tree-safe by testing
+in this runtime. Do not manually start a process that needs to survive beyond
+the current tool call; for bounded helpers, keep startup, use, and cleanup
+within one call where possible.


### PR DESCRIPTION
## What

- Adds an `AGENTS.md` rule instructing agents not to manually background a long-lived process with a bare `&`/`nohup` expecting to stop it from a later command, and points to a new reference for the exact per-assistant behavior.
- Adds a "Background process lifecycle and signal handling" section to `skills/project-workflow/references/agent-init.md` documenting how the Claude Code and Codex sandboxes each handle signals against a process that outlives the tool call that spawned it, and what to do instead: Claude Code's `run_in_background` plus its matching background-task stop tool, and Codex's same-call-only cleanup discipline.

## Why

- Agents commonly try to background a dev/test server with a bare `&`, record its PID, then kill it from a later, separate command. In the Claude Code sandbox that PID is completely unreachable once the originating tool call returns — no signal, including `kill -0`, gets through — so the process leaks, can hold a port, and blocks subsequent runs until a human kills it from outside the sandbox. This documents that boundary accurately so agents pick the supported mechanism instead of a pattern that silently fails.
- An earlier draft of this section claimed `kill -0` succeeds as a cross-call existence check. Direct testing during review showed that claim was wrong: `kill -0` fails identically to `kill`, `kill -9`, and `kill -1` once the tool call boundary is crossed. The section now states the accurate, verified behavior instead.

## Testing

- `make skills-lint` - passed
- `npx markdownlint-cli2 AGENTS.md skills/project-workflow/references/agent-init.md` - passed, 0 issues
- Manually verified the corrected claim: backgrounded a process with `nohup sleep 120 &` in one Bash call, then in later, separate calls ran `kill -0`, `kill`, `kill -9`, and `kill -1` against its PID — all failed with "operation not permitted", confirming no signal (including `-0`) crosses the tool-call boundary. A second, independent agent reproduced the same result from scratch in a fresh test.
- Doc-only change; no code paths, Make targets, or CI wiring are affected.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
