### PR TITLE
feat(skills): document transport and workspace contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,15 +162,18 @@ sandbox, and routes direct Bash commands through the `permissions` allow, ask,
 and deny guardrails. Direct Bash is broadly allowed without prompting while it
 remains sandboxed; project-local operations stay autonomous, recognized remote
 and external-system changes require approval, and catastrophic commands are
-forbidden. The unsandboxed escape hatch is disabled. The sandbox grants the
-standard Go, RuboCop, golangci-lint, and Trivy cache writes used by project
-commands, plus standard system temporary directories. Every `make` invocation
-is excluded from the sandbox and allowed without prompting, except `make pr`,
-`make draft`, `make merge`, `make ready`, and `make review`, which require
-approval because they create, merge, or force-push a pull request. Built-in
-file edits stay scoped to the workspace, and the active agent configuration
-provides runtime approval guardrails while `AGENTS.md` defines task scope and
-workflow authorization.
+forbidden. The unsandboxed escape hatch is disabled. The sandbox grants write
+access to the workspace, the standard Go, RuboCop, golangci-lint, and Trivy
+caches used by project commands, and standard system temporary directories.
+This means an allowed Bash redirect, `sed -i`, `rm`, or similar command can
+mutate workspace files without an Edit prompt; use this baseline only in trusted
+repositories and prefer diff-reviewable edits where practical. Every `make`
+invocation is excluded from the sandbox and allowed without prompting, except
+`make pr`, `make draft`, `make merge`, `make ready`, and `make review`, which
+require approval because they create, merge, or force-push a pull request.
+Built-in file edits stay scoped to the workspace, and the active agent
+configuration provides runtime approval guardrails while `AGENTS.md` defines
+task scope and workflow authorization.
 
 Permission-baseline updates propagate with the next `bin` submodule update;
 fully restart the Claude Code process afterward, since `settings.json` is read
@@ -221,6 +224,8 @@ Dockerfile lint targets depend on `shellcheck` and `hadolint`;
 - `build/docker/go/Dockerfile`: shared Go service Dockerfile template.
 - `build/docker/go/Dockerfile.dockerignore`: shared Docker build-context
   exclusions for the Go service Dockerfile.
+- `build/make/grpc.mak`: shared gRPC and protobuf targets, including
+  `proto-breaking`.
 - `quality/`: shared feature, benchmark, and coverage helpers.
 - `test/`: repository validation runners and report artifacts.
 - `AGENTS.md`: repository instructions, shared skills, and agent operating

