### PR TITLE
feat(skills): centralize scoped ledger contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,9 +188,9 @@ Treat this `AGENTS.md` as the repo-specific companion to those skills.
 ## Remembered workflow commands
 
 Treat these short commands as binding workflow shorthands, not casual prose.
-They select the matching skill and its gates before any edits. Supported gap
-IDs include `FEATURE-*`, `ISSUE-*`, `TEST-*`, `DOC-*`, `PROJECT-*`, and
-`RELIABILITY-*`; route each ID to the matching gap skill and ledger.
+They select the matching skill and its gates before any edits. Each ledger
+skill's `ledger.yaml` declares its accepted ID prefix and canonical ledger
+path; route each ID through that contract.
 
 `Start` begins the workflow, `Approved` accepts the presented solution, and
 `Done` confirms an entry is verified. After any verb, name the ID and add
@@ -210,16 +210,17 @@ bare current-request invocation targets the current repository and means the
 full review, validation, commit, force-push, and draft-PR workflow; it does not
 use a path scope.
 
-- `Start FEATURE-3 in path/FEATURES.md`: select the matching gap skill,
-  refresh evidence, present the solution, and stop at the agreement gate
-  before editing. `Start ISSUE-3 in path/ISSUES.md` follows the same shape.
-- `Approved FEATURE-3 with agents`: approve the presented solution and
+- `Start ID in SCOPE`: select the matching gap skill, resolve the exact scoped
+  ledger path from its `ledger.yaml`, refresh evidence, present the solution,
+  and stop at the agreement gate before editing. Use `in LEDGER_PATH` only when
+  the skill or scope is ambiguous.
+- `Approved ID with agents`: approve the presented solution and
   authorize sub-agents for implementation or fresh review when useful.
-- `Start FEATURE-3 with a goal`: authorize a runtime goal when goals are
+- `Start ID with a goal`: authorize a runtime goal when goals are
   available and useful.
-- `Start FEATURE-3 with agents and a goal`: authorize both sub-agents and a
+- `Start ID with agents and a goal`: authorize both sub-agents and a
   runtime goal.
-- `Done FEATURE-3`: confirm the entry is verified and complete; the selected
+- `Done ID`: confirm the entry is verified and complete; the selected
   skill continues with the next entry. The `with a goal` and `with agents and
   a goal` tails apply here too.
 

--- a/quality/skills/lint
+++ b/quality/skills/lint
@@ -72,21 +72,6 @@ reject_policy_tree_pattern() {
   fi
 }
 
