### PR TITLE
feat(skills): validate frontmatter shape and defer gap-workflow reference reads

### DIFF
--- a/quality/skills/metadata
+++ b/quality/skills/metadata
@@ -19,6 +19,9 @@ LEDGER_CONTRACT_KEYS = %w[
 ].freeze
 LEDGER_PATH_TEMPLATE = '{scope}/{ledger_filename}'
 BATCH_ID_SYNTAX = 'PREFIX-N[/N...]'
+SKILL_NAME_PATTERN = /\A[a-z0-9]+(?:-[a-z0-9]+)*\z/
+SKILL_NAME_LENGTH = (1..64)
+SKILL_DESCRIPTION_LENGTH = (1..1024)
 REFERENCE_PATTERN = %r{(?<!/)(?:\.\./)*references/[A-Za-z0-9._/-]+\.md(?:#[^\s`)]+)?}
 
 def present_string?(value)
@@ -90,6 +93,9 @@ def valid_skill?(path)
   [
     valid_skill_keys?(data, path),
     valid_required_strings?(data, %w[name description], path),
+    valid_skill_name_length?(data, path),
+    valid_skill_name_format?(data, path),
+    valid_skill_description_length?(data, path),
     valid_skill_name?(data, path)
   ].all?
 end
@@ -120,6 +126,27 @@ def valid_skill_name?(data, path)
   return true if data['name'] == skill_name
 
   report_failure("frontmatter name must match directory in #{path}: #{data['name'].inspect}")
+end
+
+def valid_skill_name_length?(data, path)
+  name = data['name']
+  return true if name.is_a?(String) && SKILL_NAME_LENGTH.cover?(name.length)
+
+  report_failure("frontmatter name must be 1-64 chars in #{path}")
+end
+
+def valid_skill_name_format?(data, path)
+  name = data['name']
+  return true if name.is_a?(String) && SKILL_NAME_PATTERN.match?(name)
+
+  report_failure("frontmatter name must use lowercase alphanumeric segments separated by single hyphens in #{path}")
+end
+
+def valid_skill_description_length?(data, path)
+  description = data['description']
+  return true if description.is_a?(String) && SKILL_DESCRIPTION_LENGTH.cover?(description.length)
+
+  report_failure("frontmatter description must be 1-1024 chars in #{path}")
 end
 
 def valid_markdown_references?(path)

--- a/skills/code-issues-find/SKILL.md
+++ b/skills/code-issues-find/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-issues-find
-description: Use when the user asks to find $code-issues-find/code issues in a package or folder, set a confidence closure target such as 95% or 99% for a code-issue audit, or asks what evidence backs a code-issue ledger entry. Find concrete bugs, security issues, compatibility breaks, and public contract violations and record scoped ledger entries; never edits code. Use $code-issues-implement to act on a confirmed entry.
+description: Find scoped code bugs, security issues, compatibility breaks, and public-contract violations without editing; use $code-issues-implement to implement a confirmed entry.
 ---
 
 # Code Issues Find
@@ -11,10 +11,13 @@ candidates; it never edits code. Use `$code-issues-implement` to re-check and
 implement a specific ledger entry, using the contract in
 `../code-issues-implement/ledger.yaml`.
 
-Before starting, read `../code-issues-implement/ledger.yaml`, `references/plan.md`,
-`../references/gap-workflow.md`, and `../references/gap-workflow/find-audit.md`;
-they own runtime state, ledger, delegation, scope, coverage, and confidence
-gates.
+Before starting, read `../references/gap-workflow.md` completely, then
+`references/plan.md`; they own runtime state, delegation, scope, coverage, and
+confidence gates. Read `references/find-rules.md` when beginning review. Read
+`../references/gap-workflow/find-audit.md` when beginning review mechanics.
+Read `../code-issues-implement/ledger.yaml` only when resolving the scoped
+ledger path or an entry ID, and its ledger format only before interpreting,
+creating, or updating an entry.
 
 ## Operating Stance
 
@@ -34,7 +37,7 @@ while prose disagrees, treat it as a documentation gap and route it to
 Follow `references/plan.md` and the find/audit rules in
 `../references/gap-workflow/find-audit.md`.
 
-Read `references/find-rules.md`; those code-issue rules remain mandatory.
+Those code-issue rules remain mandatory.
 
 ## Ledger Format
 

--- a/skills/code-issues-find/agents/openai.yaml
+++ b/skills/code-issues-find/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Code Issues Find"
   short_description: "Find scoped code defects and risks"
-  default_prompt: "Use $code-issues-find for scoped bug, security, compatibility, and public-contract findings. Follow repo archetype lead generation, apply the shared delegation gate, summarize ledger entries in a compact Title/What/Why table, resolve entry ID follow-ups through ../code-issues-implement/ledger.yaml, and never edit code — hand confirmed entries to $code-issues-implement."
+  default_prompt: "Use $code-issues-find to find scoped code bugs, security, compatibility, and public-contract issues without editing. After scoping, use repo archetype lead generation, apply the shared delegation gate, and hand confirmed entries to $code-issues-implement."

--- a/skills/code-issues-find/references/plan.md
+++ b/skills/code-issues-find/references/plan.md
@@ -19,14 +19,16 @@ security/compatibility evidence, and public contract evidence.
    Prefer a read-only agent type when one is available, because Find-mode
    reviewers do not edit. Never leave a sub-agent's model unset; an unset
    model silently inherits the session model.
-3. Read `../../code-issues-implement/ledger.yaml`; use its scoped ledger path
-   and ID prefix.
+3. When resolving a scoped ledger path or entry ID, read
+   `../../code-issues-implement/ledger.yaml`; use its scoped ledger path and ID
+   prefix.
 4. Run `$project-workflow` discovery and the shared audit preflight, including
    applicable tools, service dependencies, validation ladder, and command
    failure classification.
-5. Read `../../references/gap-lead-generation.md`, classify the repository
-   archetype, and build a lead inventory for code, compatibility, security,
-   mapping, generated-contract, and supported-usage risks in scope.
+5. After the repository archetype and audit scope make lead generation
+   relevant, read `../../references/gap-lead-generation.md` and build a lead
+   inventory for code, compatibility, security, mapping, generated-contract,
+   and supported-usage risks in scope.
 6. Inventory tests, public entrypoints, security-sensitive surfaces, supported
    construction/wiring paths, generated/provider mappings, and repository policy
    exclusions relevant to the requested scope.

--- a/skills/code-issues-implement/SKILL.md
+++ b/skills/code-issues-implement/SKILL.md
@@ -1,18 +1,23 @@
 ---
 name: code-issues-implement
-description: Use when the human asks to work on or asks what the fix is for a code-issue ledger entry. Re-check that the confirmed entry still stands, then implement it; named same-prefix batches run sequentially.
+description: Implement a confirmed code-issue ledger entry when explicitly requested; explain a fix proposal read-only otherwise. Use $code-issues-find to find issues.
 ---
 
 # Code Issues Implement
 
-Use this skill to work on an existing code-issue entry. Re-check that it still
-stands before editing, then implement it. Name an ordered same-prefix batch as
+Use this skill to work on an existing code-issue entry. An informational
+question about a fix receives a read-only explanation and does not authorize
+edits. Re-check an entry and implement it only when the human explicitly asks
+for implementation. Name an ordered same-prefix batch as
 `PREFIX-N[/N...]`, using the prefix from `ledger.yaml`. Use
 `$code-issues-find` first if no scoped ledger entry exists yet for this scope.
 
-Before starting, read `ledger.yaml`, `references/plan.md`,
-`../references/gap-workflow.md`, and `../references/gap-workflow/implementation.md`;
-they own runtime state, ledger, delegation, scope, and implementation gates.
+Before starting, read `../references/gap-workflow.md` completely, then
+`references/plan.md`; they own runtime state, delegation, scope, and
+implementation gates. Read `ledger.yaml` when resolving the scoped ledger path
+or entry ID, `references/ledger-format.md` only before interpreting, creating,
+or updating an entry, and `../references/gap-workflow/implementation.md` when
+beginning an actual implementation path.
 
 ## Operating Stance
 
@@ -27,8 +32,9 @@ non-prose evidence supports the implementation, explain that the ledger item
 is invalid as a code issue and propose reclassifying or fixing the
 documentation instead via `$doc-gaps-fix`.
 
-Follow `references/plan.md` and the implementation rules in
-`../references/gap-workflow/implementation.md`.
+Follow `references/plan.md`. For an actual implementation path, also follow
+the implementation rules in `../references/gap-workflow/implementation.md`;
+an informational explanation remains read-only.
 
 These code-issue implementation rules remain mandatory:
 

--- a/skills/code-issues-implement/agents/openai.yaml
+++ b/skills/code-issues-implement/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Code Issues Implement"
-  short_description: "Implement confirmed code-issue fixes"
-  default_prompt: "Use $code-issues-implement for a scoped code-issue ledger entry. Re-check the entry against current code, apply the shared delegation gate, resolve entry ID follow-ups through ledger.yaml, and implement it when the confirmed finding still stands."
+  short_description: "Implement confirmed code-issue entries"
+  default_prompt: "Use $code-issues-implement to implement a confirmed code issue only when explicitly requested; explain informational fix questions read-only, resolve entry ID follow-ups through ledger.yaml, and use $code-issues-find to find issues."

--- a/skills/doc-gaps-audit/SKILL.md
+++ b/skills/doc-gaps-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doc-gaps-audit
-description: Use when the user explicitly asks for $doc-gaps-audit, an audit-only documentation-gap pass, or to find doc gaps in a package or folder without editing. Find and record concrete missing, weak, stale, or misleading README, docs, examples, command help, package docs, public API comments, code comments, and docstrings as scoped ledger entries; never edits documentation. Use $doc-gaps-fix instead for the default find-and-fix pass.
+description: Audit scoped documentation for concrete gaps without editing; use $doc-gaps-fix to find and fix documentation gaps.
 ---
 
 # Doc Gaps Audit
@@ -10,10 +10,13 @@ Trigger phrases: `Audit-only $doc-gaps-audit in PACKAGE_OR_FOLDER` or
 discovers and records candidates; it never edits documentation. Use
 `$doc-gaps-fix` for the default find-and-fix pass.
 
-Before starting, read `../doc-gaps-fix/ledger.yaml`, `references/plan.md`,
-`../references/gap-workflow.md`, and `../references/gap-workflow/find-audit.md`;
-they own runtime state, ledger, delegation, scope, coverage, and confidence
-gates.
+Before starting, read `../references/gap-workflow.md` completely, then
+`references/plan.md`; they own runtime state, delegation, scope, coverage, and
+confidence gates. Read `references/audit-rules.md` when beginning review.
+Read `../references/gap-workflow/find-audit.md` when beginning review
+mechanics. Read `../doc-gaps-fix/ledger.yaml` only when resolving the scoped
+ledger path or an entry ID, and its ledger format only before interpreting,
+creating, or updating an entry.
 
 ## Operating Stance
 
@@ -31,7 +34,7 @@ correct the documentation.
 Follow `references/plan.md` and the find/audit rules in
 `../references/gap-workflow/find-audit.md`.
 
-Read `references/audit-rules.md`; those doc-gap rules remain mandatory.
+Those doc-gap rules remain mandatory.
 
 ## Documentation Review Standards
 

--- a/skills/doc-gaps-audit/agents/openai.yaml
+++ b/skills/doc-gaps-audit/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Doc Gaps Audit"
   short_description: "Audit scoped doc adequacy gaps only"
-  default_prompt: "Use $doc-gaps-audit with $doc-standards for a scoped documentation adequacy audit that only records findings. Follow repo archetype lead generation, apply the shared delegation gate, summarize ledger entries in a compact Title/What/Why table, resolve entry ID follow-ups through ../doc-gaps-fix/ledger.yaml, and never edit documentation — hand confirmed entries to $doc-gaps-fix."
+  default_prompt: "Use $doc-gaps-audit with $doc-standards to audit scoped documentation without editing. After scoping, use repo archetype lead generation, apply the shared delegation gate, and hand confirmed entries to $doc-gaps-fix."

--- a/skills/doc-gaps-fix/SKILL.md
+++ b/skills/doc-gaps-fix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doc-gaps-fix
-description: Use when the user asks to run $doc-gaps-fix, find/fix doc gaps in a package or folder, or fix doc gaps in a package or folder. Find and fix concrete missing, weak, stale, or misleading README, docs, examples, command help, package docs, public API comments, code comments, and docstrings in the same pass. Use $doc-gaps-audit instead when the user explicitly asks not to edit or asks only for an audit or ledger.
+description: Find and fix scoped documentation gaps when edits are requested; use $doc-gaps-audit for an audit-only or no-edit pass.
 ---
 
 # Doc Gaps Fix
@@ -11,12 +11,15 @@ and fixes documentation gaps in the same pass — it is the only skill in this
 pair that edits. Use `$doc-gaps-audit` instead when the user explicitly asks
 not to edit or asks only for an audit or ledger.
 
-Before starting, read `ledger.yaml`, `references/plan.md`, and
-`../references/gap-workflow.md`; they own runtime state, ledger, delegation,
-scope, coverage, and confidence gates. Also read
-`../references/gap-workflow/find-audit.md` for the find/review mechanics and
-`../references/gap-workflow/implementation.md` for fixing an existing
-unresolved ledger entry.
+Before starting, read `../references/gap-workflow.md` completely, then
+`references/plan.md`; they own runtime state, delegation, scope, coverage, and
+confidence gates. Read `references/fix-rules.md` and
+`../references/gap-workflow/find-audit.md` when beginning review. Read
+`ledger.yaml` when resolving the scoped ledger path or entry ID, and
+`references/ledger-format.md` only before interpreting, creating, or updating
+an entry. Read `../references/gap-workflow/implementation.md` only for an
+actual unresolved-ledger fix; a simple new documentation correction does not
+need that reference.
 
 To revisit an unresolved scoped entry, invoke this skill with its ID. Re-check
 that it still stands before editing, then fix it. Name an ordered same-prefix batch as `PREFIX-N[/N...]`, using the prefix from `ledger.yaml`.
@@ -38,7 +41,7 @@ the repository implements.
 Follow `references/plan.md` and the find/audit rules in
 `../references/gap-workflow/find-audit.md`.
 
-Read `references/fix-rules.md`; those doc-gap rules remain mandatory. Before
+Those doc-gap rules remain mandatory. Before
 editing, state the selected local documentation pattern, dominant relevant
 validation path, planned validation command, and any deviation from
 `AGENTS.md` or selected skills.

--- a/skills/doc-gaps-fix/agents/openai.yaml
+++ b/skills/doc-gaps-fix/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Doc Gaps Fix"
-  short_description: "Find and fix scoped doc adequacy gaps"
-  default_prompt: "Use $doc-gaps-fix with $doc-standards for scoped documentation adequacy gaps. Follow repo archetype lead generation, apply the shared delegation gate, summarize ledger entries in a compact Title/What/Why table, resolve entry ID follow-ups through ledger.yaml, and fix confirmed gaps in one pass. Use $doc-gaps-audit instead when the user explicitly asks not to edit."
+  short_description: "Find and fix scoped documentation gaps"
+  default_prompt: "Use $doc-gaps-fix to find and fix scoped documentation gaps when edits are requested; resolve entry ID follow-ups through ledger.yaml, or use $doc-gaps-audit for an audit-only pass."

--- a/skills/doc-gaps-fix/references/plan.md
+++ b/skills/doc-gaps-fix/references/plan.md
@@ -11,11 +11,13 @@ documentation surface.
 
 1. Follow `../../references/gap-workflow.md#common-plan-mechanics` for shared
    sequencing. Apply the shared gap-workflow delegation gate before review work.
-2. Read `../ledger.yaml`, then read the resolved scoped ledger when it is a
-   doc-gap ledger; stop if the file is unrelated or ambiguous active work. Use
-   its ID prefix for unresolved gaps.
-3. Read `../../references/gap-lead-generation.md`, classify the repository
-   archetype, and build a lead inventory for README, examples, command help,
+2. When resolving an existing scoped ledger or entry ID, read `../ledger.yaml`,
+   then read the resolved scoped ledger when it is a doc-gap ledger; stop if
+   the file is unrelated or ambiguous active work. Use its ID prefix for
+   unresolved gaps.
+3. After the repository archetype and audit scope make lead generation
+   relevant, read `../../references/gap-lead-generation.md` and build a lead
+   inventory for README, examples, command help,
    package docs, API comments, config docs, operational docs, generated-schema
    docs, and first-use workflows in scope.
 4. Inventory documentation locations, examples, command help, package docs,

--- a/skills/feature-gaps-find/SKILL.md
+++ b/skills/feature-gaps-find/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: feature-gaps-find
-description: Use when the user asks to find $feature-gaps-find/feature gaps in a package or folder, set a confidence closure target such as 95% or 99%, find main product capability gaps, find product-owned user/operator/service-author/package-consumer/CLI/API/library opportunities, or asks what evidence backs a feature-gap ledger entry. Find repository-fit feature opportunities with explicit audience benefit and record scoped ledger proposals; never edits code. Use $feature-gaps-implement to act on a confirmed entry. Do not use for standalone test, CI, build, Makefile, release, validation, or repository workflow gaps.
+description: Find repository-fit product capability gaps without editing; use $feature-gaps-implement for confirmed entries, not test or project-workflow gaps.
 ---
 
 # Feature Gaps Find
@@ -11,10 +11,14 @@ records candidates; it never edits code. Use `$feature-gaps-implement` to
 re-check and implement a specific ledger entry, using the contract in
 `../feature-gaps-implement/ledger.yaml`.
 
-Before starting, read `../feature-gaps-implement/ledger.yaml`,
-`references/plan.md`, `../references/gap-workflow.md`, and
-`../references/gap-workflow/find-audit.md`; they own runtime state, ledger,
-delegation, scope, coverage, and confidence gates.
+Before starting, read `../references/gap-workflow.md` completely, then
+`references/plan.md`; they own runtime state, delegation, scope, coverage, and
+confidence gates. Read `references/find-rules.md` when beginning review and
+`references/acceptance-gate.md` before recording a candidate. Read
+`../references/gap-workflow/find-audit.md` when beginning review mechanics.
+Read `../feature-gaps-implement/ledger.yaml` only when resolving the scoped
+ledger path or an entry ID, and its ledger format only before interpreting,
+creating, or updating an entry.
 
 ## Operating Stance
 
@@ -64,7 +68,7 @@ Otherwise gather more evidence or reject the proposal.
 Follow `references/plan.md` and the find/audit rules in
 `../references/gap-workflow/find-audit.md`.
 
-Read `references/find-rules.md`; those feature-gap rules remain mandatory.
+Those feature-gap rules remain mandatory.
 
 ## Ledger Format
 

--- a/skills/feature-gaps-find/agents/openai.yaml
+++ b/skills/feature-gaps-find/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Feature Gaps Find"
   short_description: "Find product feature opportunities"
-  default_prompt: "Use $feature-gaps-find for scoped product-facing capability opportunities with explicit audience benefit. Follow repo archetype lead generation, apply the shared delegation gate, summarize ledger entries in a compact Title/What/Why table, resolve entry ID follow-ups through ../feature-gaps-implement/ledger.yaml, route test/project gaps elsewhere, and never edit code — hand confirmed entries to $feature-gaps-implement."
+  default_prompt: "Use $feature-gaps-find to find scoped product capability gaps without editing. After scoping, use repo archetype lead generation, apply the shared delegation gate, route test and workflow gaps elsewhere, and hand confirmed entries to $feature-gaps-implement."

--- a/skills/feature-gaps-find/references/plan.md
+++ b/skills/feature-gaps-find/references/plan.md
@@ -10,10 +10,12 @@ delegation, external research, ledger state, and workflow routing.
 
 1. Follow `../../references/gap-workflow.md#common-plan-mechanics` for shared
    find-mode sequencing. Apply the shared gap-workflow delegation gate before review work.
-2. Read `../../feature-gaps-implement/ledger.yaml`; use its scoped ledger path
-   and ID prefix.
-3. Read `../../references/gap-lead-generation.md`, classify the repository
-   archetype, and build a lead inventory for product-facing capabilities,
+2. When resolving a scoped ledger path or entry ID, read
+   `../../feature-gaps-implement/ledger.yaml`; use its scoped ledger path and
+   ID prefix.
+3. After the repository archetype and audit scope make lead generation
+   relevant, read `../../references/gap-lead-generation.md` and build a lead
+   inventory for product-facing capabilities,
    package-consumer workflows, service-author workflows, operator surfaces, and
    shared-tooling capability when applicable.
 4. Inventory product-owned CLIs, APIs, libraries, service/operator behavior,

--- a/skills/feature-gaps-implement/SKILL.md
+++ b/skills/feature-gaps-implement/SKILL.md
@@ -1,18 +1,23 @@
 ---
 name: feature-gaps-implement
-description: Use when the human asks to work on or asks what the proposal is for a feature-gap ledger entry. Re-check that the confirmed entry still stands, then implement it; named same-prefix batches run sequentially.
+description: Implement a confirmed feature-gap ledger entry when explicitly requested; explain a proposal read-only otherwise. Use $feature-gaps-find to find feature gaps.
 ---
 
 # Feature Gaps Implement
 
-Use this skill to work on an existing feature-gap entry. Re-check that it still
-stands before editing, then implement it. Name an ordered same-prefix batch as
+Use this skill to work on an existing feature-gap entry. An informational
+question about a proposal receives a read-only explanation and does not
+authorize edits. Re-check an entry and implement it only when the human
+explicitly asks for implementation. Name an ordered same-prefix batch as
 `PREFIX-N[/N...]`, using the prefix from `ledger.yaml`. Use
 `$feature-gaps-find` first if no scoped ledger entry exists yet for this scope.
 
-Before starting, read `ledger.yaml`, `references/plan.md`,
-`../references/gap-workflow.md`, and `../references/gap-workflow/implementation.md`;
-they own runtime state, ledger, delegation, scope, and implementation gates.
+Before starting, read `../references/gap-workflow.md` completely, then
+`references/plan.md`; they own runtime state, delegation, scope, and
+implementation gates. Read `ledger.yaml` when resolving the scoped ledger path
+or entry ID, `references/ledger-format.md` only before interpreting, creating,
+or updating an entry, and `../references/gap-workflow/implementation.md` when
+beginning an actual implementation path.
 
 ## Operating Stance
 

--- a/skills/feature-gaps-implement/agents/openai.yaml
+++ b/skills/feature-gaps-implement/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Feature Gaps Implement"
   short_description: "Implement confirmed feature proposals"
-  default_prompt: "Use $feature-gaps-implement for a scoped feature-gap ledger entry. Re-check the entry against current code, apply the shared delegation gate, resolve entry ID follow-ups through ledger.yaml, and implement it when the confirmed finding still stands."
+  default_prompt: "Use $feature-gaps-implement to implement a confirmed feature entry only when explicitly requested; explain informational proposals read-only, resolve entry ID follow-ups through ledger.yaml, and use $feature-gaps-find to find gaps."

--- a/skills/project-gaps-find/SKILL.md
+++ b/skills/project-gaps-find/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-gaps-find
-description: Use when the user asks to find $project-gaps-find/project gaps in a package or folder, set a confidence closure target such as 95% or 99%, find build, CI, Makefile, release, setup, validation, command discovery, or repository workflow gaps, or asks what evidence backs a project-gap ledger entry. Find concrete repository workflow and project plumbing improvements and record scoped ledger entries; never edits files. Use $project-gaps-implement to act on a confirmed entry.
+description: Find scoped build, CI, Makefile, release, setup, validation, command-discovery, and workflow gaps without edits; use $project-gaps-implement for confirmed entries.
 ---
 
 # Project Gaps Find
@@ -11,10 +11,14 @@ records candidates; it never edits files. Use `$project-gaps-implement` to
 re-check and implement a specific ledger entry, using the contract in
 `../project-gaps-implement/ledger.yaml`.
 
-Before starting, read `../project-gaps-implement/ledger.yaml`,
-`references/plan.md`, `../references/gap-workflow.md`, and
-`../references/gap-workflow/find-audit.md`; they own runtime state, ledger,
-delegation, scope, coverage, and confidence gates.
+Before starting, read `../references/gap-workflow.md` completely, then
+`references/plan.md`; they own runtime state, delegation, scope, coverage, and
+confidence gates. Read `references/find-rules.md` when beginning review and
+`references/acceptance-gate.md` before recording a candidate. Read
+`../references/gap-workflow/find-audit.md` when beginning review mechanics.
+Read `../project-gaps-implement/ledger.yaml` only when resolving the scoped
+ledger path or an entry ID, and its ledger format only before interpreting,
+creating, or updating an entry.
 
 ## Operating Stance
 
@@ -49,7 +53,7 @@ Otherwise gather more evidence or reject the proposal.
 Follow `references/plan.md` and the find/audit rules in
 `../references/gap-workflow/find-audit.md`.
 
-Read `references/find-rules.md`; those project-gap rules remain mandatory.
+Those project-gap rules remain mandatory.
 
 If a candidate's implementation home is outside the requested scope, route it
 according to `references/find-rules.md` instead of recording it as a normal

--- a/skills/project-gaps-find/agents/openai.yaml
+++ b/skills/project-gaps-find/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Project Gaps Find"
   short_description: "Find scoped project workflow gaps"
-  default_prompt: "Use $project-gaps-find for scoped build, CI, Makefile, release, setup, dependency, validation, and workflow gaps. Follow repo archetype lead generation, apply the shared delegation gate, summarize ledger entries in a compact Title/What/Why table, classify implementation home as current repo, shared bin, external repo, or mixed, resolve entry ID follow-ups through ../project-gaps-implement/ledger.yaml, and never edit files — hand confirmed entries to $project-gaps-implement."
+  default_prompt: "Use $project-gaps-find to find scoped build, CI, Makefile, release, setup, validation, and workflow gaps without edits. After scoping, use repo archetype lead generation, apply the shared delegation gate, classify implementation home as current repo, shared bin, external repo, or mixed, and hand confirmed entries to $project-gaps-implement."

--- a/skills/project-gaps-find/references/plan.md
+++ b/skills/project-gaps-find/references/plan.md
@@ -10,10 +10,12 @@ surface, implementation home, delegation, ledger state, and workflow routing.
 
 1. Follow `../../references/gap-workflow.md#common-plan-mechanics` for shared
    find-mode sequencing. Apply the shared gap-workflow delegation gate before review work.
-2. Read `../../project-gaps-implement/ledger.yaml`; use its scoped ledger path
-   and ID prefix.
-3. Read `../../references/gap-lead-generation.md`, classify the repository
-   archetype, and build a lead inventory for build, CI, release, setup,
+2. When resolving a scoped ledger path or entry ID, read
+   `../../project-gaps-implement/ledger.yaml`; use its scoped ledger path and
+   ID prefix.
+3. After the repository archetype and audit scope make lead generation
+   relevant, read `../../references/gap-lead-generation.md` and build a lead
+   inventory for build, CI, release, setup,
    validation, command-discovery, dependency/tooling, generated-artifact, and
    shared `./bin` workflow surfaces in scope.
 4. Inventory Make targets and fragments, CI jobs, setup flows, validation and

--- a/skills/project-gaps-implement/SKILL.md
+++ b/skills/project-gaps-implement/SKILL.md
@@ -1,18 +1,23 @@
 ---
 name: project-gaps-implement
-description: Use when the human asks to work on or asks what the fix is for a project-gap ledger entry. Re-check that the confirmed entry still stands, then implement it; named same-prefix batches run sequentially.
+description: Implement a confirmed project-gap ledger entry when explicitly requested; explain a fix proposal read-only otherwise. Use $project-gaps-find to find workflow gaps.
 ---
 
 # Project Gaps Implement
 
-Use this skill to work on an existing project-gap entry. Re-check that it still
-stands before editing, then implement it. Name an ordered same-prefix batch as
+Use this skill to work on an existing project-gap entry. An informational
+question about a fix receives a read-only explanation and does not authorize
+edits. Re-check an entry and implement it only when the human explicitly asks
+for implementation. Name an ordered same-prefix batch as
 `PREFIX-N[/N...]`, using the prefix from `ledger.yaml`. Use
 `$project-gaps-find` first if no scoped ledger entry exists yet for this scope.
 
-Before starting, read `ledger.yaml`, `references/plan.md`,
-`../references/gap-workflow.md`, and `../references/gap-workflow/implementation.md`;
-they own runtime state, ledger, delegation, scope, and implementation gates.
+Before starting, read `../references/gap-workflow.md` completely, then
+`references/plan.md`; they own runtime state, delegation, scope, and
+implementation gates. Read `ledger.yaml` when resolving the scoped ledger path
+or entry ID, `references/ledger-format.md` only before interpreting, creating,
+or updating an entry, and `../references/gap-workflow/implementation.md` when
+beginning an actual implementation path.
 
 ## Operating Stance
 
@@ -29,8 +34,9 @@ workflow, or have an implementation home outside the requested scope. If the
 proposal's implementation home is outside the requested scope, stop and
 propose moving or reclassifying it instead of implementing it locally.
 
-Follow `references/plan.md` and the implementation rules in
-`../references/gap-workflow/implementation.md`.
+Follow `references/plan.md`. For an actual implementation path, also follow
+the implementation rules in `../references/gap-workflow/implementation.md`;
+an informational explanation remains read-only.
 
 These project-gap implementation rules remain mandatory:
 

--- a/skills/project-gaps-implement/agents/openai.yaml
+++ b/skills/project-gaps-implement/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Project Gaps Implement"
-  short_description: "Implement confirmed project-gap fixes"
-  default_prompt: "Use $project-gaps-implement for a scoped project-gap ledger entry. Re-check the entry against current Makefiles and CI, apply the shared delegation gate, resolve entry ID follow-ups through ledger.yaml, and implement it when the confirmed finding still stands."
+  short_description: "Implement confirmed project workflow gaps"
+  default_prompt: "Use $project-gaps-implement to implement a confirmed project workflow entry only when explicitly requested; explain informational fixes read-only, resolve entry ID follow-ups through ledger.yaml, and use $project-gaps-find to find gaps."

--- a/skills/references/gap-workflow.md
+++ b/skills/references/gap-workflow.md
@@ -99,24 +99,23 @@ questions, and implementation pairings.
 
 ## Mode-Specific References
 
-- Before Find, one-pass, or audit-only work, also read
+- When beginning review mechanics for find, one-pass, or audit-only work, read
   `gap-workflow/find-audit.md`. It owns inventory, validation, candidate
   handling, coverage accounting, and closeout outcomes.
-- Before Implement work, also read `gap-workflow/implementation.md`. It owns
-  ledger re-checks, implementation sequencing, and fresh
-  review.
-
-Use `gap-lead-generation.md` during find, audit-only, and one-pass modes to
-classify repository archetypes, build a lead inventory, use comparable
-repositories or framework checklists when useful, and account for confirmed,
-rejected, routed, deferred, and blocked leads.
+- When beginning an actual implementation path or unresolved-ledger fix, read
+  `gap-workflow/implementation.md`. It owns ledger re-checks, implementation
+  sequencing, and fresh review.
+- After the repository archetype and audit scope make lead generation relevant,
+  read `gap-lead-generation.md` to build a lead inventory and account for
+  confirmed, rejected, routed, deferred, and blocked leads.
 
 ## Scoped Ledgers
 
-- Before creating or updating a scoped ledger, read the selected skill's
-  `ledger.yaml`; ensure the consuming repository root `.gitignore` exists and
-  contains its `ledger_filename` as a standalone
-  pattern. Checking or reading an existing ledger must not modify `.gitignore`.
+- Before resolving a scoped ledger path or entry ID, read the selected skill's
+  `ledger.yaml`. Before creating or updating a scoped ledger, ensure the
+  consuming repository root `.gitignore` exists and contains its
+  `ledger_filename` as a standalone pattern. Checking or reading an existing
+  ledger must not modify `.gitignore`.
 - Use the exact path resolved from the selected skill's `ledger.yaml` and the
   requested scope.
 - In find or audit-only modes, stop when an existing scoped ledger blocks review

--- a/skills/references/gap-workflow/find-audit.md
+++ b/skills/references/gap-workflow/find-audit.md
@@ -1,7 +1,8 @@
 # Gap Workflow: Find And Audit
 
-Read `../gap-workflow.md` first. This reference contains mechanics that apply only
-while finding, auditing, or running a skill's one-pass mode.
+Navigation: `SKILL.md` already requires the complete `../gap-workflow.md` read
+before this reference. These mechanics apply only while finding, auditing, or
+running a skill's one-pass mode.
 
 ## Review Mechanics
 
@@ -14,9 +15,10 @@ For find, audit-only, and one-pass modes:
    or ambiguous active work.
 3. Run `$project-workflow` discovery for entrypoints, CI, documented commands,
    relevant public surfaces, and `./bin` wiring.
-4. Use the selected plan and `../gap-lead-generation.md` to build a recursive
-   inventory and bounded review slices. Use depth only as a discovery aid, not
-   as the review boundary.
+4. Build a recursive inventory and bounded review slices from the selected
+   plan. After the repository archetype and audit scope make it relevant, read
+   `../gap-lead-generation.md` to build the lead inventory. Use depth only as
+   a discovery aid, not as the review boundary.
 5. For broad scopes, prioritize high-risk or high-value slices and record
    `deep`, `skimmed`, `excluded`, and `deferred` coverage with exact follow-up
    scopes. A confidence closure audit may close only when every relevant slice
@@ -111,9 +113,8 @@ For find, audit-only, and one-pass modes:
   Do not pass intended conclusions, rejected-lead rationale, or proposed
   confidence numbers to the adversarial reviewer unless the validation task
   specifically requires that context.
-- Use `../finding-severity.md` to discard low-confidence candidates before
-  assigning severity or confidence. Build a lead inventory with the selected
-  plan and `../gap-lead-generation.md`; it is a recall aid and never lowers
+- Read `../finding-severity.md` only when filtering or assigning a candidate's
+  confidence or severity. The lead inventory is a recall aid and never lowers
   ownership, reproduction, validation, confidence, or implementation gates.
 - Treat comparable repositories, local checkout mappings, sibling repositories,
   and external frameworks as lead generation only. Reproduce any candidate

--- a/skills/references/gap-workflow/implementation.md
+++ b/skills/references/gap-workflow/implementation.md
@@ -1,7 +1,8 @@
 # Gap Workflow: Implementation
 
-Read `../gap-workflow.md` first. This reference contains mechanics that apply only
-while implementing a confirmed gap-ledger entry.
+Navigation: `SKILL.md` already requires the complete `../gap-workflow.md` read
+before this reference. These mechanics apply only while implementing a
+confirmed gap-ledger entry.
 
 ## Implement Mechanics
 

--- a/skills/reliability-gaps-find/SKILL.md
+++ b/skills/reliability-gaps-find/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reliability-gaps-find
-description: Use when the user asks to find $reliability-gaps-find/reliability gaps in a package or folder, review production readiness, set a confidence closure target such as 95% or 99%, or asks what evidence backs a reliability-gap ledger entry. Find verified reliability, operability, SLO, overload, observability, release-safety, recovery, data-integrity, disaster-readiness, or NALSD gaps and record scoped ledger entries; never edits code. Use $reliability-gaps-implement to act on a confirmed entry.
+description: Find scoped reliability, operability, overload, observability, recovery, and data-integrity gaps without editing; use $reliability-gaps-implement for confirmed entries.
 ---
 
 # Reliability Gaps Find
@@ -11,10 +11,13 @@ records candidates; it never edits code. Use `$reliability-gaps-implement` to
 re-check and implement a specific ledger entry, using the contract in
 `../reliability-gaps-implement/ledger.yaml`.
 
-Before starting, read `../reliability-gaps-implement/ledger.yaml`,
-`references/plan.md`, `../references/gap-workflow.md`, and
-`../references/gap-workflow/find-audit.md`; they own runtime state, ledger,
-delegation, scope, coverage, and confidence gates.
+Before starting, read `../references/gap-workflow.md` completely, then
+`references/plan.md`; they own runtime state, delegation, scope, coverage, and
+confidence gates. Read `references/find-rules.md` when beginning review. Read
+`../references/gap-workflow/find-audit.md` when beginning review mechanics.
+Read `../reliability-gaps-implement/ledger.yaml` only when resolving the
+scoped ledger path or an entry ID, and its ledger format only before
+interpreting, creating, or updating an entry.
 
 ## Operating Stance
 
@@ -43,7 +46,7 @@ instead.
 Follow `references/plan.md` and the find/audit rules in
 `../references/gap-workflow/find-audit.md`.
 
-Read `references/find-rules.md`; those reliability-gap rules remain mandatory.
+Those reliability-gap rules remain mandatory.
 
 ## Ledger Format
 

--- a/skills/reliability-gaps-find/agents/openai.yaml
+++ b/skills/reliability-gaps-find/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Reliability Gaps Find"
   short_description: "Find scoped SRE readiness gaps"
-  default_prompt: "Use $reliability-gaps-find for scoped SRE, operability, overload, observability, release-safety, recovery, and data-integrity gaps. Follow repo archetype lead generation, apply the shared delegation gate, summarize ledger entries in a compact Title/What/Why table, verify concrete failure paths, resolve entry ID follow-ups through ../reliability-gaps-implement/ledger.yaml, and never edit code — hand confirmed entries to $reliability-gaps-implement."
+  default_prompt: "Use $reliability-gaps-find to find scoped operability, overload, observability, recovery, and data-integrity gaps without editing. After scoping, use repo archetype lead generation, apply the shared delegation gate, and hand confirmed entries to $reliability-gaps-implement."

--- a/skills/reliability-gaps-find/references/plan.md
+++ b/skills/reliability-gaps-find/references/plan.md
@@ -10,13 +10,15 @@ delegation, ledger state, operational expectation, and failure-mode evidence.
 
 1. Follow `../../references/gap-workflow.md#common-plan-mechanics` for shared
    find-mode sequencing. Apply the shared gap-workflow delegation gate before review work.
-2. Read `../../reliability-gaps-implement/ledger.yaml`; use its scoped ledger
-   path and ID prefix.
+2. When resolving a scoped ledger path or entry ID, read
+   `../../reliability-gaps-implement/ledger.yaml`; use its scoped ledger path
+   and ID prefix.
 3. Run `$project-workflow` discovery and the shared audit preflight, including
    applicable tools, service dependencies, validation ladder, and command
    failure classification.
-4. Read `../../references/gap-lead-generation.md`, classify the repository
-   archetype, and build a lead inventory for operational, overload, lifecycle,
+4. After the repository archetype and audit scope make lead generation
+   relevant, read `../../references/gap-lead-generation.md` and build a lead
+   inventory for operational, overload, lifecycle,
    release-safety, observability, recovery, data-integrity, and operator
    diagnostic risks in scope.
 5. Inventory services, APIs, CLIs, jobs, scripts, deployment/config,

--- a/skills/reliability-gaps-implement/SKILL.md
+++ b/skills/reliability-gaps-implement/SKILL.md
@@ -1,19 +1,24 @@
 ---
 name: reliability-gaps-implement
-description: Use when the human asks to work on or asks what the fix is for a reliability-gap ledger entry. Re-check that the confirmed entry still stands, then implement it; named same-prefix batches run sequentially.
+description: Implement a confirmed reliability-gap ledger entry when explicitly requested; explain a fix proposal read-only otherwise. Use $reliability-gaps-find to find reliability gaps.
 ---
 
 # Reliability Gaps Implement
 
-Use this skill to work on an existing reliability-gap entry. Re-check that it
-still stands before editing, then implement it. Name an ordered same-prefix
-batch as `PREFIX-N[/N...]`, using the prefix from `ledger.yaml`. Use
+Use this skill to work on an existing reliability-gap entry. An informational
+question about a fix receives a read-only explanation and does not authorize
+edits. Re-check an entry and implement it only when the human explicitly asks
+for implementation. A named same-prefix batch uses `PREFIX-N[/N...]`, using
+the prefix from `ledger.yaml`. Use
 `$reliability-gaps-find` first if no scoped ledger entry exists yet for this
 scope.
 
-Before starting, read `ledger.yaml`, `references/plan.md`,
-`../references/gap-workflow.md`, and `../references/gap-workflow/implementation.md`;
-they own runtime state, ledger, delegation, scope, and implementation gates.
+Before starting, read `../references/gap-workflow.md` completely, then
+`references/plan.md`; they own runtime state, delegation, scope, and
+implementation gates. Read `ledger.yaml` when resolving the scoped ledger path
+or entry ID, `references/ledger-format.md` only before interpreting, creating,
+or updating an entry, and `../references/gap-workflow/implementation.md` when
+beginning an actual implementation path.
 
 ## Operating Stance
 
@@ -33,8 +38,9 @@ non-prose evidence supports the implementation, explain that the ledger item
 is invalid as a reliability gap and propose reclassifying or fixing
 documentation instead.
 
-Follow `references/plan.md` and the implementation rules in
-`../references/gap-workflow/implementation.md`.
+Follow `references/plan.md`. For an actual implementation path, also follow
+the implementation rules in `../references/gap-workflow/implementation.md`;
+an informational explanation remains read-only.
 
 These reliability implementation rules remain mandatory:
 

--- a/skills/reliability-gaps-implement/agents/openai.yaml
+++ b/skills/reliability-gaps-implement/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Reliability Gaps Implement"
-  short_description: "Implement confirmed reliability fixes"
-  default_prompt: "Use $reliability-gaps-implement for a scoped reliability-gap ledger entry. Re-check the entry against current code, apply the shared delegation gate, resolve entry ID follow-ups through ledger.yaml, and implement it when the confirmed finding still stands."
+  short_description: "Implement confirmed reliability findings"
+  default_prompt: "Use $reliability-gaps-implement to implement a confirmed reliability entry only when explicitly requested; explain informational fixes read-only, resolve entry ID follow-ups through ledger.yaml, and use $reliability-gaps-find to find gaps."

--- a/skills/test-gaps-find/SKILL.md
+++ b/skills/test-gaps-find/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-gaps-find
-description: Use when the user asks to find $test-gaps-find/test gaps in a package or folder, set a confidence closure target such as 95% or 99% for a test-gap audit, find flaky tests, wrong-layer tests, weak harnesses, or test-support-code gaps, or asks what evidence backs a test-gap ledger entry. Find concrete missing, weak, misleading, flaky, wrong-layer, or brittle coverage and record scoped ledger entries; never edits tests. Use $test-gaps-implement to act on a confirmed entry.
+description: Find scoped missing, weak, flaky, wrong-layer, or brittle test coverage without editing; use $test-gaps-implement for confirmed entries.
 ---
 
 # Test Gaps Find
@@ -11,10 +11,13 @@ candidates; it never edits tests. Use `$test-gaps-implement` to re-check and
 implement a specific ledger entry, using the contract in
 `../test-gaps-implement/ledger.yaml`.
 
-Before starting, read `../test-gaps-implement/ledger.yaml`, `references/plan.md`,
-`../references/gap-workflow.md`, and `../references/gap-workflow/find-audit.md`;
-they own runtime state, ledger, delegation, scope, coverage, and confidence
-gates.
+Before starting, read `../references/gap-workflow.md` completely, then
+`references/plan.md`; they own runtime state, delegation, scope, coverage, and
+confidence gates. Read `references/find-rules.md` when beginning review. Read
+`../references/gap-workflow/find-audit.md` when beginning review mechanics.
+Read `../test-gaps-implement/ledger.yaml` only when resolving the scoped
+ledger path or an entry ID, and its ledger format only before interpreting,
+creating, or updating an entry.
 
 ## Operating Stance
 
@@ -45,7 +48,7 @@ improvements to `$project-gaps-find`.
 Follow `references/plan.md` and the find/audit rules in
 `../references/gap-workflow/find-audit.md`.
 
-Read `references/find-rules.md`; those test-gap rules remain mandatory.
+Those test-gap rules remain mandatory.
 
 ## Ledger Format
 

--- a/skills/test-gaps-find/agents/openai.yaml
+++ b/skills/test-gaps-find/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Test Gaps Find"
   short_description: "Find weak tests and harness gaps"
-  default_prompt: "Use $test-gaps-find for scoped missing, weak, misleading, flaky, wrong-layer, or harness coverage gaps. Follow repo archetype lead generation, apply the shared delegation gate, summarize ledger entries in a compact Title/What/Why table, verify front-door behavior, resolve entry ID follow-ups through ../test-gaps-implement/ledger.yaml, and never edit tests — hand confirmed entries to $test-gaps-implement."
+  default_prompt: "Use $test-gaps-find to find scoped missing, weak, flaky, wrong-layer, or brittle coverage without editing. After scoping, use repo archetype lead generation, apply the shared delegation gate, and hand confirmed entries to $test-gaps-implement."

--- a/skills/test-gaps-find/references/plan.md
+++ b/skills/test-gaps-find/references/plan.md
@@ -10,10 +10,12 @@ surface, delegation, ledger state, and repository-owned behavior.
 
 1. Follow `../../references/gap-workflow.md#common-plan-mechanics` for shared
    find-mode sequencing. Apply the shared gap-workflow delegation gate before review work.
-2. Read `../../test-gaps-implement/ledger.yaml`; use its scoped ledger path
-   and ID prefix.
-3. Read `../../references/gap-lead-generation.md`, classify the repository
-   archetype, and build a lead inventory for public behavior, dominant harness,
+2. When resolving a scoped ledger path or entry ID, read
+   `../../test-gaps-implement/ledger.yaml`; use its scoped ledger path and ID
+   prefix.
+3. After the repository archetype and audit scope make lead generation
+   relevant, read `../../references/gap-lead-generation.md` and build a lead
+   inventory for public behavior, dominant harness,
    fixtures, generated stubs, service-feature coverage, failure paths,
    determinism, and harness support in scope.
 4. Inventory existing tests, fixtures, helpers, test-support code, dominant

--- a/skills/test-gaps-implement/SKILL.md
+++ b/skills/test-gaps-implement/SKILL.md
@@ -1,18 +1,23 @@
 ---
 name: test-gaps-implement
-description: Use when the human asks to work on or asks what the fix is for a test-gap ledger entry. Re-check that the confirmed entry still stands, then implement it; named same-prefix batches run sequentially.
+description: Implement a confirmed test-gap ledger entry when explicitly requested; explain a fix proposal read-only otherwise. Use $test-gaps-find to find test gaps.
 ---
 
 # Test Gaps Implement
 
-Use this skill to work on an existing test-gap entry. Re-check that it still
-stands before editing, then implement it. Name an ordered same-prefix batch as
+Use this skill to work on an existing test-gap entry. An informational question
+about a fix receives a read-only explanation and does not authorize edits.
+Re-check an entry and implement it only when the human explicitly asks for
+implementation. Name an ordered same-prefix batch as
 `PREFIX-N[/N...]`, using the prefix from `ledger.yaml`. Use
 `$test-gaps-find` first if no scoped ledger entry exists yet for this scope.
 
-Before starting, read `ledger.yaml`, `references/plan.md`,
-`../references/gap-workflow.md`, and `../references/gap-workflow/implementation.md`;
-they own runtime state, ledger, delegation, scope, and implementation gates.
+Before starting, read `../references/gap-workflow.md` completely, then
+`references/plan.md`; they own runtime state, delegation, scope, and
+implementation gates. Read `ledger.yaml` when resolving the scoped ledger path
+or entry ID, `references/ledger-format.md` only before interpreting, creating,
+or updating an entry, and `../references/gap-workflow/implementation.md` when
+beginning an actual implementation path.
 
 ## Operating Stance
 
@@ -31,8 +36,9 @@ supports the implementation, explain that the ledger item is invalid as a test
 gap and propose reclassifying or fixing documentation instead via
 `$doc-gaps-fix`.
 
-Follow `references/plan.md` and the implementation rules in
-`../references/gap-workflow/implementation.md`.
+Follow `references/plan.md`. For an actual implementation path, also follow
+the implementation rules in `../references/gap-workflow/implementation.md`;
+an informational explanation remains read-only.
 
 These test-gap implementation rules remain mandatory:
 

--- a/skills/test-gaps-implement/agents/openai.yaml
+++ b/skills/test-gaps-implement/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Test Gaps Implement"
-  short_description: "Implement confirmed test-gap fixes"
-  default_prompt: "Use $test-gaps-implement for a scoped test-gap ledger entry. Re-check the entry against current tests, apply the shared delegation gate, resolve entry ID follow-ups through ledger.yaml, and implement it when the confirmed finding still stands."
+  short_description: "Implement confirmed test coverage gaps"
+  default_prompt: "Use $test-gaps-implement to implement a confirmed test-gap entry only when explicitly requested; explain informational fixes read-only, resolve entry ID follow-ups through ledger.yaml, and use $test-gaps-find to find gaps."


### PR DESCRIPTION
## What

- Adds three checks to `quality/skills/metadata` (run by `make skills-lint`): a skill frontmatter `name` must be 1-64 characters using lowercase alphanumeric segments joined by single hyphens, and a skill frontmatter `description` must be 1-1024 characters.
- Reworks the shared gap-workflow references (`skills/references/gap-workflow.md`, `gap-workflow/find-audit.md`, `gap-workflow/implementation.md`) and 12 gap-workflow skill pairs (code-issues, doc-gaps, feature-gaps, project-gaps, reliability-gaps, test-gaps): eager "read X first" instructions become step-gated reads ("read X when beginning review", "read X only when resolving the scoped ledger path or entry ID"), so an agent no longer has to load every reference file before it knows which mode it is running.
- Shortens several SKILL.md frontmatter `description` fields and `agents/openai.yaml` `default_prompt`/`short_description` values to plainer, terser wording.
- Two spots from review are intentionally left as-is in this PR: the `gap-lead-generation.md` read gate (in `gap-workflow.md`, `find-audit.md`, and six `plan.md` files) is phrased as a relevance judgment rather than a concrete trigger step like its sibling gates, and a few shortened frontmatter descriptions drop trigger phrases (confidence-target wording, doc-surface enumeration) that remain in the SKILL.md body but not in the frontmatter description used for skill selection.

## Why

- The new frontmatter checks give `make skills-lint` a guardrail against malformed or oversized skill names/descriptions as more skills get added, instead of relying on manual review to catch it.
- Step-gating the reference reads keeps each skill's "before starting" instructions from forcing a full read of every paired reference file regardless of which mode (find, audit, implement) an invocation actually needs, reducing avoidable context load per invocation.

## Testing

- `make skills-lint` - passed
- `make lint` - passed (6 files inspected, no offenses detected)
- Independent agent review of the full diff - no blocking findings; the two non-blocking notes above were raised and left open for follow-up rather than fixed in this PR.
