### PR TITLE
docs(readme): correct stale local-contract references and comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,8 +303,9 @@ Do not infer the test language from the implementation language alone.
 ## Local contracts
 
 - Public shared surfaces live in `build/make/`, `build/docker/`, `build/go/`,
-  `build/git/`, `build/sec/`, `build/claude/`, `quality/`, and `skills/`;
-  inspect the relevant files before editing.
+  `build/git/`, `build/sec/`, `build/shell/`, `build/claude/`, `build/codex/`,
+  `build/test/`, `lib/`, `quality/`, and `skills/`; inspect the relevant files
+  before editing.
 - Preserve formatting from `.editorconfig`, Ruby settings from `.rubocop.yml`,
   and nearby Bash/Ruby style. Do not duplicate those config files here.
 - Make fragments derive `BIN_ROOT` from their include location. For path-related
@@ -313,8 +314,9 @@ Do not infer the test language from the implementation language alone.
 - `build/docker/env` clones or updates `git@github.com:alexfalkowski/docker.git`
   in sibling `../docker`; `make start` and `make stop` paths can require SSH and
   network access.
-- `quality/go/*` helpers read and write under `test/reports/`; preserve that
-  downstream test-report contract.
+- `quality/go/*` coverage and benchmark-profile helpers read and write under
+  `test/reports/`; preserve that downstream test-report contract.
+  `quality/go/create-diagram` is the exception and writes to `assets/` instead.
 - `build/go/lint` is a no-op unless `golangci-lint` exists in `PATH`; do not
   report full lint coverage unless the binary ran.
 - `master` is the canonical branch in this repo and shared fragments. Hardcoded
@@ -350,6 +352,7 @@ Do not infer the test language from the implementation language alone.
 - Treat skills as maintained artifacts and review them when project workflow,
   tooling, model behavior, or team conventions change.
 - Treat external skills like third-party dependencies. Use `security-audit` with
-  `skills/references/skills.md` for skill-specific security review.
+  `skills/security-audit/references/skills.md` for skill-specific security
+  review.
 - After edits, run the narrowest repository-defined checks that cover the
   changed files, then expand to CI-equivalent targets when risk justifies it.

--- a/build/make/claude.mak
+++ b/build/make/claude.mak
@@ -3,6 +3,7 @@
 BIN_ROOT ?= $(abspath $(dir $(lastword $(MAKEFILE_LIST)))../..)
 
 # Wire this repository for Claude Code using the shared bin skills.
-# Creates a `.claude/skills` symlink and a managed `CLAUDE.md` import block.
+# Creates `.claude/skills` and `.claude/settings.json` symlinks and a managed
+# `CLAUDE.md` import block.
 claude-init:
 	@BIN_ROOT="$(BIN_ROOT)" "$(BIN_ROOT)/build/claude/init"

--- a/quality/skills/metadata
+++ b/quality/skills/metadata
@@ -1,6 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# Validates skill frontmatter, agent metadata, gap-pair wiring, and ledger
+# contract markdown references across skills/.
+
 require 'yaml'
 
 GAP_PAIRS = [


### PR DESCRIPTION
## What

- Update `AGENTS.md`'s local-contracts list of public shared surfaces to include `build/shell`, `build/codex`, `build/test`, and `lib`, alongside the already-listed directories.
- Clarify that the `test/reports/` contract applies specifically to `quality/go/*` coverage and benchmark-profile helpers, and note that `quality/go/create-diagram` is the exception that writes to `assets/` instead.
- Fix a stale security-audit reference path in `AGENTS.md` from `skills/references/skills.md` to the actual `skills/security-audit/references/skills.md`.
- Update the `claude-init` Make target comment in `build/make/claude.mak` to mention that it also creates a `.claude/settings.json` symlink, matching what `build/claude/init` actually does.
- Add a top-of-file comment to `quality/skills/metadata` describing what the script validates (skill frontmatter, agent metadata, gap-pair wiring, and ledger contract markdown references).

## Why

- `AGENTS.md`'s local-contracts section is the reference agents use before editing shared surfaces; missing directories and a stale reference path could cause an agent to skip inspecting relevant files or follow a dead path.
- The `claude.mak` comment and `quality/skills/metadata` header keep the code's stated behavior in sync with what it actually does, reducing the chance a future edit relies on an outdated description.

## Testing

- `make skills-lint` - passed
- `make scripts-lint` - passed
- Manually verified `build/shell`, `build/codex`, `build/test`, and `lib` exist; `quality/go/create-diagram` writes to `assets/`; `skills/security-audit/references/skills.md` exists while the old `skills/references/skills.md` path is unreferenced anywhere; `build/claude/init` creates the `.claude/settings.json` symlink.
- Doc/comment-only change with no behavior change, so no additional test coverage is needed.
