### PR TITLE
feat(skills): clarify uptime monitor matching

### DIFF
--- a/skills/repo-health/references/sources.md
+++ b/skills/repo-health/references/sources.md
@@ -219,6 +219,11 @@ curl -fsS -X POST https://api.uptimerobot.com/v2/getMonitors \
 Set `UPTIMEROBOT_MONITOR_IDS` to the comma-separated IDs for the services in
 scope.
 
+The collector accepts a monitor only when its `friendly_name` or `url` contains
+the repository basename. Configure the selected monitor accordingly. If the
+configured IDs do not yield a match, the collector retries once without the ID
+filter before reporting UptimeRobot as unavailable.
+
 Useful data:
 
 - current monitor status;


### PR DESCRIPTION
## What

- Clarify how repo-health selects an UptimeRobot monitor and when it retries without configured monitor IDs.

## Why

- Help operators configure monitors that the collector can match, avoiding otherwise unexplained unavailable UptimeRobot data.

## Testing

- `make skills-lint` - passed
- Verified the documented basename filter and one-time fallback against `skills/repo-health/scripts/collect.rb`.

AI-assisted-by: [Codex](https://openai.com/codex/)
