### PR TITLE
feat(make): avoid hash characters in git.mak's inline ruby snippets

### DIFF
--- a/build/make/git.mak
+++ b/build/make/git.mak
@@ -2,11 +2,11 @@
 
 BIN_ROOT ?= $(abspath $(dir $(lastword $(MAKEFILE_LIST)))../..)
 
-USER:=$(shell ruby -e 'require "etc"; print "#{Etc.getpwuid(Process.uid).name}-#{Random.rand(0...100_000)}"')
+USER:=$(shell ruby -e 'require "etc"; print Etc.getpwuid(Process.uid).name, "-", Random.rand(100_000)')
 BRANCH:=$(shell git branch --show-current)
 export BRANCH
 NEW_BRANCH:=$(subst $() ,-,$(name))
-PREFIX:=$(shell ruby -e '_, t, n = (ENV["BRANCH"] || "").split("/"); print "#{t}(#{n}):" unless t.nil?')
+PREFIX:=$(shell ruby -e '_, t, n = (ENV["BRANCH"] || "").split("/"); print "%s(%s):" % [t, n] unless t.nil?')
 export PREFIX
 
 override export msg := $(value msg)


### PR DESCRIPTION
## What

- `build/make/git.mak`'s `USER` and `PREFIX` variable assignments each run a `ruby -e` one-liner through `$(shell ...)`; both previously used Ruby string interpolation (`#{...}`), which contains literal `#` characters.
- Rewrote both one-liners to produce the same output without any literal `#`: `USER` now builds the string with `print` and comma-separated arguments instead of interpolation, and `PREFIX` now uses `"%s(%s):" % [...]` instead of interpolation.
- Output is unchanged for both: `USER` is still `<unix-username>-<random 0-99999>`, and `PREFIX` is still `type(scope):` derived from the branch name, or nothing when the branch doesn't split into three `/`-separated segments.

## Why

- Downstream consumers that vendor this project as `./bin` reported `bin/build/make/git.mak:5: unterminated call to function 'shell'` when this fragment loads. An unescaped `#` inside a `:=` variable assignment can be treated as the start of a Make comment for the rest of that physical line, truncating the `$(shell ...)` call before its closing parenthesis, depending on the Make implementation/version in use. Both affected lines are immediate (`:=`) assignments evaluated as soon as the fragment loads, so any consumer whose Make treats that `#` as a comment start hits the failure immediately on include.
- Removing the `#` characters from both one-liners avoids that failure without changing the output contract other Make targets and downstream repos depend on.

## Testing

- `make lint` - passed (RuboCop doesn't inspect `.mak` files, so this only confirms the rest of the Ruby sources are unaffected by this change)
- `make scripts-lint` - passed (ShellCheck doesn't inspect `.mak` files either)
- Ran both rewritten `ruby -e` one-liners directly and compared their output against the original interpolated versions across edge cases (a typical `user/type/scope` branch, no `BRANCH` set, a branch with no `/`, a branch with more than three segments, and a segment containing a literal `%s`/`%d`) - byte-identical output in every case.
- Did not reproduce the reported "unterminated call to function 'shell'" error locally with GNU Make 4.4.1; the failure is specific to the Make implementation/version used by the reporting downstream consumers, so this fix is validated by output-equivalence with the original Ruby snippets rather than a local repro of the original failure.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