-require_gitignore_pattern() {
-  local pattern="$1"
-
-  if [[ ! -f .gitignore ]]; then
-    printf 'missing file: .gitignore\n' >&2
-    missing=1
-    return
-  fi
-
-  if ! grep -Fxq -- "$pattern" .gitignore; then
-    printf 'missing .gitignore pattern: %s\n' "$pattern" >&2
-    missing=1
-  fi
-}
-
 require_reference() {
   local source="$1"
   local reference="$2"
@@ -101,13 +86,6 @@ require_reference() {
 if ! ruby quality/skills/metadata; then
   missing=1
 fi
-
-require_gitignore_pattern "ISSUES.md"
-require_gitignore_pattern "TESTS.md"
-require_gitignore_pattern "DOCS.md"
-require_gitignore_pattern "FEATURES.md"
-require_gitignore_pattern "PROJECTS.md"
-require_gitignore_pattern "RELIABILITY.md"
 
 require_pattern AGENTS.md "mandatory operating rules, not advisory guidance"
 require_pattern AGENTS.md "## Local pattern binding"
@@ -132,17 +110,15 @@ reject_pattern AGENTS.md "Agent judgment is sufficient"
 reject_pattern AGENTS.md "Use sub-agents in that case"
 require_pattern AGENTS.md "## Remembered workflow commands"
 require_pattern AGENTS.md "binding workflow shorthands"
-require_pattern AGENTS.md "Supported gap"
-require_pattern AGENTS.md "ISSUE-*"
-require_pattern AGENTS.md "TEST-*"
-require_pattern AGENTS.md "Start FEATURE-3 in path/FEATURES.md"
-require_pattern AGENTS.md "Start ISSUE-3 in path/ISSUES.md"
+require_pattern AGENTS.md "Each ledger"
+require_pattern AGENTS.md "Start ID in SCOPE"
+require_pattern AGENTS.md "its \`ledger.yaml\`"
 require_pattern AGENTS.md "stop at the agreement"
-require_pattern AGENTS.md "Approved FEATURE-3 with agents"
-require_pattern AGENTS.md "Start FEATURE-3 with a goal"
-require_pattern AGENTS.md "Start FEATURE-3 with agents and a goal"
+require_pattern AGENTS.md "Approved ID with agents"
+require_pattern AGENTS.md "Start ID with a goal"
+require_pattern AGENTS.md "Start ID with agents and a goal"
 require_pattern AGENTS.md "tails apply here too"
-require_pattern AGENTS.md "Done FEATURE-3"
+require_pattern AGENTS.md "Done ID"
 require_pattern AGENTS.md "They do not bypass solution agreement"
 require_pattern AGENTS.md "## Skill workflow mechanics"
 require_pattern AGENTS.md "references/long-running-work.md"
@@ -188,18 +164,12 @@ require_pattern skills/project-gaps/SKILL.md "After the human agrees and before 
 require_pattern skills/project-gaps/SKILL.md "| Implementation home | current repo \| shared bin \| external repo \| mixed |"
 require_pattern skills/project-gaps/SKILL.md "If a candidate's implementation home is outside the requested scope"
 require_pattern skills/reliability-gaps/SKILL.md "After the human agrees and before editing, state the selected local code/config/docs pattern"
-require_pattern skills/code-issues/SKILL.md "asks about issue IDs such as ISSUE-1"
-require_pattern skills/test-gaps/SKILL.md "asks about test gap IDs such as TEST-1"
-require_pattern skills/doc-gaps/SKILL.md "asks about doc gap IDs such as DOC-1"
-require_pattern skills/feature-gaps/SKILL.md "asks about feature IDs such as FEATURE-1"
-require_pattern skills/project-gaps/SKILL.md "asks about project gap IDs such as PROJECT-1"
-require_pattern skills/reliability-gaps/SKILL.md "asks about reliability gap IDs such as REL-1"
 require_pattern skills/feature-gaps/SKILL.md "state the feature execution checklist before"
 require_pattern skills/feature-gaps/SKILL.md "Use \`Refactor: none (<reason>)\`"
 require_pattern skills/feature-gaps/SKILL.md "## Implementation Proposal Gate"
 require_pattern skills/feature-gaps/SKILL.md "## Solution Shape"
-require_pattern skills/feature-gaps/SKILL.md "\`Approved FEATURE-N\` approves this solution shape"
-require_pattern skills/feature-gaps/SKILL.md "\`Approved FEATURE-N with agents\` approves this solution shape"
+require_pattern skills/feature-gaps/SKILL.md "\`Approved <ID>-N\` using the prefix from \`ledger.yaml\` approves this solution shape"
+require_pattern skills/feature-gaps/SKILL.md "\`Approved <ID>-N with agents\` approves this solution shape"
 require_pattern skills/feature-gaps/SKILL.md "tails apply here too"
 require_pattern skills/feature-gaps/agents/openai.yaml "Solution Shape first"
 require_pattern skills/project-gaps/SKILL.md "state the project execution checklist before editing"
@@ -278,6 +248,9 @@ require_pattern skills/references/gap-workflow.md "supported-usage evidence, and
 require_pattern skills/references/gap-workflow.md "without requiring migration"
 require_pattern skills/references/gap-workflow.md "Make every ledger entry understandable without opening source files"
 require_pattern skills/references/gap-workflow.md "workflow mechanics and the common session"
+require_pattern skills/references/gap-workflow.md "## Ledger Contract Resolution"
+require_pattern skills/references/gap-workflow.md "search the workspace for possible ledgers"
+require_pattern skills/references/gap-workflow/implementation.md "If the resolved ledger is missing, stop and"
 require_pattern skills/references/gap-workflow/find-audit.md "../gap-workflow.md"
 require_pattern skills/references/gap-workflow/find-audit.md "../gap-lead-generation.md"
 require_pattern skills/references/gap-workflow.md "| Title | What | Why |"
@@ -327,6 +300,7 @@ for plan in \
   skills/test-gaps/references/plan.md
 do
   require_pattern "$plan" "Apply the shared gap-workflow delegation gate before review work"
+  require_pattern "$plan" "../ledger.yaml"
   require_pattern "$plan" "../../references/gap-lead-generation.md"
   require_pattern "$plan" "rejected"
   require_pattern "$plan" "routed"
@@ -343,12 +317,12 @@ require_pattern skills/testing-standards/agents/openai.yaml "stop on unexpected 
 require_pattern skills/testing-standards/agents/openai.yaml "run a two-pass Refactor assessment"
 require_pattern skills/testing-standards/agents/openai.yaml "use a third pass for shared, public"
 require_pattern skills/go-standards/agents/openai.yaml "MUST NOT invent import aliases for readability, caution, brevity, or personal clarity"
-require_pattern skills/reliability-gaps/agents/openai.yaml "answer reliability gap ID follow-ups such as REL-1"
-require_pattern skills/code-issues/agents/openai.yaml "answer issue ID follow-ups such as ISSUE-1"
-require_pattern skills/test-gaps/agents/openai.yaml "answer test gap ID follow-ups such as TEST-1"
-require_pattern skills/doc-gaps/agents/openai.yaml "answer doc gap ID follow-ups such as DOC-1"
-require_pattern skills/feature-gaps/agents/openai.yaml "answer feature ID follow-ups such as FEATURE-1"
-require_pattern skills/project-gaps/agents/openai.yaml "answer project gap ID follow-ups such as PROJECT-1"
+require_pattern skills/reliability-gaps/agents/openai.yaml "resolve entry ID follow-ups through ledger.yaml"
+require_pattern skills/code-issues/agents/openai.yaml "resolve entry ID follow-ups through ledger.yaml"
+require_pattern skills/test-gaps/agents/openai.yaml "resolve entry ID follow-ups through ledger.yaml"
+require_pattern skills/doc-gaps/agents/openai.yaml "resolve entry ID follow-ups through ledger.yaml"
+require_pattern skills/feature-gaps/agents/openai.yaml "resolve entry ID follow-ups through ledger.yaml"
+require_pattern skills/project-gaps/agents/openai.yaml "resolve entry ID follow-ups through ledger.yaml"
 require_pattern skills/code-issues/agents/openai.yaml "apply the shared delegation gate"
 require_pattern skills/doc-gaps/agents/openai.yaml "apply the shared delegation gate"
 require_pattern skills/feature-gaps/agents/openai.yaml "apply the shared delegation gate"

--- a/quality/skills/metadata
+++ b/quality/skills/metadata
@@ -3,14 +3,21 @@
 
 require 'yaml'
 
-GAP_CONTRACTS = {
-  'code-issues' => { ledger: 'ISSUES.md', id: 'ISSUE' },
-  'test-gaps' => { ledger: 'TESTS.md', id: 'TEST' },
-  'doc-gaps' => { ledger: 'DOCS.md', id: 'DOC' },
-  'feature-gaps' => { ledger: 'FEATURES.md', id: 'FEATURE' },
-  'project-gaps' => { ledger: 'PROJECTS.md', id: 'PROJECT' },
-  'reliability-gaps' => { ledger: 'RELIABILITY.md', id: 'REL' }
-}.freeze
+GAP_SKILLS = %w[
+  code-issues
+  test-gaps
+  doc-gaps
+  feature-gaps
+  project-gaps
+  reliability-gaps
+].freeze
+LEDGER_CONTRACT_KEYS = %w[
+  version
+  id_prefix
+  ledger_filename
+  ledger_path_template
+].freeze
+LEDGER_PATH_TEMPLATE = '{scope}/{ledger_filename}'
 REFERENCE_PATTERN = %r{(?<!/)(?:\.\./)*references/[A-Za-z0-9._/-]+\.md(?:#[^\s`)]+)?}
 
 def present_string?(value)
@@ -199,17 +206,25 @@ def valid_pairs?(names, message)
   false
 end
 
-def valid_gap_contract?(skill_name, contract)
-  skill_path = "skills/#{skill_name}/SKILL.md"
-  plan_path = "skills/#{skill_name}/references/plan.md"
-  agent_path = "skills/#{skill_name}/agents/openai.yaml"
+def valid_gap_contract?(skill_name)
+  paths = gap_contract_paths(skill_name)
 
   [
-    valid_gap_file?(skill_path, skill_name),
-    valid_gap_file?(plan_path, skill_name),
-    valid_gap_file?(agent_path, skill_name),
-    valid_gap_text?(skill_path, plan_path, agent_path, contract)
+    paths.values.map { |path| valid_gap_file?(path, skill_name) }.all?,
+    valid_ledger_contract?(paths[:contract]),
+    valid_gap_text?(paths)
   ].all?
+end
+
+def gap_contract_paths(skill_name)
+  root = "skills/#{skill_name}"
+
+  {
+    skill: "#{root}/SKILL.md",
+    plan: "#{root}/references/plan.md",
+    agent: "#{root}/agents/openai.yaml",
+    contract: "#{root}/ledger.yaml"
+  }
 end
 
 def valid_gap_file?(path, skill_name)
@@ -218,17 +233,86 @@ def valid_gap_file?(path, skill_name)
   report_failure("missing gap workflow file for #{skill_name}: #{path}")
 end
 
-def valid_gap_text?(skill_path, plan_path, agent_path, contract)
-  return false unless [skill_path, plan_path, agent_path].all? { |path| File.file?(path) }
+def valid_ledger_contract?(path)
+  data = safe_load_file(path)
+  return false unless mapping?(data, path, 'ledger contract must be a mapping')
 
-  skill_text = File.read(skill_path)
-  plan_text = File.read(plan_path)
-  agent_text = File.read(agent_path)
-  combined_text = [skill_text, plan_text, agent_text].join("\n")
+  [
+    valid_contract_keys?(data, path),
+    valid_contract_values?(data, path),
+    ledger_filename_ignored?(data['ledger_filename'], path)
+  ].all?
+end
 
-  valid_gap_skill_text?(skill_text, skill_path) &&
-    valid_gap_plan_text?(plan_text, plan_path) &&
-    valid_gap_contract_text?(combined_text, skill_path, contract)
+def valid_contract_keys?(data, path)
+  extra = data.keys - LEDGER_CONTRACT_KEYS
+  missing = LEDGER_CONTRACT_KEYS - data.keys
+
+  [
+    extra.empty? || report_failure("unexpected ledger contract keys in #{path}: #{extra.join(', ')}"),
+    missing.empty? || report_failure("missing ledger contract keys in #{path}: #{missing.join(', ')}")
+  ].all?
+end
+
+def valid_contract_values?(data, path)
+  [
+    data['version'] == 1 || report_failure("ledger contract version must be 1 in #{path}"),
+    valid_id_prefix?(data['id_prefix'], path),
+    valid_ledger_filename?(data['ledger_filename'], path),
+    valid_ledger_path_template?(data['ledger_path_template'], path)
+  ].all?
+end
+
+def valid_id_prefix?(value, path)
+  return true if value.is_a?(String) && value.match?(/\A[A-Z][A-Z0-9]*\z/)
+
+  report_failure("invalid id_prefix in #{path}")
+end
+
+def valid_ledger_filename?(value, path)
+  return true if value.is_a?(String) && value.match?(/\A[A-Z][A-Z0-9_]*\.md\z/)
+
+  report_failure("invalid ledger_filename in #{path}")
+end
+
+def valid_ledger_path_template?(value, path)
+  return true if value == LEDGER_PATH_TEMPLATE
+
+  report_failure("ledger_path_template must be #{LEDGER_PATH_TEMPLATE.inspect} in #{path}")
+end
+
+def ledger_filename_ignored?(filename, contract_path)
+  return true unless present_string?(filename)
+  return report_failure('missing file: .gitignore') unless File.file?('.gitignore')
+  return true if File.readlines('.gitignore', chomp: true).include?(filename)
+
+  report_failure("ledger filename from #{contract_path} is missing from .gitignore: #{filename}")
+end
+
+def valid_gap_text?(paths)
+  return false unless paths.values.all? { |path| File.file?(path) }
+
+  valid_gap_text_content?(gap_text(paths), paths)
+end
+
+def gap_text(paths)
+  {
+    skill: File.read(paths[:skill]),
+    plan: File.read(paths[:plan]),
+    agent: File.read(paths[:agent]),
+    contract: safe_load_file(paths[:contract])
+  }
+end
+
+def valid_gap_text_content?(text, paths)
+  contract = text[:contract]
+  return false unless contract
+
+  combined_text = text.values_at(:skill, :plan, :agent).join("\n")
+
+  valid_gap_skill_text?(text[:skill], paths[:skill]) &&
+    valid_gap_plan_text?(text[:plan], paths[:plan]) &&
+    valid_gap_contract_text?(combined_text, paths[:skill], paths[:contract], contract)
 end
 
 def valid_gap_skill_text?(skill_text, skill_path)
@@ -242,10 +326,10 @@ def valid_gap_plan_text?(plan_text, plan_path)
   required_text?(plan_text, plan_path, 'shared gap workflow')
 end
 
-def valid_gap_contract_text?(combined_text, skill_path, contract)
+def valid_gap_contract_text?(combined_text, skill_path, contract_path, contract)
   [
-    required_text?(combined_text, skill_path, contract.fetch(:ledger)),
-    required_gap_id?(combined_text, skill_path, contract.fetch(:id))
+    required_text?(combined_text, skill_path, 'ledger.yaml'),
+    no_legacy_ledger_metadata?(skill_path, contract_path, contract)
   ].all?
 end
 
@@ -255,10 +339,40 @@ def required_text?(text, path, expected)
   report_failure("missing required text in #{path}: #{expected}")
 end
 
-def required_gap_id?(text, path, id)
-  return true if text.match?(/\b#{Regexp.escape(id)}-(?:1|N|<number>)/)
+def no_legacy_ledger_metadata?(skill_path, contract_path, contract)
+  ledger_filename = contract.fetch('ledger_filename')
+  id_pattern = /\b#{Regexp.escape(contract.fetch('id_prefix'))}-(?:1|N|<number>)/
 
-  report_failure("missing gap ID pattern in #{path}: #{id}-1, #{id}-N, or #{id}-<number>")
+  gap_skill_files(skill_path, contract_path).map do |path|
+    no_legacy_ledger_metadata_in_file?(path, contract_path, ledger_filename, id_pattern)
+  end.all?
+end
+
+def gap_skill_files(skill_path, contract_path)
+  Dir[File.join(File.dirname(skill_path), '**', '*')].select do |path|
+    File.file?(path) && path != contract_path
+  end
+end
+
+def no_legacy_ledger_metadata_in_file?(path, contract_path, filename, id_pattern)
+  text = File.read(path)
+
+  [
+    no_legacy_ledger_filename?(text, path, contract_path, filename),
+    no_legacy_ledger_id_prefix?(text, path, contract_path, id_pattern)
+  ].all?
+end
+
+def no_legacy_ledger_filename?(text, path, contract_path, filename)
+  return true unless text.include?(filename)
+
+  report_failure("ledger filename must be read from #{contract_path}, not repeated in #{path}")
+end
+
+def no_legacy_ledger_id_prefix?(text, path, contract_path, id_pattern)
+  return true unless text.match?(id_pattern)
+
+  report_failure("ledger ID prefix must be read from #{contract_path}, not repeated in #{path}")
 end
 
 ok = true
@@ -266,6 +380,6 @@ Dir['skills/*/SKILL.md'].each { |path| ok = false unless valid_skill?(path) }
 Dir['skills/*/agents/openai.yaml'].each { |path| ok = false unless valid_agent?(path) }
 Dir['skills/**/*.md'].each { |path| ok = false unless valid_markdown_references?(path) }
 ok = false unless valid_skill_agent_pairs?
-GAP_CONTRACTS.each { |skill_name, contract| ok = false unless valid_gap_contract?(skill_name, contract) }
+GAP_SKILLS.each { |skill_name| ok = false unless valid_gap_contract?(skill_name) }
 
 exit(ok ? 0 : 1)

--- a/skills/code-issues/SKILL.md
+++ b/skills/code-issues/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: code-issues
-description: Use when the user asks to find or implement $code-issues/code issues in a package or folder, set a confidence closure target such as 95% or 99%, uses Start ISSUE-1 or Approved ISSUE-1 with agents and a goal, asks about issue IDs such as ISSUE-1, asks what the fix is for ISSUE-1, asks to fix or verify ISSUE-1, or uses Done ISSUE-1. Find concrete bugs, security issues, compatibility breaks, and public contract violations; record scoped ISSUES.md entries; later propose and implement agreed fixes one at a time.
+description: Use when the user asks to find or implement $code-issues/code issues in a package or folder, set a confidence closure target such as 95% or 99%, uses Start, Approved, or Done with ledger entry IDs and optional agents or a goal, or asks what the fix is for a code-issue ledger entry. Find concrete bugs, security issues, compatibility breaks, and public contract violations; record scoped ledger entries; later propose and implement agreed fixes one at a time.
 ---
 
 # Code Issues
 
 Use Find mode by default when no mode is stated. Enter Implement mode only
 after the human explicitly agrees to a specific proposed solution, typically
-with `Approved ISSUE-N`. Do not combine modes in one pass:
+with `Approved <ID>-N` using the prefix from `ledger.yaml`. Do not combine modes in one pass:
 
 - **Find mode**: `Find $code-issues in PACKAGE_OR_FOLDER` or `Find code issues in PACKAGE_OR_FOLDER`.
 - **Implement mode**: `Implement $code-issues in PACKAGE_OR_FOLDER` or `Implement code issues in PACKAGE_OR_FOLDER`.
 
-Before either mode, read `references/plan.md` and
+Before either mode, read `ledger.yaml`, `references/plan.md`, and
 `../references/gap-workflow.md` and the mode-specific reference below own
 runtime state, ledger, delegation,
 scope, coverage, confidence, and approval gates. Before Find mode, also read
@@ -23,7 +23,7 @@ scope, coverage, confidence, and approval gates. Before Find mode, also read
 
 Operate as a strict issue triager and ledger owner: separate confirmed code
 defects from test gaps, doc gaps, polish, and speculation; keep the scoped
-`ISSUES.md` actionable, deduplicated, and tied to user-visible or contract risk.
+scoped ledger actionable, deduplicated, and tied to user-visible or contract risk.
 
 Code is the default source of behavioral truth. Comments, GoDoc, README prose,
 examples, and other documentation can be stale. Do not record or implement a
@@ -41,9 +41,9 @@ Follow `references/plan.md#find-mode-plan` and the find/audit rules in
 Read `references/find-rules.md`; those code-issue rules remain mandatory in
 Find mode.
 
-## `ISSUES.md` Format
+## Ledger Format
 
-Before creating, updating, or interpreting `ISSUES.md`, read
+Before creating, updating, or interpreting the scoped ledger, read `ledger.yaml` and
 `references/ledger-format.md`. Each entry is a self-contained mini-RFC using
 `What -> Why -> How`. The required core must keep `| Field | Value |`,
 `| Status |`, and `**Summary.**`; `### What` with `**Current.**` and
@@ -67,15 +67,15 @@ These code-issue implementation rules remain mandatory:
 - After the human agrees and before editing, state the selected local code pattern, dominant relevant test harness, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
 - Use `$testing-standards` when deciding whether to add or update regression tests for the fix, and prefer its test-first or scenario-first loop when a behavior-changing fix has a credible test or BDD layer.
 - For behavior-changing fixes, state the issue execution checklist before editing: `TDD decision`, `First test/scenario`, `Expected red`, `Intended green change`, `Refactor checkpoint`, and `Validation`. When the harness is runnable, observe and paste the red (command + failing output) before implementation edits; if it is not runnable, stop and request agreement to proceed test-after with the reason rather than skipping red silently.
-- Report `Red`, `Green`, `Refactor`, and `Validation` entries. `Red` and `Green` must each paste the actual command and its real output using the same command/selector; a label without pasted output is not acceptable, and work where red was never observed before implementation must be labeled `test-after (not TDD)` with the reason instead of a TDD cycle. Use `Refactor: none (<reason>)` when no cleanup was needed after green. Ask the human to verify and say `Done ISSUE-N`.
+- Report `Red`, `Green`, `Refactor`, and `Validation` entries. `Red` and `Green` must each paste the actual command and its real output using the same command/selector; a label without pasted output is not acceptable, and work where red was never observed before implementation must be labeled `test-after (not TDD)` with the reason instead of a TDD cycle. Use `Refactor: none (<reason>)` when no cleanup was needed after green. Ask the human to verify and say `Done <ID>-N` using the prefix from `ledger.yaml`.
 
 ## References
 
 - Read `references/plan.md` before starting Find mode or Implement mode.
 - Read `references/find-rules.md` during Find mode before reviewing or
   recording candidates.
-- Read `references/ledger-format.md` before creating, updating, or interpreting
-  `ISSUES.md`.
+- Read `ledger.yaml` and `references/ledger-format.md` before creating,
+  updating, or interpreting the scoped ledger.
 - Read `../references/gap-workflow.md` for shared scoped-ledger and delegation
   gates; read `../references/gap-workflow/find-audit.md` for Find-mode rules and
   `../references/gap-workflow/implementation.md` for Implement-mode rules.

--- a/skills/code-issues/agents/openai.yaml
+++ b/skills/code-issues/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Code Issues"
   short_description: "Find scoped code defects and risks"
-  default_prompt: "Use $code-issues for scoped bug, security, compatibility, and public-contract findings. Default to Find mode when no mode is stated; follow repo archetype lead generation, apply the shared delegation gate, summarize ledger entries in a compact Title/What/Why table, preserve the evidence and approval workflow, answer issue ID follow-ups such as ISSUE-1, and implement only after explicit agreement to a specific proposal."
+  default_prompt: "Use $code-issues for scoped bug, security, compatibility, and public-contract findings. Default to Find mode when no mode is stated; follow repo archetype lead generation, apply the shared delegation gate, summarize ledger entries in a compact Title/What/Why table, preserve the evidence and approval workflow, resolve entry ID follow-ups through ledger.yaml, and implement only after explicit agreement to a specific proposal."

--- a/skills/code-issues/ledger.yaml
+++ b/skills/code-issues/ledger.yaml
@@ -1,0 +1,4 @@
+version: 1
+id_prefix: ISSUE
+ledger_filename: ISSUES.md
+ledger_path_template: "{scope}/{ledger_filename}"

--- a/skills/code-issues/references/find-rules.md
+++ b/skills/code-issues/references/find-rules.md
@@ -2,8 +2,7 @@
 
 These rules remain mandatory:
 
-- Use `ISSUES.md` in the requested package or folder as the review ledger, for
-  example `PACKAGE_OR_FOLDER/ISSUES.md`.
+- Read `../ledger.yaml` and use its resolved scoped path as the review ledger.
 - Prefer slices based on repository-owned behavior and risk: public commands/APIs, changed or recently touched areas, auth/network/filesystem/process boundaries, config/CI/release paths, documented workflows, and nearby tests. Use depth only as a discovery aid, not as the review boundary.
 - For delegated review, each assigned agent owns recursive review only within its bounded slice. Each agent must perform a thorough and accurate `$code-review` and `$security-audit` for that slice, using `$testing-standards` for concrete missing-coverage or weak-test analysis and `$change-validation` for likely validation commands.
 - Confirm each candidate finding against the code before recording it. Findings must be concrete bugs, security issues, compatibility breaks, or violated public contracts with user-visible impact.

--- a/skills/code-issues/references/ledger-format.md
+++ b/skills/code-issues/references/ledger-format.md
@@ -1,4 +1,4 @@
-# `ISSUES.md` Format
+# Ledger Format
 
 Each entry is a self-contained, debatable mini-RFC. A reviewer must be able to
 understand the problem, the evidence, and the proposed direction without opening
@@ -23,7 +23,7 @@ Use this structure for every entry:
 ````markdown
 # Issues
 
-## ISSUE-1: Short concrete title
+## <ID>-1: Short concrete title
 
 | Field | Value |
 | --- | --- |

--- a/skills/code-issues/references/plan.md
+++ b/skills/code-issues/references/plan.md
@@ -21,7 +21,7 @@ state, code/security/compatibility evidence, and public contract evidence.
    Prefer a read-only agent type when one is available, because Find-mode
    reviewers do not edit. Never leave a sub-agent's model unset; an unset
    model silently inherits the session model.
-3. Use `ISSUES.md` as the scoped ledger and `ISSUE-<number>` IDs.
+3. Read `../ledger.yaml`; use its scoped ledger path and ID prefix.
 4. Run `$project-workflow` discovery and the shared audit preflight, including
    applicable tools, service dependencies, validation ladder, and command
    failure classification.
@@ -48,7 +48,7 @@ state, code/security/compatibility evidence, and public contract evidence.
    report it as a confidence limiter or route it to the right workflow; do not
    record it as a code issue unless a concrete bug or violated contract is
    confirmed.
-10. If confirmed issues remain, write scoped `ISSUES.md`, present the ledger,
+10. If confirmed issues remain, write the resolved scoped ledger, present it,
     coverage state, proposed fix plan, and runnable follow-up scopes, then stop
     before fixing.
 

--- a/skills/doc-gaps/SKILL.md
+++ b/skills/doc-gaps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doc-gaps
-description: Use when the user asks to run $doc-gaps, find/fix doc gaps in a package or folder, set a confidence closure target such as 95% or 99%, review docs for gaps, run audit-only doc gaps, uses Start DOC-1 or Approved DOC-1 with agents and a goal, asks about doc gap IDs such as DOC-1, asks what the fix is for DOC-1, asks to fix or verify DOC-1, or uses Done DOC-1. Find and fix concrete missing, weak, stale, or misleading README, docs, examples, command help, package docs, public API comments, code comments, and docstrings.
+description: Use when the user asks to run $doc-gaps, find/fix doc gaps in a package or folder, set a confidence closure target such as 95% or 99%, review docs for gaps, run audit-only doc gaps, uses Start, Approved, or Done with ledger entry IDs and optional agents or a goal, or asks what the fix is for a doc-gap ledger entry. Find and fix concrete missing, weak, stale, or misleading README, docs, examples, command help, package docs, public API comments, code comments, and docstrings.
 ---
 
 # Doc Gaps
@@ -10,7 +10,7 @@ Use one-pass mode by default; use audit-only mode only when explicitly asked:
 - **One-pass mode**: `Run $doc-gaps in PACKAGE_OR_FOLDER`, `Find doc gaps in PACKAGE_OR_FOLDER`, or `Fix doc gaps in PACKAGE_OR_FOLDER`.
 - **Audit-only mode**: `Audit-only $doc-gaps in PACKAGE_OR_FOLDER` or `Find doc gaps in PACKAGE_OR_FOLDER without editing`.
 
-Before either mode, read `references/plan.md` and
+Before either mode, read `ledger.yaml`, `references/plan.md`, and
 `../references/gap-workflow.md` and the mode-specific reference below own
 runtime state, ledger, delegation,
 scope, coverage, confidence, and approval gates. Before one-pass or audit-only
@@ -60,9 +60,9 @@ recording findings. Keep GoDoc details in `$go-standards`, RDoc details in
 `$ruby-standards`, and shell script/function comment rules in
 `$shell-standards`.
 
-## Candidate And `DOCS.md` Format
+## Candidate And Ledger Format
 
-Before creating, updating, or interpreting `DOCS.md`, read
+Before creating, updating, or interpreting the scoped ledger, read `ledger.yaml` and
 `references/ledger-format.md`. Each entry is a self-contained mini-RFC using
 `What -> Why -> How`. The required core must keep `| Field | Value |`,
 `| Status |`, and `**Summary.**`; `### What` with `**Current.**` and
@@ -81,8 +81,8 @@ entry warrants them.
   editing, or recording candidates.
 - Read `references/audit-rules.md` during audit-only mode before reviewing or
   recording candidates.
-- Read `references/ledger-format.md` before creating, updating, or interpreting
-  `DOCS.md`.
+- Read `ledger.yaml` and `references/ledger-format.md` before creating,
+  updating, or interpreting the scoped ledger.
 - Read `../references/gap-workflow.md` for shared scoped-ledger and delegation
   gates; read `../references/gap-workflow/find-audit.md` for one-pass/audit-only
   rules and `../references/gap-workflow/implementation.md` for entry fixes.

--- a/skills/doc-gaps/agents/openai.yaml
+++ b/skills/doc-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Doc Gaps"
   short_description: "Find and fix scoped doc adequacy gaps"
-  default_prompt: "Use $doc-gaps with $doc-standards for scoped documentation adequacy gaps. Follow repo archetype lead generation, apply the shared delegation gate, summarize ledger entries in a compact Title/What/Why table, answer doc gap ID follow-ups such as DOC-1, and fix confirmed gaps in one pass."
+  default_prompt: "Use $doc-gaps with $doc-standards for scoped documentation adequacy gaps. Follow repo archetype lead generation, apply the shared delegation gate, summarize ledger entries in a compact Title/What/Why table, resolve entry ID follow-ups through ledger.yaml, and fix confirmed gaps in one pass."

--- a/skills/doc-gaps/ledger.yaml
+++ b/skills/doc-gaps/ledger.yaml
@@ -1,0 +1,4 @@
+version: 1
+id_prefix: DOC
+ledger_filename: DOCS.md
+ledger_path_template: "{scope}/{ledger_filename}"

--- a/skills/doc-gaps/references/audit-rules.md
+++ b/skills/doc-gaps/references/audit-rules.md
@@ -2,7 +2,7 @@
 
 These rules remain mandatory:
 
-- Use `DOCS.md` in the requested package or folder as the audit ledger, for example `PACKAGE_OR_FOLDER/DOCS.md`.
-- If `DOCS.md` already exists in the requested package or folder, stop unless the human explicitly asked to refresh or overwrite that scoped ledger.
+- Read `../ledger.yaml` and use its resolved scoped path as the audit ledger.
+- If the resolved scoped ledger already exists, stop unless the human explicitly asked to refresh or overwrite it.
 - Use the same delegation, surface-routing, candidate confirmation, severity, and out-of-scope rules as one-pass mode.
 - Stop after presenting the audit ledger. Do not make fixes in audit-only mode.

--- a/skills/doc-gaps/references/ledger-format.md
+++ b/skills/doc-gaps/references/ledger-format.md
@@ -1,4 +1,4 @@
-# Candidate And `DOCS.md` Format
+# Candidate And Ledger Format
 
 Each review candidate and each unresolved or audit-only ledger entry is a
 self-contained, debatable mini-RFC. A reviewer must be able to understand the
@@ -24,7 +24,7 @@ Use this structure for every entry:
 ````markdown
 # Docs
 
-## DOC-1: Short concrete title
+## <ID>-1: Short concrete title
 
 | Field | Value |
 | --- | --- |

--- a/skills/doc-gaps/references/one-pass-rules.md
+++ b/skills/doc-gaps/references/one-pass-rules.md
@@ -4,8 +4,8 @@ These rules remain mandatory:
 
 - Treat `Run $doc-gaps in PACKAGE_OR_FOLDER`, `Find doc gaps in PACKAGE_OR_FOLDER`, or `Fix doc gaps in PACKAGE_OR_FOLDER` as permission to edit documentation in scope, run appropriate validation, and summarize the result in one pass.
 - Use audit-only mode only when the user explicitly asks not to edit or asks only for an audit or ledger. When a stop gate prevents a correct documentation fix during one-pass mode, record unresolved confirmed findings instead of switching modes.
-- Use `DOCS.md` in the requested package or folder as the scoped ledger.
-- If scoped `DOCS.md` already exists, read it before reviewing. If it is a doc-gap ledger, include unresolved findings in the candidate set and update or delete the ledger after fixing them. If it is unrelated or ambiguous active work, stop and ask before editing it.
+- Read `../ledger.yaml` and use its resolved scoped path as the scoped ledger.
+- If the resolved scoped ledger already exists, read it before reviewing. If it is a doc-gap ledger, include unresolved findings in the candidate set and update or delete the ledger after fixing them. If it is unrelated or ambiguous active work, stop and ask before editing it.
 - Before assigning review agents or starting local review, build a recursive documentation inventory for the requested package or folder: README files, docs, examples, command help surfaces, package docs, public API comments, code-comment/docstring surfaces, first-level subfolders, nested packages, generated/vendor/build/cache exclusions, and relevant validation entrypoints.
 - Prefer slices based on authoritative documentation owner and user risk: README or user docs, command help, examples, public API/package docs, documented workflows, changed or recently touched areas, and code areas with public interfaces. Use depth only as a discovery aid, not as the review boundary.
 - For delegated review, each assigned agent owns recursive review only within its bounded slice. Each agent must perform a thorough documentation review for that slice, pairing with `$doc-standards`, relevant language standards, `$naming-standards` when terminology is unclear or inconsistent, and `$change-validation` for likely validation commands.
@@ -19,7 +19,7 @@ These rules remain mandatory:
 - For unresolved-ledger fixes or any case where human approval is still required: After the human agrees and before editing, state the selected local documentation pattern, dominant relevant validation path, planned validation command, and any deviation from `AGENTS.md` or selected skills. If a deviation is needed, stop and ask before editing.
 - Implement confirmed doc gaps with the smallest clear documentation change using the established documentation location and style.
 - Stop and ask before editing when behavior, audience, documentation location, public-contract wording, examples, validation, or user intent is ambiguous enough that a correct documentation change cannot be inferred from local context.
-- Write unresolved confirmed findings to the scoped `DOCS.md` only when they cannot be fixed in the same pass, the user requested audit-only mode, validation or permission is blocked, or the scope is too large to complete.
+- Write unresolved confirmed findings to the resolved scoped ledger only when they cannot be fixed in the same pass, the user requested audit-only mode, validation or permission is blocked, or the scope is too large to complete.
 - Validate documentation changes with commands appropriate to the changed files.
-- If all confirmed doc gaps are fixed, do not leave a new `DOCS.md` behind. If an existing doc-gap ledger is fully resolved, delete it.
-- Final output must summarize fixed gaps, dismissed or out-of-scope candidates when relevant, broad-scope coverage notes when the requested scope was too broad for complete deep review, unresolved findings written to `DOCS.md` if any, and validation results.
+- If all confirmed doc gaps are fixed, do not leave a new scoped ledger behind. If an existing doc-gap ledger is fully resolved, delete it.
+- Final output must summarize fixed gaps, dismissed or out-of-scope candidates when relevant, broad-scope coverage notes when the requested scope was too broad for complete deep review, unresolved findings written to the resolved scoped ledger if any, and validation results.

--- a/skills/doc-gaps/references/plan.md
+++ b/skills/doc-gaps/references/plan.md
@@ -13,9 +13,9 @@ documentation surface.
 
 1. Follow `../../references/gap-workflow.md#common-plan-mechanics` for shared
    one-pass sequencing. Apply the shared gap-workflow delegation gate before review work.
-2. Read an existing scoped `DOCS.md` when it is a doc-gap ledger; stop if the
-   file is unrelated or ambiguous active work. Use `DOC-<number>` IDs for
-   unresolved gaps.
+2. Read `../ledger.yaml`, then read the resolved scoped ledger when it is a
+   doc-gap ledger; stop if the file is unrelated or ambiguous active work. Use
+   its ID prefix for unresolved gaps.
 3. Read `../../references/gap-lead-generation.md`, classify the repository
    archetype, and build a lead inventory for README, examples, command help,
    package docs, API comments, config docs, operational docs, generated-schema
@@ -41,7 +41,7 @@ documentation surface.
    missing-contract categories, rejected and routed leads, validation evidence,
    and policy exclusions checked.
 9. Implement confirmed doc gaps with the smallest clear documentation changes.
-   If a confirmed gap cannot be fixed correctly, write or update `DOCS.md`; if
+   If a confirmed gap cannot be fixed correctly, write or update the resolved scoped ledger; if
    an existing doc-gap ledger is fully resolved, delete it.
 10. Validate changed docs and present fixed gaps, dismissed or out-of-scope
    candidates when relevant, coverage state, unresolved ledger entries if any,
@@ -50,10 +50,10 @@ documentation surface.
 ## Audit-Only Mode Plan
 
 1. Follow the one-pass review and closeout rules, but check whether scoped
-   `DOCS.md` already exists and stop unless the human explicitly asked to
+   the resolved scoped ledger already exists and stop unless the human explicitly asked to
    refresh or overwrite that ledger.
 2. Do not edit documentation. If no confirmed gaps remain, report coverage and
-   do not create `DOCS.md`; if confirmed gaps remain, write the scoped audit
-   ledger with `DOC-<number>` IDs.
+   do not create a scoped ledger; if confirmed gaps remain, write the resolved
+   scoped audit ledger with its ID prefix.
 3. Present the scoped audit ledger, coverage state, and runnable follow-up
    scopes, then stop before making fixes.

--- a/skills/feature-gaps/SKILL.md
+++ b/skills/feature-gaps/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: feature-gaps
-description: Use when the user asks to find or implement $feature-gaps/feature gaps in a package or folder, set a confidence closure target such as 95% or 99%, find main product capability gaps, find product-owned user/operator/service-author/package-consumer/CLI/API/library opportunities, uses Start FEATURE-1 or Approved FEATURE-1 with agents and a goal, asks about feature IDs such as FEATURE-1, asks what the proposal is for FEATURE-1, asks to fix or verify FEATURE-1, or uses Done FEATURE-1. Find repository-fit feature opportunities with explicit audience benefit; record scoped FEATURES.md proposals; later propose and implement agreed changes one at a time. Do not use for standalone test, CI, build, Makefile, release, validation, or repository workflow gaps.
+description: Use when the user asks to find or implement $feature-gaps/feature gaps in a package or folder, set a confidence closure target such as 95% or 99%, find main product capability gaps, find product-owned user/operator/service-author/package-consumer/CLI/API/library opportunities, uses Start, Approved, or Done with ledger entry IDs and optional agents or a goal, or asks what the proposal is for a feature-gap ledger entry. Find repository-fit feature opportunities with explicit audience benefit; record scoped ledger proposals; later propose and implement agreed changes one at a time. Do not use for standalone test, CI, build, Makefile, release, validation, or repository workflow gaps.
 ---
 
 # Feature Gaps
 
 Use Find mode by default when no mode is stated. Enter Implement mode only
 after the human explicitly agrees to a specific proposed solution, typically
-with `Approved FEATURE-N`. Do not combine modes in one pass:
+with `Approved <ID>-N` using the prefix from `ledger.yaml`. Do not combine modes in one pass:
 
 - **Find mode**: `Find $feature-gaps in PACKAGE_OR_FOLDER` or `Find feature gaps in PACKAGE_OR_FOLDER`.
 - **Implement mode**: `Implement $feature-gaps in PACKAGE_OR_FOLDER` or `Implement feature gaps in PACKAGE_OR_FOLDER`.
 
-Before either mode, read `references/plan.md` and
+Before either mode, read `ledger.yaml`, `references/plan.md`, and
 `../references/gap-workflow.md` and the mode-specific reference below own
 runtime state, ledger, delegation,
 scope, coverage, confidence, and approval gates. Before Find mode, also read
@@ -56,7 +56,7 @@ permission request.
 
 ## Acceptance Gate
 
-Before recording any `FEATURES.md` candidate, read
+Before recording any scoped-ledger candidate, read
 `references/acceptance-gate.md`. A proposal must satisfy that gate at the
 active confidence threshold or higher. Use an explicit confidence target from
 the current request when provided; otherwise use the 90% default (or the 95%
@@ -72,9 +72,9 @@ Follow `references/plan.md#find-mode-plan` and the find/audit rules in
 Read `references/find-rules.md`; those feature-gap rules remain mandatory in
 Find mode.
 
-## `FEATURES.md` Format
+## Ledger Format
 
-Before creating, updating, or interpreting `FEATURES.md`, read
+Before creating, updating, or interpreting the scoped ledger, read `ledger.yaml` and
 `references/ledger-format.md`. Each entry is a self-contained mini-PRD organized
 like the shared mini-RFC: `What -> Why -> How`. The required core must keep
 `| Field | Value |`, `| Status |`, and `**Summary.**`; `### What` with
@@ -96,7 +96,7 @@ Follow `references/plan.md#implement-mode-plan` and the implementation rules in
 Before asking for agreement to edit a feature, read
 `references/implementation-proposal.md` and present that decision packet. It
 must lead with `## Solution Shape` and include a self-contained `What`, `Why`,
-and `How` decision summary. `Approved FEATURE-N` approves this solution shape and starts implementation. `Approved FEATURE-N with agents` approves this solution shape and authorizes sub-agents for implementation or fresh review when useful. The `with a goal` and `with agents and a goal` tails apply here too.
+and `How` decision summary. `Approved <ID>-N` using the prefix from `ledger.yaml` approves this solution shape and starts implementation. `Approved <ID>-N with agents` approves this solution shape and authorizes sub-agents for implementation or fresh review when useful. The `with a goal` and `with agents and a goal` tails apply here too.
 
 These feature implementation rules remain mandatory:
 
@@ -141,17 +141,17 @@ These feature implementation rules remain mandatory:
 - Use `$doc-standards` when the feature changes public commands, APIs, examples,
   configuration, or documented workflows.
 - Use `$change-validation` when selecting validation commands.
-- Report `Red`, `Green`, `Refactor`, and `Validation` entries. `Red` and `Green` must each paste the actual command and its real output using the same command/selector; a label without pasted output is not acceptable, and work where red was never observed before implementation must be labeled `test-after (not TDD)` with the reason instead of a TDD cycle. Use `Refactor: none (<reason>)` when no cleanup was needed after green. Ask the human to verify and say `Done FEATURE-N`.
+- Report `Red`, `Green`, `Refactor`, and `Validation` entries. `Red` and `Green` must each paste the actual command and its real output using the same command/selector; a label without pasted output is not acceptable, and work where red was never observed before implementation must be labeled `test-after (not TDD)` with the reason instead of a TDD cycle. Use `Refactor: none (<reason>)` when no cleanup was needed after green. Ask the human to verify and say `Done <ID>-N` using the prefix from `ledger.yaml`.
 
 ## References
 
 - Read `references/plan.md` before starting Find mode or Implement mode.
 - Read `references/find-rules.md` during Find mode before reviewing or
   recording candidates.
-- Read `references/acceptance-gate.md` before recording any `FEATURES.md`
+- Read `references/acceptance-gate.md` before recording any scoped-ledger
   candidate.
-- Read `references/ledger-format.md` before creating, updating, or interpreting
-  `FEATURES.md`.
+- Read `ledger.yaml` and `references/ledger-format.md` before creating,
+  updating, or interpreting the scoped ledger.
 - Read `references/implementation-proposal.md` before asking for agreement to
   edit a feature.
 - Read `../references/gap-workflow.md` for shared scoped-ledger and delegation

--- a/skills/feature-gaps/agents/openai.yaml
+++ b/skills/feature-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Feature Gaps"
   short_description: "Find product feature opportunities"
-  default_prompt: "Use $feature-gaps for scoped product-facing capability opportunities with explicit audience benefit. Default to Find mode when no mode is stated; follow repo archetype lead generation, apply the shared delegation gate, summarize ledger entries in a compact Title/What/Why table, put Solution Shape first, answer feature ID follow-ups such as FEATURE-1, implement only after explicit agreement to a specific proposal, and route test/project gaps elsewhere."
+  default_prompt: "Use $feature-gaps for scoped product-facing capability opportunities with explicit audience benefit. Default to Find mode when no mode is stated; follow repo archetype lead generation, apply the shared delegation gate, summarize ledger entries in a compact Title/What/Why table, put Solution Shape first, resolve entry ID follow-ups through ledger.yaml, implement only after explicit agreement to a specific proposal, and route test/project gaps elsewhere."

--- a/skills/feature-gaps/ledger.yaml
+++ b/skills/feature-gaps/ledger.yaml
@@ -1,0 +1,4 @@
+version: 1
+id_prefix: FEATURE
+ledger_filename: FEATURES.md
+ledger_path_template: "{scope}/{ledger_filename}"

--- a/skills/feature-gaps/references/acceptance-gate.md
+++ b/skills/feature-gaps/references/acceptance-gate.md
@@ -1,6 +1,6 @@
 # Feature-Gap Acceptance Gate
 
-Apply this gate before recording any candidate in `FEATURES.md`. A feature
+Apply this gate before recording any candidate in the resolved scoped ledger. A feature
 proposal must satisfy every item below at or above the active confidence
 threshold. The active threshold is the explicit confidence target in the
 current request when one is provided; otherwise it is 90% by default (or 95%

--- a/skills/feature-gaps/references/find-rules.md
+++ b/skills/feature-gaps/references/find-rules.md
@@ -2,8 +2,7 @@
 
 These rules remain mandatory:
 
-- Use `FEATURES.md` in the requested package or folder as the proposal ledger,
-  for example `PACKAGE_OR_FOLDER/FEATURES.md`.
+- Read `../ledger.yaml` and use its resolved scoped path as the proposal ledger.
 - Before assigning review agents or starting local review, build a recursive
   scope inventory for the requested package or folder: relevant file count,
   first-level subfolders, nested packages, dominant languages, tests, public
@@ -25,7 +24,7 @@ These rules remain mandatory:
   as the proposed feature surface requires. Agents must use `$testing-standards`
   and `$project-workflow` to route test-harness, build, CI, Makefile, release,
   validation, command-discovery, or repository-workflow candidates away from
-  `FEATURES.md` before returning feature proposals.
+  the resolved scoped ledger before returning feature proposals.
 - Confirm each candidate feature against `acceptance-gate.md`, code, generated
   surfaces, framework wrappers, shared helpers, vendored dependency behavior
   when delegated, docs, tests, examples, command behavior, current

--- a/skills/feature-gaps/references/implementation-proposal.md
+++ b/skills/feature-gaps/references/implementation-proposal.md
@@ -2,9 +2,9 @@
 
 Before asking for agreement to edit a feature, present a compact decision card.
 Its job is to make the *what*, *why*, *how*, and ask understandable without
-opening `FEATURES.md` or source files. Lead with `## Solution Shape` (the
+opening the scoped ledger or source files. Lead with `## Solution Shape` (the
 concrete implementation shape), then give a self-contained decision summary and
-the main cost to watch. Keep `FEATURE-N` as the full mini-PRD and include its ID
+the main cost to watch. Keep the selected ledger entry as the full mini-PRD and include its ID
 so the reader can find it; do not use it as a substitute for the summary or bury
 the ask after a long plan update. The `## Decision` block is the shared decision
 card (`../../references/decision-card.md`);
@@ -42,24 +42,24 @@ validation:
 | What | Current audience outcome -> expected audience outcome, in one plain sentence. |
 | Why | Audience impact plus the strongest observed evidence. |
 | How | This solution shape, what remains unchanged, and how success will be proved. |
-| Scope | FEATURE-N and the smallest package/config/doc surfaces needed. |
+| Scope | Selected ledger entry and the smallest package/config/doc surfaces needed. |
 | Compatibility | Additive \| Breaking \| Mixed, with the concrete reason. |
 | Confidence | 94% — one-line reason; active threshold is the explicit request, otherwise 90% (or 95% for high-risk acceptance). |
 | Watch | The main compatibility, maintenance, dependency, security, or config-surface cost to weigh. |
 
-Source mini-PRD: FEATURE-N in `FEATURES.md`. This locator is for deeper
+Source mini-PRD: selected entry in the resolved scoped ledger. This locator is for deeper
 verification; the decision above must stand on its own.
 
 Approval command:
 
-- `Approved FEATURE-N` approves this solution shape and starts implementation.
-- `Approved FEATURE-N with agents` approves this solution shape and authorizes
+- `Approved <ID>-N` using the prefix from `../ledger.yaml` approves this solution shape and starts implementation.
+- `Approved <ID>-N with agents` using the prefix from `../ledger.yaml` approves this solution shape and authorizes
   sub-agents for implementation or fresh review when useful. The `with a goal`
   and `with agents and a goal` tails apply here too.
 ````
 
 Add this section only when a real fork exists in *how* to implement the feature;
-omit it otherwise (feature-level alternatives stay in the `FEATURES.md` entry):
+omit it otherwise (feature-level alternatives stay in the scoped ledger entry):
 
 ````markdown
 ### Other Shapes Considered

--- a/skills/feature-gaps/references/ledger-format.md
+++ b/skills/feature-gaps/references/ledger-format.md
@@ -1,4 +1,4 @@
-# `FEATURES.md` Format
+# Ledger Format
 
 Each entry is a self-contained, debatable mini-PRD: the product form of the
 shared mini-RFC. A reviewer must be able to understand the opportunity, the
@@ -24,7 +24,7 @@ Use this structure for every entry:
 ````markdown
 # Features
 
-## FEATURE-1: Short concrete title
+## <ID>-1: Short concrete title
 
 | Field | Value |
 | --- | --- |

--- a/skills/feature-gaps/references/plan.md
+++ b/skills/feature-gaps/references/plan.md
@@ -12,7 +12,7 @@ validation, delegation, external research, ledger state, and workflow routing.
 
 1. Follow `../../references/gap-workflow.md#common-plan-mechanics` for shared
    find-mode sequencing. Apply the shared gap-workflow delegation gate before review work.
-2. Use `FEATURES.md` as the scoped ledger and `FEATURE-<number>` IDs.
+2. Read `../ledger.yaml`; use its scoped ledger path and ID prefix.
 3. Read `../../references/gap-lead-generation.md`, classify the repository
    archetype, and build a lead inventory for product-facing capabilities,
    package-consumer workflows, service-author workflows, operator surfaces, and
@@ -45,7 +45,7 @@ validation, delegation, external research, ledger state, and workflow routing.
    workflows, public commands/APIs or package-consumer paths, comparable-tool
    research decisions, rejected and routed leads, validation evidence, and
    policy exclusions checked.
-10. If confirmed gaps remain, write scoped `FEATURES.md`, present the ledger,
+10. If confirmed gaps remain, write the resolved scoped ledger, present it,
    coverage state, proposed implementation plan, and runnable follow-up scopes,
    then stop before implementing features.
 
@@ -61,7 +61,7 @@ validation, delegation, external research, ledger state, and workflow routing.
    asking for agreement. It must lead with `## Solution Shape`, make the
    proposed design visually scannable before confidence or evidence details,
    show tradeoffs visually, name intended validation, and end by pointing to
-   the canonical `Approved FEATURE-N` and `Approved FEATURE-N with agents`
+   the canonical `Approved <ID>-N` and `Approved <ID>-N with agents` forms
    approval commands.
 4. After agreement, state local code/config/docs pattern, dominant relevant
    test harness, planned validation, and deviations. For behavior-changing

--- a/skills/project-gaps/SKILL.md
+++ b/skills/project-gaps/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: project-gaps
-description: Use when the user asks to find or implement $project-gaps/project gaps in a package or folder, set a confidence closure target such as 95% or 99%, find build, CI, Makefile, release, setup, validation, command discovery, or repository workflow gaps, uses Start PROJECT-1 or Approved PROJECT-1 with agents and a goal, asks about project gap IDs such as PROJECT-1, asks what the fix is for PROJECT-1, asks to fix or verify PROJECT-1, or uses Done PROJECT-1. Find concrete repository workflow and project plumbing improvements; record scoped PROJECTS.md entries; later propose and implement agreed fixes one at a time.
+description: Use when the user asks to find or implement $project-gaps/project gaps in a package or folder, set a confidence closure target such as 95% or 99%, find build, CI, Makefile, release, setup, validation, command discovery, or repository workflow gaps, uses Start, Approved, or Done with ledger entry IDs and optional agents or a goal, or asks what the fix is for a project-gap ledger entry. Find concrete repository workflow and project plumbing improvements; record scoped ledger entries; later propose and implement agreed fixes one at a time.
 ---
 
 # Project Gaps
 
 Use Find mode by default when no mode is stated. Enter Implement mode only
 after the human explicitly agrees to a specific proposed solution, typically
-with `Approved PROJECT-N`. Do not combine modes in one pass:
+with `Approved <ID>-N` using the prefix from `ledger.yaml`. Do not combine modes in one pass:
 
 - **Find mode**: `Find $project-gaps in PACKAGE_OR_FOLDER` or `Find project gaps in PACKAGE_OR_FOLDER`.
 - **Implement mode**: `Implement $project-gaps in PACKAGE_OR_FOLDER` or `Implement project gaps in PACKAGE_OR_FOLDER`.
 
-Before either mode, read `references/plan.md` and
+Before either mode, read `ledger.yaml`, `references/plan.md`, and
 `../references/gap-workflow.md` and the mode-specific reference below own
 runtime state, ledger, delegation,
 scope, coverage, confidence, and approval gates. Before Find mode, also read
@@ -41,7 +41,7 @@ to this repository's workflow ownership, audience, and maintenance posture.
 
 ## Acceptance Gate
 
-Before recording any `PROJECTS.md` candidate, read
+Before recording any scoped-ledger candidate, read
 `references/acceptance-gate.md`. A proposal must satisfy that gate at the
 active confidence threshold or higher. Use an explicit confidence target from
 the current request when provided; otherwise use the 90% default (or the 95%
@@ -61,9 +61,9 @@ If a candidate's implementation home is outside the requested scope, route it
 according to `references/find-rules.md` instead of recording it as a normal
 local project gap.
 
-## `PROJECTS.md` Format
+## Ledger Format
 
-Before creating, updating, or interpreting `PROJECTS.md`, read
+Before creating, updating, or interpreting the scoped ledger, read `ledger.yaml` and
 `references/ledger-format.md`. Each entry is a self-contained mini-RFC using
 `What -> Why -> How`. The required core must keep `| Field | Value |`,
 `| Status |`, and `**Summary.**`; `### What` with `**Current.**` and
@@ -109,17 +109,17 @@ These project-gap implementation rules remain mandatory:
 - Use `$doc-standards` when the project change affects public commands, Make
   targets, setup, validation, release, configuration, or documented workflows.
 - Use `$change-validation` when selecting validation commands.
-- Report `Red`, `Green`, `Refactor`, and `Validation` entries. `Red` and `Green` must each paste the actual command and its real output using the same command/selector; a label without pasted output is not acceptable, and work where red was never observed before implementation must be labeled `test-after (not TDD)` with the reason instead of a TDD cycle. Use `Refactor: none (<reason>)` when no cleanup was needed after green. Ask the human to verify and say `Done PROJECT-N`.
+- Report `Red`, `Green`, `Refactor`, and `Validation` entries. `Red` and `Green` must each paste the actual command and its real output using the same command/selector; a label without pasted output is not acceptable, and work where red was never observed before implementation must be labeled `test-after (not TDD)` with the reason instead of a TDD cycle. Use `Refactor: none (<reason>)` when no cleanup was needed after green. Ask the human to verify and say `Done <ID>-N` using the prefix from `ledger.yaml`.
 
 ## References
 
 - Read `references/plan.md` before starting Find mode or Implement mode.
 - Read `references/find-rules.md` during Find mode before reviewing or
   recording candidates.
-- Read `references/acceptance-gate.md` before recording any `PROJECTS.md`
+- Read `references/acceptance-gate.md` before recording any scoped-ledger
   candidate.
-- Read `references/ledger-format.md` before creating, updating, or interpreting
-  `PROJECTS.md`.
+- Read `ledger.yaml` and `references/ledger-format.md` before creating,
+  updating, or interpreting the scoped ledger.
 - Read `../references/gap-workflow.md` for shared scoped-ledger and delegation
   gates; read `../references/gap-workflow/find-audit.md` for Find-mode rules and
   `../references/gap-workflow/implementation.md` for Implement-mode rules.

--- a/skills/project-gaps/agents/openai.yaml
+++ b/skills/project-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Project Gaps"
   short_description: "Find scoped project workflow gaps"
-  default_prompt: "Use $project-gaps for scoped build, CI, Makefile, release, setup, dependency, validation, and workflow gaps. Default to Find mode when no mode is stated; follow repo archetype lead generation, apply the shared delegation gate, summarize ledger entries in a compact Title/What/Why table, classify implementation home as current repo, shared bin, external repo, or mixed, answer project gap ID follow-ups such as PROJECT-1, and implement only after explicit agreement to a specific proposal."
+  default_prompt: "Use $project-gaps for scoped build, CI, Makefile, release, setup, dependency, validation, and workflow gaps. Default to Find mode when no mode is stated; follow repo archetype lead generation, apply the shared delegation gate, summarize ledger entries in a compact Title/What/Why table, classify implementation home as current repo, shared bin, external repo, or mixed, resolve entry ID follow-ups through ledger.yaml, and implement only after explicit agreement to a specific proposal."

--- a/skills/project-gaps/ledger.yaml
+++ b/skills/project-gaps/ledger.yaml
@@ -1,0 +1,4 @@
+version: 1
+id_prefix: PROJECT
+ledger_filename: PROJECTS.md
+ledger_path_template: "{scope}/{ledger_filename}"

--- a/skills/project-gaps/references/acceptance-gate.md
+++ b/skills/project-gaps/references/acceptance-gate.md
@@ -1,6 +1,6 @@
 # Project-Gap Acceptance Gate
 
-Apply this gate before recording any candidate in `PROJECTS.md`. A project
+Apply this gate before recording any candidate in the resolved scoped ledger. A project
 proposal must satisfy every item below at or above the active confidence
 threshold. The active threshold is the explicit confidence target in the
 current request when one is provided; otherwise it is 90% by default (or 95%

--- a/skills/project-gaps/references/find-rules.md
+++ b/skills/project-gaps/references/find-rules.md
@@ -2,8 +2,7 @@
 
 These rules remain mandatory:
 
-- Use `PROJECTS.md` in the requested package or folder as the proposal ledger,
-  for example `PACKAGE_OR_FOLDER/PROJECTS.md`.
+- Read `../ledger.yaml` and use its resolved scoped path as the proposal ledger.
 - Classify every candidate's implementation home before recording it. Use:
   `current repo` when the requested scope owns the fix; `shared bin` when
   reusable `bin` tooling owns the fix; `external repo` when another repository,
@@ -13,7 +12,7 @@ These rules remain mandatory:
   both necessary.
 - Treat third-party library, framework, tool, and image defects as project
   workflow candidates only for the repository-owned response. The upstream
-  defect itself is not a normal `PROJECT-N` for the current scope.
+  defect itself is not a normal scoped ledger entry for the current scope.
 - Before assigning review agents or starting local review, build a recursive
   scope inventory for the requested package or folder: relevant file count,
   first-level subfolders, nested packages, dominant languages, Makefiles, CI
@@ -52,7 +51,7 @@ These rules remain mandatory:
   `$feature-gaps`.
 - If a candidate mostly documents existing behavior, route it to `$doc-gaps`.
 - If a candidate's implementation home is outside the requested scope, do not
-  record it as a normal `PROJECT-N` for that scope. Record it under
+  record it as a normal scoped ledger entry for that scope. Record it under
   `Routed Project Follow-Ups` with the owning home and local evidence, or route
   it to a separate project-gaps run in the owning repository or shared tooling
   scope.

--- a/skills/project-gaps/references/ledger-format.md
+++ b/skills/project-gaps/references/ledger-format.md
@@ -1,4 +1,4 @@
-# `PROJECTS.md` Format
+# Ledger Format
 
 Each entry is a self-contained, debatable mini-RFC. A reviewer must be able to
 understand the workflow gap, the evidence, and the proposed direction without
@@ -23,7 +23,7 @@ Use this structure for every entry:
 ````markdown
 # Projects
 
-## PROJECT-1: Short concrete title
+## <ID>-1: Short concrete title
 
 | Field | Value |
 | --- | --- |

--- a/skills/project-gaps/references/plan.md
+++ b/skills/project-gaps/references/plan.md
@@ -12,7 +12,7 @@ implementation home, validation, delegation, ledger state, and workflow routing.
 
 1. Follow `../../references/gap-workflow.md#common-plan-mechanics` for shared
    find-mode sequencing. Apply the shared gap-workflow delegation gate before review work.
-2. Use `PROJECTS.md` as the scoped ledger and `PROJECT-<number>` IDs.
+2. Read `../ledger.yaml`; use its scoped ledger path and ID prefix.
 3. Read `../../references/gap-lead-generation.md`, classify the repository
    archetype, and build a lead inventory for build, CI, release, setup,
    validation, command-discovery, dependency/tooling, generated-artifact, and
@@ -37,7 +37,7 @@ implementation home, validation, delegation, ledger state, and workflow routing.
    validation and release paths, command-discovery surfaces, implementation
    homes, rejected and routed leads, validation evidence, and policy exclusions
    checked.
-9. If confirmed gaps remain, write scoped `PROJECTS.md`, present the ledger,
+9. If confirmed gaps remain, write the resolved scoped ledger, present it,
    coverage state, proposed implementation plan, and runnable follow-up scopes,
    then stop before implementing project changes.
 

--- a/skills/references/gap-workflow.md
+++ b/skills/references/gap-workflow.md
@@ -10,8 +10,9 @@ summary shape.
 - If no scope is provided, stop and ask for the package or folder.
 - Treat remembered commands as gap-workflow shorthand. `Start` begins the
   workflow, `Approved` accepts the presented solution, and `Done` confirms an
-  entry is verified. Each takes the optional tail `in LEDGER_PATH` when an ID
-  is ambiguous, and `with agents`, `with a goal`, or `with agents and a goal`:
+  entry is verified. Each takes the optional tail `in LEDGER_PATH` only when a
+  selected ledger skill and scope cannot resolve the entry, and `with agents`,
+  `with a goal`, or `with agents and a goal`:
   - `Start ID` selects the matching gap skill and enters implement mode for the
     entry. `Start ID1/ID2 in LEDGER_PATH` selects multiple entries.
   - `Start ID with agents` explicitly authorizes sub-agents for the current
@@ -76,7 +77,21 @@ summary shape.
 
 Use these mechanics with the selected skill's `references/plan.md`. The plan
 names the domain-specific inventory surfaces, candidate tests, closeout
-questions, ledger filename, ID prefix, and implementation pairings.
+questions, and implementation pairings.
+
+## Ledger Contract Resolution
+
+- Each ledger skill owns `ledger.yaml`. It is the authoritative source of its
+  `id_prefix`, `ledger_filename`, and `ledger_path_template` values.
+- When the selected ledger skill and scope are known, read that contract and
+  resolve the exact ledger path by substituting the scope and ledger filename
+  into `ledger_path_template`. The version-1 template is
+  `{scope}/{ledger_filename}`.
+- For `Start`, `Approved`, and `Done`, validate the ID against the resolved
+  contract prefix, then read or update only the resolved ledger path. Do not
+  search the workspace for possible ledgers or infer a different ledger path.
+- An explicit `in LEDGER_PATH` tail remains available only when the selected
+  skill or scope is ambiguous. Once both are known, the contract path wins.
 
 ## Mode-Specific References
 
@@ -94,12 +109,12 @@ rejected, routed, deferred, and blocked leads.
 
 ## Scoped Ledgers
 
-- Before creating or updating a scoped ledger, ensure the consuming repository
-  root `.gitignore` exists and contains that ledger filename as a standalone
+- Before creating or updating a scoped ledger, read the selected skill's
+  `ledger.yaml`; ensure the consuming repository root `.gitignore` exists and
+  contains its `ledger_filename` as a standalone
   pattern. Checking or reading an existing ledger must not modify `.gitignore`.
-- Use the selected skill's ledger filename in the requested package or folder,
-  such as `PACKAGE_OR_FOLDER/ISSUES.md`, `TESTS.md`, `DOCS.md`, `FEATURES.md`,
-  `PROJECTS.md`, or `RELIABILITY.md`.
+- Use the exact path resolved from the selected skill's `ledger.yaml` and the
+  requested scope.
 - In find or audit-only modes, stop when an existing scoped ledger blocks review
   unless the selected skill explicitly allows reading or refreshing it. In
   implement mode, read it first; if it does not exist, ask whether to run find
@@ -108,8 +123,7 @@ rejected, routed, deferred, and blocked leads.
   without requiring migration. Rewrite them to the current `What` / `Why` /
   `How` shape only when creating or updating that entry.
 - Record durable findings or proposals only in the selected scoped ledger and
-  assign IDs using its prefix, such as `ISSUE-N`, `TEST-N`, `DOC-N`,
-  `FEATURE-N`, `PROJECT-N`, or `REL-N`.
+  assign IDs using the contract's `id_prefix`.
 
 ## Session Summary
 

--- a/skills/references/gap-workflow/implementation.md
+++ b/skills/references/gap-workflow/implementation.md
@@ -5,8 +5,10 @@ while implementing an agreed gap-ledger entry.
 
 ## Implement Mechanics
 
-1. Confirm scope and read the selected scoped ledger, or stop and ask whether to
-   run the matching find mode first.
+1. Confirm scope and selected ledger skill, read its `ledger.yaml`, resolve the
+   exact scoped ledger path, and read only that path. Do not search the
+   workspace for possible ledgers. If the resolved ledger is missing, stop and
+   ask whether to run the matching find mode first.
 2. Run `$project-workflow` discovery for current entrypoints, CI, documented
    commands, relevant public surfaces, and `./bin` wiring.
 3. Select the named entry or next entry and re-check its evidence against

--- a/skills/reliability-gaps/SKILL.md
+++ b/skills/reliability-gaps/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: reliability-gaps
-description: Use when the user asks to find or implement $reliability-gaps/reliability gaps in a package or folder, review production readiness, set a confidence closure target such as 95% or 99%, uses Start REL-1 or Approved REL-1 with agents and a goal, asks about reliability gap IDs such as REL-1, asks what the fix is for REL-1, asks to fix or verify REL-1, or uses Done REL-1. Find verified reliability, operability, SLO, overload, observability, release-safety, recovery, data-integrity, disaster-readiness, or NALSD gaps; record scoped RELIABILITY.md entries; implement agreed fixes gap by gap.
+description: Use when the user asks to find or implement $reliability-gaps/reliability gaps in a package or folder, review production readiness, set a confidence closure target such as 95% or 99%, uses Start, Approved, or Done with ledger entry IDs and optional agents or a goal, or asks what the fix is for a reliability-gap ledger entry. Find verified reliability, operability, SLO, overload, observability, release-safety, recovery, data-integrity, disaster-readiness, or NALSD gaps; record scoped ledger entries; implement agreed fixes gap by gap.
 ---
 
 # Reliability Gaps
 
 Use Find mode by default when no mode is stated. Enter Implement mode only
 after the human explicitly agrees to a specific proposed solution, typically
-with `Approved REL-N`. Do not combine modes in one pass:
+with `Approved <ID>-N` using the prefix from `ledger.yaml`. Do not combine modes in one pass:
 
 - **Find mode**: `Find $reliability-gaps in PACKAGE_OR_FOLDER` or `Find reliability gaps in PACKAGE_OR_FOLDER`.
 - **Implement mode**: `Implement $reliability-gaps in PACKAGE_OR_FOLDER` or `Implement reliability gaps in PACKAGE_OR_FOLDER`.
 
-Before either mode, read `references/plan.md` and
+Before either mode, read `ledger.yaml`, `references/plan.md`, and
 `../references/gap-workflow.md` and the mode-specific reference below own
 runtime state, ledger, delegation,
 scope, coverage, confidence, and approval gates. Before Find mode, also read
@@ -50,9 +50,9 @@ Follow `references/plan.md#find-mode-plan` and the find/audit rules in
 Read `references/find-rules.md`; those reliability-gap rules remain mandatory
 in Find mode.
 
-## `RELIABILITY.md` Format
+## Ledger Format
 
-Before creating, updating, or interpreting `RELIABILITY.md`, read
+Before creating, updating, or interpreting the scoped ledger, read `ledger.yaml` and
 `references/ledger-format.md`. Each entry is a self-contained mini-RFC using
 `What -> Why -> How`. The required core must keep `| Field | Value |`,
 `| Status |`, and `**Summary.**`; `### What` with `**Current.**` and
@@ -78,15 +78,15 @@ These reliability implementation rules remain mandatory:
 - For behavior-changing fixes, state the reliability execution checklist before editing: `TDD decision`, `First test/scenario`, `Expected red`, `Intended green change`, `Refactor checkpoint`, and `Validation`. When the harness is runnable, observe and paste the red (command + failing output) before implementation edits; if it is not runnable, stop and request agreement to proceed test-after with the reason rather than skipping red silently.
 - Implement only the agreed finding with the smallest clear reliability change.
 - Use `$reliability-standards` for reliability design, `$change-safety` for public or operational compatibility, `$testing-standards` for failure-path tests, and `$change-validation` for checks. Pair with `$security-audit` when the fix touches auth, secrets, privilege, DoS, logs, supply chain, or incident containment.
-- Report `Red`, `Green`, `Refactor`, and `Validation` entries. `Red` and `Green` must each paste the actual command and its real output using the same command/selector; a label without pasted output is not acceptable, and work where red was never observed before implementation must be labeled `test-after (not TDD)` with the reason instead of a TDD cycle. Use `Refactor: none (<reason>)` when no cleanup was needed after green. Ask the human to verify and say `Done REL-N`.
+- Report `Red`, `Green`, `Refactor`, and `Validation` entries. `Red` and `Green` must each paste the actual command and its real output using the same command/selector; a label without pasted output is not acceptable, and work where red was never observed before implementation must be labeled `test-after (not TDD)` with the reason instead of a TDD cycle. Use `Refactor: none (<reason>)` when no cleanup was needed after green. Ask the human to verify and say `Done <ID>-N` using the prefix from `ledger.yaml`.
 
 ## References
 
 - Read `references/plan.md` before starting Find mode or Implement mode.
 - Read `references/find-rules.md` during Find mode before reviewing or
   recording candidates.
-- Read `references/ledger-format.md` before creating, updating, or interpreting
-  `RELIABILITY.md`.
+- Read `ledger.yaml` and `references/ledger-format.md` before creating,
+  updating, or interpreting the scoped ledger.
 - Read `../references/gap-workflow.md` for shared scoped-ledger and delegation
   gates; read `../references/gap-workflow/find-audit.md` for Find-mode rules and
   `../references/gap-workflow/implementation.md` for Implement-mode rules.

--- a/skills/reliability-gaps/agents/openai.yaml
+++ b/skills/reliability-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Reliability Gaps"
   short_description: "Find scoped SRE readiness gaps"
-  default_prompt: "Use $reliability-gaps for scoped SRE, operability, overload, observability, release-safety, recovery, and data-integrity gaps. Default to Find mode when no mode is stated; follow repo archetype lead generation, apply the shared delegation gate, summarize ledger entries in a compact Title/What/Why table, verify concrete failure paths, answer reliability gap ID follow-ups such as REL-1, and implement only after explicit agreement to a specific proposal."
+  default_prompt: "Use $reliability-gaps for scoped SRE, operability, overload, observability, release-safety, recovery, and data-integrity gaps. Default to Find mode when no mode is stated; follow repo archetype lead generation, apply the shared delegation gate, summarize ledger entries in a compact Title/What/Why table, verify concrete failure paths, resolve entry ID follow-ups through ledger.yaml, and implement only after explicit agreement to a specific proposal."

--- a/skills/reliability-gaps/ledger.yaml
+++ b/skills/reliability-gaps/ledger.yaml
@@ -1,0 +1,4 @@
+version: 1
+id_prefix: REL
+ledger_filename: RELIABILITY.md
+ledger_path_template: "{scope}/{ledger_filename}"

--- a/skills/reliability-gaps/references/find-rules.md
+++ b/skills/reliability-gaps/references/find-rules.md
@@ -2,8 +2,7 @@
 
 These rules remain mandatory:
 
-- Use `RELIABILITY.md` in the requested package or folder as the review ledger,
-  for example `PACKAGE_OR_FOLDER/RELIABILITY.md`.
+- Read `../ledger.yaml` and use its resolved scoped path as the review ledger.
 - Prefer slices based on repository-owned reliability and operational risk: public commands/APIs, changed or recently touched areas, retries/timeouts/backpressure, config/CI/release paths, observability/runbook surfaces, documented workflows, and nearby tests. Use depth only as a discovery aid, not as the review boundary.
 - For delegated review, each assigned agent owns recursive review only within its bounded slice. Each agent must perform a thorough `$reliability-standards` review for that slice, pairing with `$change-safety`, `$security-audit`, `$testing-standards`, and `$change-validation` as the surface requires.
 - Confirm each candidate gap against current evidence before recording it. Try to disprove the candidate by tracing the current code path, reading the documented workflow, checking the relevant config, inspecting existing tests, or running an allowed local command. A gap must name the affected reliability promise or operational expectation, the trigger condition, the failure mode, the missing or weak control, and the likely user or operator impact.

--- a/skills/reliability-gaps/references/ledger-format.md
+++ b/skills/reliability-gaps/references/ledger-format.md
@@ -1,4 +1,4 @@
-# `RELIABILITY.md` Format
+# Ledger Format
 
 Each entry is a self-contained, debatable mini-RFC. A reviewer must be able to
 understand the failure mode, the evidence, and the proposed control without
@@ -23,7 +23,7 @@ Use this structure for every entry:
 ````markdown
 # Reliability
 
-## REL-1: Short concrete title
+## <ID>-1: Short concrete title
 
 | Field | Value |
 | --- | --- |

--- a/skills/reliability-gaps/references/plan.md
+++ b/skills/reliability-gaps/references/plan.md
@@ -13,7 +13,7 @@ evidence.
 
 1. Follow `../../references/gap-workflow.md#common-plan-mechanics` for shared
    find-mode sequencing. Apply the shared gap-workflow delegation gate before review work.
-2. Use `RELIABILITY.md` as the scoped ledger and `REL-<number>` IDs.
+2. Read `../ledger.yaml`; use its scoped ledger path and ID prefix.
 3. Run `$project-workflow` discovery and the shared audit preflight, including
    applicable tools, service dependencies, validation ladder, and command
    failure classification.
@@ -49,7 +49,7 @@ evidence.
    representative stress, race, outage, fault-injection, sidecar, integration,
    freshness, or operator-scenario evidence is a confidence limiter or routed
    follow-up unless a current repository-owned failure mode is confirmed.
-11. If confirmed gaps remain, write scoped `RELIABILITY.md`, present the ledger,
+11. If confirmed gaps remain, write the resolved scoped ledger, present it,
     coverage state, proposed reliability-fix plan, and runnable follow-up
     scopes, then stop before fixing.
 

--- a/skills/reliability-standards/SKILL.md
+++ b/skills/reliability-standards/SKILL.md
@@ -74,7 +74,7 @@ evidence.
 ## Boundaries
 
 - Use `$reliability-gaps` when the user asks to find or implement scoped
-  reliability gaps through a `RELIABILITY.md` ledger.
+  reliability gaps through that skill's contract-resolved ledger.
 - Use `$code-review` or `$code-issues` when the finding is a concrete bug,
   violated contract, or broken behavior rather than a missing reliability
   control.

--- a/skills/style-review/SKILL.md
+++ b/skills/style-review/SKILL.md
@@ -41,7 +41,7 @@ security, compatibility, testing, or documentation findings.
 8. Prefer concrete suggestions over taste. Each note should explain why the
    change would make the code easier to read, maintain, or align with local
    patterns.
-9. Do not create or update `ISSUES.md`; style notes are not ledger findings.
+9. Do not create or update a code-issue ledger; style notes are not ledger findings.
 10. For standalone output, use `references/output-format.md`.
 11. When another skill embeds style notes, preserve the non-blocking nature,
    file references, suggestions, and rationale in the caller's output format.

--- a/skills/test-gaps/SKILL.md
+++ b/skills/test-gaps/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: test-gaps
-description: Use when the user asks to find or implement $test-gaps/test gaps in a package or folder, set a confidence closure target such as 95% or 99%, find flaky tests, wrong-layer tests, weak harnesses, or test-support-code gaps, uses Start TEST-1 or Approved TEST-1 with agents and a goal, asks about test gap IDs such as TEST-1, asks what the fix is for TEST-1, asks to fix or verify TEST-1, or uses Done TEST-1. Find concrete missing, weak, misleading, flaky, wrong-layer, or brittle coverage; record scoped TESTS.md entries; later propose and implement agreed fixes gap by gap.
+description: Use when the user asks to find or implement $test-gaps/test gaps in a package or folder, set a confidence closure target such as 95% or 99%, find flaky tests, wrong-layer tests, weak harnesses, or test-support-code gaps, uses Start, Approved, or Done with ledger entry IDs and optional agents or a goal, or asks what the fix is for a test-gap ledger entry. Find concrete missing, weak, misleading, flaky, wrong-layer, or brittle coverage; record scoped ledger entries; later propose and implement agreed fixes gap by gap.
 ---
 
 # Test Gaps
 
 Use Find mode by default when no mode is stated. Enter Implement mode only
 after the human explicitly agrees to a specific proposed solution, typically
-with `Approved TEST-N`. Do not combine modes in one pass:
+with `Approved <ID>-N` using the prefix from `ledger.yaml`. Do not combine modes in one pass:
 
 - **Find mode**: `Find $test-gaps in PACKAGE_OR_FOLDER` or `Find test gaps in PACKAGE_OR_FOLDER`.
 - **Implement mode**: `Implement $test-gaps in PACKAGE_OR_FOLDER` or `Implement test gaps in PACKAGE_OR_FOLDER`.
 
-Before either mode, read `references/plan.md` and
+Before either mode, read `ledger.yaml`, `references/plan.md`, and
 `../references/gap-workflow.md` and the mode-specific reference below own
 runtime state, ledger, delegation,
 scope, coverage, confidence, and approval gates. Before Find mode, also read
@@ -53,9 +53,9 @@ Follow `references/plan.md#find-mode-plan` and the find/audit rules in
 Read `references/find-rules.md`; those test-gap rules remain mandatory in Find
 mode.
 
-## `TESTS.md` Format
+## Ledger Format
 
-Before creating, updating, or interpreting `TESTS.md`, read
+Before creating, updating, or interpreting the scoped ledger, read `ledger.yaml` and
 `references/ledger-format.md`. Each entry is a self-contained mini-RFC using
 `What -> Why -> How`. The required core must keep `| Field | Value |`,
 `| Status |`, and `**Summary.**`; `### What` with `**Current.**` and
@@ -81,15 +81,15 @@ These test-gap implementation rules remain mandatory:
 - Implement only the agreed finding with the smallest clear test change, preferring the existing local test shape over new standalone structure.
 - Use `$testing-standards` for test design and pair with the relevant language standard for local idioms. If implementing the test gap requires production behavior to change, prefer the test-first or scenario-first loop from `$testing-standards`.
 - For test gaps that require behavior-changing production code, state the test execution checklist before editing: `TDD decision`, `First test/scenario`, `Expected red`, `Intended green change`, `Refactor checkpoint`, and `Validation`. When the harness is runnable, observe and paste the red (command + failing output) before implementation edits; if it is not runnable, stop and request agreement to proceed test-after with the reason rather than skipping red silently.
-- Report `Red`, `Green`, `Refactor`, and `Validation` entries. `Red` and `Green` must each paste the actual command and its real output using the same command/selector; a label without pasted output is not acceptable, and work where red was never observed before implementation must be labeled `test-after (not TDD)` with the reason instead of a TDD cycle. Use `Refactor: none (<reason>)` when no cleanup was needed after green. Ask the human to verify and say `Done TEST-N`.
+- Report `Red`, `Green`, `Refactor`, and `Validation` entries. `Red` and `Green` must each paste the actual command and its real output using the same command/selector; a label without pasted output is not acceptable, and work where red was never observed before implementation must be labeled `test-after (not TDD)` with the reason instead of a TDD cycle. Use `Refactor: none (<reason>)` when no cleanup was needed after green. Ask the human to verify and say `Done <ID>-N` using the prefix from `ledger.yaml`.
 
 ## References
 
 - Read `references/plan.md` before starting Find mode or Implement mode.
 - Read `references/find-rules.md` during Find mode before reviewing or
   recording candidates.
-- Read `references/ledger-format.md` before creating, updating, or interpreting
-  `TESTS.md`.
+- Read `ledger.yaml` and `references/ledger-format.md` before creating,
+  updating, or interpreting the scoped ledger.
 - Read `../references/gap-workflow.md` for shared scoped-ledger and delegation
   gates; read `../references/gap-workflow/find-audit.md` for Find-mode rules and
   `../references/gap-workflow/implementation.md` for Implement-mode rules.

--- a/skills/test-gaps/agents/openai.yaml
+++ b/skills/test-gaps/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Test Gaps"
   short_description: "Find weak tests and harness gaps"
-  default_prompt: "Use $test-gaps for scoped missing, weak, misleading, flaky, wrong-layer, or harness coverage gaps. Default to Find mode when no mode is stated; follow repo archetype lead generation, apply the shared delegation gate, summarize ledger entries in a compact Title/What/Why table, verify front-door behavior, answer test gap ID follow-ups such as TEST-1, and implement only after explicit agreement to a specific proposal."
+  default_prompt: "Use $test-gaps for scoped missing, weak, misleading, flaky, wrong-layer, or harness coverage gaps. Default to Find mode when no mode is stated; follow repo archetype lead generation, apply the shared delegation gate, summarize ledger entries in a compact Title/What/Why table, verify front-door behavior, resolve entry ID follow-ups through ledger.yaml, and implement only after explicit agreement to a specific proposal."

--- a/skills/test-gaps/ledger.yaml
+++ b/skills/test-gaps/ledger.yaml
@@ -1,0 +1,4 @@
+version: 1
+id_prefix: TEST
+ledger_filename: TESTS.md
+ledger_path_template: "{scope}/{ledger_filename}"

--- a/skills/test-gaps/references/find-rules.md
+++ b/skills/test-gaps/references/find-rules.md
@@ -2,11 +2,10 @@
 
 These rules remain mandatory:
 
-- Use `TESTS.md` in the requested package or folder as the review ledger, for
-  example `PACKAGE_OR_FOLDER/TESTS.md`.
+- Read `../ledger.yaml` and use its resolved scoped path as the review ledger.
 - Prefer slices based on repository-owned behavior and test risk: public commands/APIs, changed or recently touched areas, documented workflows, compatibility-sensitive behavior, release paths, and nearby existing tests. Use depth only as a discovery aid, not as the review boundary.
 - For delegated review, each assigned agent owns recursive review only within its bounded slice. Each agent must perform a thorough and accurate `$testing-standards` review for that slice, pairing with relevant language standards and `$change-validation` for likely validation commands.
-- For delegated review, require each agent to return findings in the same shape as the `TESTS.md` format, without final IDs unless useful locally. Each finding must name the repository-owned behavior being protected; reject findings that only test dependency semantics, aliases, or pass-through wrappers.
+- For delegated review, require each agent to return findings in the same shape as the scoped ledger format, without final IDs unless useful locally. Each finding must name the repository-owned behavior being protected; reject findings that only test dependency semantics, aliases, or pass-through wrappers.
 - Confirm each candidate gap against the code and existing tests before recording it. Gaps must be concrete missing, weak, misleading, flaky, or wrong-layer coverage with credible risk to changed behavior, public contracts, compatibility, release-sensitive workflows, or documented command/API behavior.
 - For each candidate, identify the real front door: the command, scenario,
   package/API consumer, service boundary, workflow, or documented entrypoint

--- a/skills/test-gaps/references/ledger-format.md
+++ b/skills/test-gaps/references/ledger-format.md
@@ -1,4 +1,4 @@
-# `TESTS.md` Format
+# Ledger Format
 
 Each entry is a self-contained, debatable mini-RFC. A reviewer must be able to
 understand the coverage risk, the evidence, and the proposed direction without
@@ -23,7 +23,7 @@ Use this structure for every entry:
 ````markdown
 # Tests
 
-## TEST-1: Short concrete title
+## <ID>-1: Short concrete title
 
 | Field | Value |
 | --- | --- |

--- a/skills/test-gaps/references/plan.md
+++ b/skills/test-gaps/references/plan.md
@@ -12,7 +12,7 @@ surface, validation, delegation, ledger state, and repository-owned behavior.
 
 1. Follow `../../references/gap-workflow.md#common-plan-mechanics` for shared
    find-mode sequencing. Apply the shared gap-workflow delegation gate before review work.
-2. Use `TESTS.md` as the scoped ledger and `TEST-<number>` IDs.
+2. Read `../ledger.yaml`; use its scoped ledger path and ID prefix.
 3. Read `../../references/gap-lead-generation.md`, classify the repository
    archetype, and build a lead inventory for public behavior, dominant harness,
    fixtures, generated stubs, service-feature coverage, failure paths,
@@ -32,7 +32,7 @@ surface, validation, delegation, ledger state, and repository-owned behavior.
    documented workflows, dominant harnesses, nearby tests, test-support
    surfaces, rejected and routed leads, validation evidence, and policy
    exclusions checked.
-9. If confirmed gaps remain, write scoped `TESTS.md`, present the ledger,
+9. If confirmed gaps remain, write the resolved scoped ledger, present it,
    coverage state, proposed test-fix plan, and runnable follow-up scopes, then
    stop before fixing.
 


### PR DESCRIPTION
## What

- Move each gap workflow's ID prefix, ledger filename, and scoped path template into a validated `ledger.yaml` contract.
- Update workflow guidance and metadata validation to resolve ledgers from that contract while preserving existing ledger names and ID prefixes.
- Keep skill linting compatible with the new contracts and report a missing `.gitignore` cleanly.

## Why

- A single contract prevents the repeated ledger metadata in skill instructions, plans, and validators from drifting while retaining the existing user-facing workflow.
- The compatibility checks protect shared downstream agent workflows from an incomplete or malformed ledger migration.

## Testing

- `make lint` - passed
- `make skills-lint` - passed
- `make scripts-lint` - passed
- `make sec` - passed (Trivy reported zero dependency vulnerabilities and no detected secrets)
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
