### PR TITLE
feat(skills): clarify agent capability descriptions

### DIFF
--- a/skills/api-standards/SKILL.md
+++ b/skills/api-standards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api-standards
-description: Use when designing, reviewing, documenting, or changing API surfaces in repos that use this shared ./bin tooling, especially gRPC, Protocol Buffer, HTTP transcoding, REST, HTTP/JSON, generated clients, public request/response schemas, Go API handlers, Ruby API clients, and compatibility-sensitive API changes. Apply Google Cloud API Design Guide and Google AIP guidance as the default API design bar; apply REST best practices when the API is REST-oriented or exposes direct HTTP resources.
+description: Use when designing, reviewing, documenting, or changing an API contract in a repository using this shared tooling, including adding an endpoint or RPC, changing a request/response schema or client interface, or preserving API compatibility. Apply Google Cloud API Design Guide and Google AIP guidance by default; apply REST best practices to direct HTTP resources.
 ---
 
 # API Standards

--- a/skills/api-standards/agents/openai.yaml
+++ b/skills/api-standards/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "API Standards"
-  short_description: "Design gRPC and REST APIs consistently"
-  default_prompt: "Use $api-standards when designing, reviewing, or changing gRPC, Protocol Buffer, REST, HTTP/JSON, Go, or Ruby API surfaces; apply Google Cloud API design guidance first and REST-specific best practices when the API is REST-oriented."
+  short_description: "Design and review API contracts"
+  default_prompt: "Use $api-standards to design or review an API contract, including an endpoint or RPC, schema, client interface, or compatibility change."

--- a/skills/change-validation/SKILL.md
+++ b/skills/change-validation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: change-validation
-description: Use when running or selecting validation after code, docs, Makefile, shell, Dockerfile, Go, Ruby, generated-output, CI, security, benchmark, or shared ./bin changes. Choose and report credible repository-defined checks.
+description: Use when a user asks how to verify a change, choose tests or lint checks, reproduce CI locally, or decide whether code, documentation, build, security, or shared-tooling work is ready. Select and report the smallest credible repository-defined validation.
 ---
 
 # Change Validation

--- a/skills/change-validation/agents/openai.yaml
+++ b/skills/change-validation/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Change Validation"
-  short_description: "Choose tests, lint, and CI checks"
-  default_prompt: "Use $change-validation to choose and report validation for this change. Prefer repository-defined commands in the configured command environment, run supported area/package/file/scenario/example/test-name selectors before broad suites, classify failures before retrying, never replace a failed repo command with an ad hoc command merely to make progress, detect no-op wrappers, report tool/PATH mismatches as gaps, and rerun checks when file changes make prior validation stale."
+  short_description: "Verify changes with trusted checks"
+  default_prompt: "Use $change-validation to verify this change with the narrowest credible repository-defined test, lint, CI, or security check in the configured command environment; rerun checks when file changes make prior validation stale."

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: Use when the user asks for a general code review, diff review, PR check, or pre-merge issue pass. Review changed code for bugs, regressions, risky assumptions, missing tests, compatibility breaks, missing or stale documentation, and language-specific maintainability or idiom risks; pair documentation judgment with $doc-standards and delegate explicit security scope to $security-audit.
+description: Use when a user asks to review a diff, branch, PR, or pending change before merging. Find evidence-backed bugs, regressions, compatibility risks, test or documentation gaps, and maintainability concerns; use $style-review for non-blocking polish and $security-audit for explicit security review.
 ---
 
 # Code Review

--- a/skills/code-review/agents/openai.yaml
+++ b/skills/code-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Code Review"
-  short_description: "Review diffs for bugs and regressions"
-  default_prompt: "Use $code-review for a general bug, regression, missing-coverage, documentation, naming, and language-idiom risk review; pair docs judgment with $doc-standards and security-sensitive scope with $security-audit. Inventory changed README, doc, and example files alongside code, apply $doc-standards to any of them as a MUST rather than an optional pairing, and always report doc-staleness status in the Documentation output section even when no doc update was needed. Before reporting a finding, challenge confidence with the strongest reasonable counterquestion and confirm supported usage plus correct ownership. Route third-party/tooling defects to $project-gaps-find and project-owned upstream library bugs to that library's agent or ledger unless local adapter behavior is independently wrong. Flag unnecessary defensive complexity or abstraction only when it creates concrete maintenance risk without a supported failure mode, domain concept, boundary, compatibility need, or local pattern."
+  short_description: "Review changes for risks and regressions"
+  default_prompt: "Use $code-review to review this diff, branch, or PR for evidence-backed bugs, regressions, compatibility risks, test or documentation gaps, and maintainability concerns."

