### PR TITLE
feat(skills): require approval for claude write calls and skip ledger content in doc checks

### DIFF
--- a/build/claude/settings.json
+++ b/build/claude/settings.json
@@ -40,7 +40,6 @@
       "Bash(make *)",
       "Read(**)",
       "Edit(**)",
-      "Write(**)",
       "Read(//tmp/**)",
       "Read(//private/tmp/**)",
       "Read(//var/tmp/**)",
@@ -50,10 +49,6 @@
       "Edit(//private/tmp/**)",
       "Edit(//var/tmp/**)",
       "Edit(//var/folders/**)",
-      "Write(//tmp/**)",
-      "Write(//private/tmp/**)",
-      "Write(//var/tmp/**)",
-      "Write(//var/folders/**)",
       "WebFetch",
       "WebSearch"
     ],

--- a/skills/project-workflow/references/agent-init.md
+++ b/skills/project-workflow/references/agent-init.md
@@ -63,8 +63,9 @@ sandbox and allowed without prompting, except `make pr`, `make draft`, `make
 merge`, `make ready`, and `make review`, which require approval because they
 create, merge, or force-push a pull request. Built-in file reads and edits are scoped
 to the workspace plus the standard system temporary directories (`/tmp`,
-`/private/tmp`, `/var/tmp`, `/var/folders`), which are readable and writable
-without prompting. Per-repo or per-machine permission tweaks belong in the
+`/private/tmp`, `/var/tmp`, `/var/folders`), which are readable and editable
+without prompting; the Write tool has no auto-allow rule and always prompts.
+Per-repo or per-machine permission tweaks belong in the
 gitignored `.claude/settings.local.json`, which Claude Code merges over the
 baseline.
 

--- a/test/skills/validate
+++ b/test/skills/validate
@@ -354,6 +354,22 @@ def ledger_filename_ignored?(filename, contract_path)
   report_failure("ledger filename from #{contract_path} is missing from .gitignore: #{filename}")
 end
 
+def ledger_filenames
+  GAP_PAIRS.filter_map { |pair| ledger_filename_for(pair[:implement]) }
+end
+
+def ledger_filename_for(implement_skill_name)
+  path = "skills/#{implement_skill_name}/ledger.yaml"
+  return nil unless File.file?(path)
+
+  data = YAML.safe_load_file(path)
+  return nil unless data.is_a?(Hash)
+
+  data['ledger_filename']
+rescue Psych::SyntaxError
+  nil
+end
+
 def valid_gap_pair_text?(pair, find_paths, implement_paths, ledger_paths)
   return false unless valid_gap_pair_text_paths?(find_paths, implement_paths, ledger_paths)
 
@@ -469,7 +485,12 @@ end
 ok = true
 Dir['skills/*/SKILL.md'].each { |path| ok = false unless valid_skill?(path) }
 Dir['skills/*/agents/openai.yaml'].each { |path| ok = false unless valid_agent?(path) }
-Dir['skills/**/*.md'].each { |path| ok = false unless valid_markdown_references?(path) }
+ignored_ledger_filenames = ledger_filenames
+Dir['skills/**/*.md'].each do |path|
+  next if ignored_ledger_filenames.include?(File.basename(path))
+
+  ok = false unless valid_markdown_references?(path)
+end
 ok = false unless valid_skill_agent_pairs?
 GAP_PAIRS.each { |pair| ok = false unless valid_gap_pair?(pair) }
 


### PR DESCRIPTION
## What

- Removes the blanket approval-free `Write(**)` and `Write(//tmp/**)`-style rules from the shared Claude Code permissions baseline (`build/claude/settings.json`), so any Write tool call now prompts for approval instead of being auto-allowed anywhere, workspace or system temp dirs alike. Read and Edit stay auto-allowed as before.
- Updates `skills/project-workflow/references/agent-init.md` to match: file reads and edits stay auto-allowed, but the Write tool always prompts now.
- `test/skills/validate` now skips the gap-workflow ledger filenames (`ISSUES.md`, `DOCS.md`, and the other files named in each `ledger.yaml` contract) when scanning `skills/**/*.md` for stale `references/*.md` links, since those are generated ledger content, not authored skill docs.
- Guards the new ledger-filename lookup against a malformed (non-mapping) `ledger.yaml`, so it fails cleanly instead of raising.

## Why

- The repository currently carries a maintainer-owned `skills/DOCS.md` generated ledger file whose freeform content happens to match the reference-link pattern the validator scans for, and it was failing `test/skills/validate` with false "missing referenced file" errors.
- Auto-allowing Write anywhere, including system temp dirs, let the agent create or overwrite files without a diff-reviewable prompt, unlike Edit; narrowing it to always-prompt matches the trusted-repositories-only posture already documented for this baseline.
- Left unfixed, the doc would keep telling operators that writes are silent, and a malformed `ledger.yaml` would crash the validator with a raw backtrace instead of a clean, actionable failure.

## Testing

- `ruby test/skills/validate` - passed (exit 0). Reproduced the pre-fix failure on the unmodified script against the current repo state: `missing referenced file in skills/DOCS.md: references/safety-checks.md` and `references/conventions.md`.
- `make skills-lint` - passed.
- `make sec` - passed (Trivy: 0 vulnerabilities, 0 secrets).
- `bundle exec rubocop test/skills/validate` - passed, no offenses.
- `jq empty build/claude/settings.json` - passed (valid JSON).
- Simulated a non-mapping `ledger.yaml` in a scratch copy of `skills/`: the original script already failed cleanly via `valid_ledger_contract?`'s mapping check; the ledger-filename lookup without a guard crashed with `TypeError`; the guarded version fails cleanly again.
- Confirmed `build/codex/config.toml` and the Codex/README write-permission wording are unaffected: Codex grants filesystem `write` on temp dirs through a different mechanism than Claude's `Write(**)` tool rule, and this change only touches the Claude baseline.
- No automated test covers Claude Code's live permission-prompt behavior; the Write-prompt change is verified against the settings.json rule set itself, not a runtime session replay.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