--- a/build/claude/settings.json
+++ b/build/claude/settings.json
@@ -19,6 +19,7 @@
     ],
     "filesystem": {
       "allowWrite": [
+        ".",
         "/tmp",
         "/private/tmp",
         "/var/tmp",

--- a/skills/api-standards/SKILL.md
+++ b/skills/api-standards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api-standards
-description: Use when designing, reviewing, documenting, or changing an API contract in a repository using this shared tooling, including adding an endpoint or RPC, changing a request/response schema or client interface, or preserving API compatibility. Apply Google Cloud API Design Guide and Google AIP guidance by default; apply REST best practices to direct HTTP resources.
+description: Use when designing, reviewing, documenting, or changing an API contract in a repository using this shared tooling, including adding an endpoint or RPC, changing a request/response schema or client interface, or preserving API compatibility. Apply Google Cloud API Design Guide and Google AIP guidance by default; identify the route's real `net/http/rpc`, `net/http/rest`, or `net/http/mvc` transport contract before applying REST rules.
 ---
 
 # API Standards
@@ -25,9 +25,7 @@ versioning risk, and with `$change-validation` for command selection.
    resource-oriented design, resource names, standard methods, custom methods,
    errors, inline documentation, proto3, versioning, backward compatibility,
    file layout, and naming.
-3. For REST-only or direct HTTP/JSON APIs, use REST best practices as secondary
-   REST-specific guidance: `https://restfulapi.net/rest-api-best-practices/`.
-4. When local repository contracts, generated protobuf contracts, OpenAPI specs,
+3. When local repository contracts, generated protobuf contracts, OpenAPI specs,
    or existing API docs are stricter than the external guides, preserve the
    local contract unless the task explicitly approves a migration.
 
@@ -36,8 +34,14 @@ versioning risk, and with `$change-validation` for command selection.
 1. Identify the API surface in scope: `.proto`, service method, resource name,
    HTTP mapping, request or response message, REST route, generated client,
    public Go or Ruby API wrapper, documentation, or compatibility policy.
-2. Identify the transport contract: gRPC-first, gRPC with HTTP transcoding,
-   REST-only, internal-only RPC, external public API, or generated client API.
+2. Read `references/conventions.md` and identify which of this ecosystem's
+   three real `go-service` HTTP transports the specific route or service
+   surface uses: `net/http/rpc`, `net/http/rest`, or `net/http/mvc`.
+   Identify per route or service surface, not per repository — a `net/http/rest`
+   route may serve the request directly or front a generated gRPC client, so
+   check the handler body, not just the repository. Treat `net/http/mvc` view
+   routes as outside this skill's API-contract scope; do not apply REST/AIP/CRUD
+   rules to them.
 3. Inspect nearby APIs, generated files, docs, tests, and consumers before
    proposing names, routes, fields, methods, or compatibility changes.
 4. Prefer resource-oriented design: stable resources, clear parent-child
@@ -57,12 +61,21 @@ versioning risk, and with `$change-validation` for command selection.
 8. Use consistent errors, pagination, filtering, sorting, idempotency, retry,
    timeout, authentication, authorization, rate-limit, and observability
    semantics across the API family.
-9. For REST APIs, use stable resource nouns, lowercase URI paths, standard HTTP
-   methods, standard status codes, stateless requests, clear versioning, and
-   documented deprecation or migration paths.
+9. For `net/http/rest` routes, follow the local contract in
+   `references/conventions.md`: verb-qualified routing with Go 1.22 path
+   templates, Accept/Content-Type negotiation falling back to JSON,
+   `status.SafeError` for error responses, and `Retry-After` only on
+   3xx/429/503 responses (RFC 9110 §10.2.3 for 3xx/503, RFC 6585 §4 for 429).
+   Treat any endpoint-specific `Location` restriction as a local contract, not
+   a general REST rule.
 10. Validate API changes through repository-defined Make targets and generated
     contract checks. Do not bypass existing protobuf, feature, lint, or
     compatibility workflows with ad hoc commands.
+
+## References
+
+- Read `references/conventions.md` for this ecosystem's three real
+  `net/http/rpc`, `net/http/rest`, and `net/http/mvc` transport contracts.
 
 ## Review Gate
 

--- a/skills/api-standards/agents/openai.yaml
+++ b/skills/api-standards/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "API Standards"
   short_description: "Design and review API contracts"
-  default_prompt: "Use $api-standards to design or review an API contract, including an endpoint or RPC, schema, client interface, or compatibility change."
+  default_prompt: "Use $api-standards to design or review an API contract, including an endpoint or RPC, schema, client interface, or compatibility change. Identify the API surface, then its net/http/rpc, net/http/rest, or net/http/mvc transport contract."

--- a/skills/api-standards/references/conventions.md
+++ b/skills/api-standards/references/conventions.md
@@ -1,0 +1,78 @@
+# API Conventions
+
+Use this reference to identify which of this ecosystem's three real
+`go-service` HTTP transports a route or service surface uses, and to apply
+that transport's local contract instead of generic REST/AIP/CRUD rules.
+
+## Transport Identification
+
+Identify the transport per route or service surface, not per repository. A
+repository can mix transports, and a `net/http/rest` route can either serve
+the request directly or front a generated gRPC client — check the handler
+body, not just the repository.
+
+- `net/http/rpc` — POST-only, gRPC-first services (`standort`, `bezeichner`,
+  `migrieren`) exposing their proto-defined gRPC services over HTTP with
+  routes keyed on the full gRPC method name.
+- `net/http/rest` — verb-qualified `<METHOD> <pattern>` routing with Go 1.22
+  path templates. Two supported patterns exist: standalone HTTP-only
+  (`status`, a diagnostic endpoint mapping all five HTTP verbs to one handler)
+  and a gateway in front of a generated gRPC client (`go-monolith`, e.g.
+  `rest.Get("/greeter/v1/hello/{name}", ...)` calling a generated
+  `client.Hello`).
+- `net/http/mvc` — server-rendered HTML (`web`), `GET` full view / `PUT`
+  partial view for the same resource path. Not an API; out of this skill's
+  contract scope.
+
+## `net/http/rpc` Contract
+
+- Every route is `POST <full gRPC method name>`; there is no resource-oriented
+  URL design.
+- Responses use a `meta map<string, string>` envelope field (e.g.
+  `standort/api/standort/v2/service.proto`).
+- Batch/generation RPCs use a config-driven per-request item-count limit
+  instead of AIP `page_token`/`page_size` pagination — e.g.
+  `GenerateIdentifiersRequest.count` and `MapIdentifiersRequest.ids` in
+  `bezeichner/api/bezeichner/v1/service.proto`, with the effective limits
+  reported back via a `RequestLimits` field on `ListApplicationsResponse`.
+- Partial-failure batches use `oneof outcome` with a `google.rpc.Status`
+  branch per item (e.g. `standort/api/standort/v2/service.proto`).
+- Long-running operations document gRPC diagnostic trailers directly in the
+  `.proto` comments (e.g. `migrieren/api/migrieren/v1/service.proto`).
+- Guard compatibility with the repository's `make proto-breaking` target
+  (provided by `build/make/grpc.mak`); do not apply AIP HTTP-transcoding
+  annotations
+  (`google.api.http`) — this ecosystem's `rpc` services do not use them.
+
+## `net/http/rest` Contract
+
+- Routes are verb-qualified: `<METHOD> <pattern>` with Go 1.22 path
+  templating.
+- Content negotiation reads `Accept`/`Content-Type` and falls back to JSON.
+- Error responses use `status.SafeError`, not ad hoc error bodies.
+- `Retry-After` is set only on 3xx/429/503 responses: 3xx and 503 usage
+  matches RFC 9110 §10.2.3, and 429 usage matches RFC 6585 §4. `status`'s
+  diagnostic endpoint additionally
+  restricts its query-driven `Location` header to 3xx codes as a local
+  validation choice, not a general RFC rule: RFC 9110 §10.2.2 also permits
+  `Location` on a 201 Created response, so a resource-creating
+  `net/http/rest` route may still set it there.
+- Before proposing resource-oriented REST design, confirm whether the route
+  serves the request directly (no resource model, e.g. `status`) or fronts a
+  generated gRPC client (apply the `net/http/rpc` contract above to the
+  backing service, e.g. `go-monolith`).
+
+## `net/http/mvc` Contract
+
+- `GET` renders the full view; `PUT` renders the partial view for the same
+  resource path (e.g. `web`).
+- Treat these as HTML view routes, not API contracts — do not apply
+  REST/AIP/CRUD or JSON schema rules to them.
+
+## When To Use The External Guides
+
+- Use the Google Cloud API Design Guide and Google AIPs for proto3/gRPC design
+  on `net/http/rpc` surfaces, and for resource-oriented design questions not
+  answered by a local contract above.
+- Do not apply generic REST-best-practices guidance to `net/http/rest` routes;
+  use the local contract above instead.

--- a/skills/project-workflow/references/agent-init.md
+++ b/skills/project-workflow/references/agent-init.md
@@ -49,25 +49,33 @@ sandbox, and routes direct Bash through the `permissions` allow/ask/deny
 guardrails. Direct Bash is broadly allowed without prompting while sandboxed;
 project-local operations stay autonomous, recognized remote and
 external-service changes require approval, and catastrophic commands remain
-forbidden. The unsandboxed escape hatch is disabled. The sandbox grants the
-standard Go, RuboCop, golangci-lint, and Trivy cache writes needed by project
-commands plus standard system temporary directories, and allows unrestricted
-outbound network access to match the Codex profile, with macOS `trustd` access
-enabled so Go-based CLI tools (`gh`, `gcloud`, `terraform`) can verify TLS
-through the sandbox network proxy. It also allows binding to local ports (for
-local dev servers and tests) and all Unix domain socket connections (for
-Docker, ssh-agent, and local database sockets); the latter can grant effective
-host access through sockets like `/var/run/docker.sock`, so keep using these
-profiles only in trusted repositories. Every `make` invocation is excluded from the
-sandbox and allowed without prompting, except `make pr`, `make draft`, `make
-merge`, `make ready`, and `make review`, which require approval because they
-create, merge, or force-push a pull request. Built-in file reads and edits are scoped
-to the workspace plus the standard system temporary directories (`/tmp`,
+forbidden. The unsandboxed escape hatch is disabled. The sandbox grants write
+access to the workspace (`.`) plus the standard Go, RuboCop, golangci-lint, and
+Trivy cache writes needed by project commands and standard system temporary
+directories, and allows unrestricted outbound network access to match the
+Codex profile, with macOS `trustd` access enabled so Go-based CLI tools (`gh`,
+`gcloud`, `terraform`) can verify TLS through the sandbox network proxy. It
+also allows binding to local ports (for local dev servers and tests) and all
+Unix domain socket connections (for Docker, ssh-agent, and local database
+sockets); the latter can grant effective host access through sockets like
+`/var/run/docker.sock`, so keep using these profiles only in trusted
+repositories. Every `make` invocation is excluded from the sandbox and allowed
+without prompting, except `make pr`, `make draft`, `make merge`, `make ready`,
+and `make review`, which require approval because they create, merge, or
+force-push a pull request. Built-in file reads and edits are scoped to the
+workspace plus the standard system temporary directories (`/tmp`,
 `/private/tmp`, `/var/tmp`, `/var/folders`), which are readable and editable
 without prompting; the Write tool has no auto-allow rule and always prompts.
-Per-repo or per-machine permission tweaks belong in the
-gitignored `.claude/settings.local.json`, which Claude Code merges over the
-baseline.
+Because ordinary Bash commands not matched by the `ask`/`deny` rules are
+auto-allowed, and the sandbox now permits workspace writes, a shell redirect,
+`sed -i`, `rm`, or similar local file mutation can create, overwrite, or
+delete workspace files with neither a prompt nor a diff-reviewable Edit — the
+same risk the Write-tool prompt exists to gate, reopened through Bash for
+commands the `ask`/`deny` rules do not already cover. This is a deliberate
+trusted-repository trade-off, not an oversight; route diff-reviewable content
+changes through Edit where practical. Per-repo or
+per-machine permission tweaks belong in the gitignored
+`.claude/settings.local.json`, which Claude Code merges over the baseline.
 
 ## Background process lifecycle and signal handling
 


### PR DESCRIPTION
## What

- Guide API work by identifying the local HTTP transport contract and document the shared `proto-breaking` target.
- Document Claude's workspace write scope and the trusted-repository trade-off for direct Bash mutations.

## Why

- Local transport rules prevent generic REST guidance from producing incompatible API recommendations, while accurate permission documentation lets downstream maintainers make an informed trust decision.

## Testing

- `make dep && make clean-dep` - passed
- `make scripts-lint` - passed
- `make skills-lint` - passed
- `make docker-lint` - passed
- `make lint` - passed
- `make sec` - passed
- `git diff --check` - passed
- No new tests: this changes shared configuration and documentation rather than repository-owned executable behavior.