--- a/skills/project-workflow/SKILL.md
+++ b/skills/project-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-workflow
-description: Use when starting in a project, inspecting how to run tasks, deciding trusted entrypoints, or editing/debugging shared Makefile fragments. Discover project-local workflow, command surfaces, CI expectations, shared ./bin submodule wiring, and reusable build/make/*.mak fragment behavior before work begins.
+description: Use when you need to discover how a repository is built, tested, linted, released, or configured; when choosing a supported command; or before changing shared Makefile tooling. Identify project commands, CI expectations, local patterns, and downstream ./bin behavior.
 ---
 
 # Project Workflow

--- a/skills/project-workflow/agents/openai.yaml
+++ b/skills/project-workflow/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Project Workflow"
-  short_description: "Discover commands, CI, bin wiring, and local patterns"
-  default_prompt: "Use $project-workflow to discover project entrypoints, CI expectations, ./bin wiring, shared Makefile fragment behavior, local code/test/config/validation patterns, and the configured command environment before work begins. For Makefiles, treat target comments as the external command catalog, treat uncommented targets as internal, and keep .PHONY selective rather than adding it to every target. Classify command failures before retrying, and never replace a failed repo command with an ad hoc command merely to make progress. Treat AGENTS.md and selected skills as mandatory rules."
+  short_description: "Discover project commands and conventions"
+  default_prompt: "Use $project-workflow to discover how this repository is built, tested, linted, released, and configured before beginning work in the configured command environment. Treat AGENTS.md and selected skills as mandatory rules."

--- a/skills/reliability-standards/SKILL.md
+++ b/skills/reliability-standards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reliability-standards
-description: Use when reviewing or changing reliability-sensitive behavior, retries, timeouts, backpressure, SLOs, SLIs, error budgets, monitoring, alerting, runbooks, release safety, overload handling, cascading failures, data integrity, disaster recovery, or concrete NALSD design estimates. Apply SRE, NALSD, and secure/reliable systems standards to code, designs, scripts, Make targets, services, jobs, deployment/config, observability, incident, recovery, capacity, and production-readiness work; pair with $reliability-gaps-find for scoped reliability-gap discovery.
+description: Use when reviewing or changing production reliability, including failure recovery, retries, timeouts, overload, data integrity, observability, SLOs, release safety, capacity, or operational readiness. Apply SRE, NALSD, and secure/reliable-systems standards; use $reliability-gaps-find for a scoped reliability-gap audit.
 ---
 
 # Reliability Standards

--- a/skills/reliability-standards/agents/openai.yaml
+++ b/skills/reliability-standards/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Reliability Standards"
-  short_description: "Review SRE and production readiness"
-  default_prompt: "Use $reliability-standards to review SRE, NALSD, and production-readiness concerns for this change, verifying concrete current failure paths before reporting SLO impact, overload behavior, observability, release safety, recovery, or operator actionability concerns."
+  short_description: "Assess production reliability and readiness"
+  default_prompt: "Use $reliability-standards to assess this change's production reliability, failure recovery, operational readiness, and SLO impact."

--- a/skills/repo-health/SKILL.md
+++ b/skills/repo-health/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: repo-health
-description: Use when the user asks for repo health, repository health report, delivery health report, weekly or daily engineering metrics, repo health comparison, service health summary, library maintenance summary, or period-over-period view for a specific GitHub repository. Produce daily or weekly summaries across delivery flow, CI quality, release/deploy activity, and service reliability using local git, GitHub, CircleCI, Kubernetes/DigitalOcean, and UptimeRobot evidence.
+description: Use when a user asks for a daily or weekly engineering, project, service, library, or repository health report; a delivery or reliability trend; or a period-over-period comparison for a GitHub repository. Summarize delivery flow, CI quality, release/deploy activity, and service reliability from available evidence.
 ---
 
 # Repo Health

--- a/skills/repo-health/agents/openai.yaml
+++ b/skills/repo-health/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Repo Health"
-  short_description: "Summarize actionable repo health"
-  default_prompt: "Use $repo-health to produce daily or weekly delivery, CI quality, release/deploy, and service-reliability summaries for the requested repository and period, with explicit comparison windows, top bottleneck, prioritized action queue, trend context, and missing-source setup actions."
+  short_description: "Summarize repository health and trends"
+  default_prompt: "Use $repo-health to produce a daily or weekly repository health report with delivery, CI, release, reliability, trend, and action evidence."


### PR DESCRIPTION
## What

- Refine discovery descriptions and Codex metadata for API, validation, review, workflow, reliability, and health guidance.
- Keep the underlying workflow instructions unchanged; the update only clarifies routing and user-facing prompts.

## Why

- Make the available agent guidance easier to recognize while preserving existing behavior and compatibility.

## Testing

- `git diff --check` - passed
- `make skills-lint` - passed
- Validates skill frontmatter, Codex metadata, references, and required policy markers.
