### PR TITLE
feat(skills): fix repo-health collector pagination, dst, and readiness gaps

### DIFF
--- a/skills/repo-health/references/metrics.md
+++ b/skills/repo-health/references/metrics.md
@@ -75,6 +75,9 @@ Interpretation:
 - Rising open or stale PR counts are bottleneck signals.
 - Very small sample sizes should be labeled as low confidence.
 - If all sampled PRs lack review records, report review latency as `n/a`.
+- If pre-boundary activity evidence cannot prove whether an open PR was stale
+  at the current-period end, report stale PRs as unavailable rather than a
+  count derived from live activity.
 
 ## CI Quality
 

--- a/skills/repo-health/scripts/collect.rb
+++ b/skills/repo-health/scripts/collect.rb
@@ -3,9 +3,11 @@
 
 # rubocop:disable Metrics/ClassLength, Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
+require 'date'
 require 'json'
 require 'net/http'
 require 'open3'
+require 'openssl'
 require 'optparse'
 require 'time'
 require 'uri'
@@ -17,6 +19,14 @@ class RepoHealthCollector
   HTTP_TIMEOUT_SECONDS = 15
   TREND_WINDOW_COUNT = 4
   STALE_PR_SECONDS = 7 * 24 * 60 * 60
+  GITHUB_PR_PAGE_LIMIT = 100
+  GITHUB_PR_PAGE_LIMIT_MAX = 6_400
+  HTTP_RETRY_MAX_ATTEMPTS = 3
+  HTTP_RETRY_BASE_DELAY_SECONDS = 0.2
+  TRANSIENT_HTTP_ERRORS = [
+    OpenSSL::SSL::SSLError, EOFError, Errno::ECONNRESET, Errno::EPIPE, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
+    Errno::EHOSTUNREACH, Errno::ENETUNREACH, Net::OpenTimeout, Net::ReadTimeout
+  ].freeze
   CI_SUCCESS_RATE_ACTION_THRESHOLD = 0.90
   CHANGE_RATIO_ACTION_THRESHOLD = 0.25
   LIBRARY_RELEASE_AGE_ACTION_SECONDS = 90 * 24 * 60 * 60
@@ -28,9 +38,10 @@ class RepoHealthCollector
     @include_jobs = options.fetch(:include_jobs)
     @now = options[:now] ? parse_time(options[:now]) : Time.now
     @current_end = options[:current_end] ? parse_time(options[:current_end]) : day_start(@now)
-    @current_start = options[:current_start] ? parse_time(options[:current_start]) : @current_end - (7 * 24 * 60 * 60)
+    @current_start =
+      options[:current_start] ? parse_time(options[:current_start]) : subtract_local_days(@current_end, 7)
     @previous_end = @current_start
-    @previous_start = options[:previous_start] ? parse_time(options[:previous_start]) : @previous_end - window_seconds
+    @previous_start = options[:previous_start] ? parse_time(options[:previous_start]) : default_previous_start
   end
 
   def call
@@ -69,6 +80,52 @@ class RepoHealthCollector
     with_timezone do
       local = Time.local(time.year, time.month, time.day)
       Time.parse(local.strftime('%Y-%m-%d 00:00:00 %z'))
+    end
+  end
+
+  # Subtracts whole local calendar days while preserving wall-clock
+  # hour/minute/second, so the result lands on local midnight (or whatever
+  # time-of-day was given) even across a daylight-saving transition, instead
+  # of drifting by the transition's offset change like fixed-second
+  # subtraction would.
+  def subtract_local_days(time, days)
+    date = Date.new(time.year, time.month, time.day) - days
+    with_timezone do
+      local = Time.local(date.year, date.month, date.day, time.hour, time.min, time.sec)
+      Time.parse(local.strftime('%Y-%m-%d %H:%M:%S %z'))
+    end
+  end
+
+  # Whole calendar-day span between two local times, or nil when they do not
+  # share a time-of-day (an explicit arbitrary-instant window), in which case
+  # callers fall back to elapsed-second arithmetic.
+  def local_day_span(start_time, end_time)
+    same_time_of_day = [start_time.hour, start_time.min, start_time.sec] == [end_time.hour, end_time.min, end_time.sec]
+    return nil unless same_time_of_day
+
+    end_date = Date.new(end_time.year, end_time.month, end_time.day)
+    start_date = Date.new(start_time.year, start_time.month, start_time.day)
+    (end_date - start_date).to_i
+  end
+
+  def default_previous_start
+    days = local_day_span(@current_start, @current_end)
+    return @previous_end - window_seconds unless days
+
+    subtract_local_days(@previous_end, days)
+  end
+
+  def default_window_start(end_time)
+    days = local_day_span(@current_start, @current_end)
+    return elapsed_window_start(end_time) unless days
+
+    subtract_local_days(end_time, days)
+  end
+
+  def elapsed_window_start(end_time)
+    with_timezone do
+      time = Time.at(end_time.to_i - window_seconds)
+      time.getlocal(time.utc_offset)
     end
   end
 
@@ -163,44 +220,61 @@ class RepoHealthCollector
   def collect_github(owner_repo)
     return skipped('gh is not installed') unless command_available?('gh')
 
-    open_prs = gh_json(
-      'pr', 'list', '--repo', owner_repo, '--state', 'open',
-      '--json', 'number,title,createdAt,updatedAt,url'
-    )
-    stale_prs = open_prs.select do |pull_request|
-      updated = pull_request['updatedAt'] && Time.parse(pull_request.fetch('updatedAt'))
-      updated && updated < @current_end - STALE_PR_SECONDS
-    end
+    open_state = github_open_prs_at_end(owner_repo)
     trend = period_windows.map { |window| github_period(owner_repo, window.fetch(:start), window.fetch(:end)) }
 
     {
       current: trend[0],
       previous: trend[1],
       trend: trend,
-      open_pr_count: open_prs.length,
-      open_prs: open_prs,
-      stale_pr_count: stale_prs.length,
-      stale_prs: stale_prs
+      open_pr_count: open_state.fetch(:open).length,
+      open_prs: open_state.fetch(:open),
+      stale_pr_count: open_state.fetch(:stale)&.length,
+      stale_prs: open_state.fetch(:stale)
     }
   rescue StandardError => e
     unavailable(e.message)
   end
 
+  # Reconstructs which PRs were open at @current_end from complete creation
+  # and closed timestamps, since the live open-PR queue reflects collection
+  # time, not a historical period end. Stale classification is reliable only
+  # when a PR's last known activity is at or before @current_end; otherwise
+  # activity could have happened after the boundary, so staleness is reported
+  # as unavailable rather than reused from the live `updatedAt`.
+  def github_open_prs_at_end(owner_repo)
+    candidates = gh_pr_list(
+      'pr', 'list', '--repo', owner_repo, '--state', 'all',
+      '--search', "created:<=#{@current_end.getutc.strftime('%Y-%m-%d')}",
+      '--json', 'number,title,createdAt,updatedAt,closedAt,url'
+    )
+    open_prs = candidates.select do |pr|
+      Time.parse(pr.fetch('createdAt')) <= @current_end &&
+        (pr['closedAt'].nil? || Time.parse(pr.fetch('closedAt')) > @current_end)
+    end
+
+    known_activity = open_prs.map { |pr| pr['updatedAt'] && Time.parse(pr.fetch('updatedAt')) }
+    return { open: open_prs, stale: nil } if known_activity.any? { |updated| updated.nil? || updated > @current_end }
+
+    stale = open_prs.zip(known_activity).select { |_, updated| updated < @current_end - STALE_PR_SECONDS }.map(&:first)
+    { open: open_prs, stale: stale }
+  end
+
   def github_period(owner_repo, start_time, end_time)
-    date_range = "#{start_time.strftime('%Y-%m-%d')}..#{(end_time - 1).strftime('%Y-%m-%d')}"
-    merged = gh_json(
+    date_range = "#{start_time.getutc.strftime('%Y-%m-%d')}..#{(end_time - 1).getutc.strftime('%Y-%m-%d')}"
+    merged = gh_pr_list(
       'pr', 'list', '--repo', owner_repo, '--state', 'merged', '--search', "merged:#{date_range}",
-      '--limit', '300', '--json', 'number,title,createdAt,mergedAt,url,reviews'
+      '--json', 'number,title,createdAt,mergedAt,url,reviews'
     ).select { |pr| within?(Time.parse(pr.fetch('mergedAt')), start_time, end_time) }
 
-    created = gh_json(
+    created = gh_pr_list(
       'pr', 'list', '--repo', owner_repo, '--state', 'all', '--search', "created:#{date_range}",
-      '--limit', '300', '--json', 'number,createdAt'
+      '--json', 'number,createdAt'
     ).count { |pr| within?(Time.parse(pr.fetch('createdAt')), start_time, end_time) }
 
-    closed_unmerged = gh_json(
+    closed_unmerged = gh_pr_list(
       'pr', 'list', '--repo', owner_repo, '--state', 'closed',
-      '--search', "closed:#{date_range} -merged:#{date_range}", '--limit', '300', '--json', 'number,closedAt,mergedAt'
+      '--search', "closed:#{date_range} -merged:#{date_range}", '--json', 'number,closedAt,mergedAt'
     ).count do |pr|
       pr['mergedAt'].nil? && pr['closedAt'] && within?(Time.parse(pr.fetch('closedAt')), start_time,
                                                        end_time)
@@ -416,11 +490,13 @@ class RepoHealthCollector
 
   def pod_summary(pod)
     statuses = pod.dig('status', 'containerStatuses') || []
+    conditions = pod.dig('status', 'conditions') || []
+    ready_condition = conditions.find { |condition| condition['type'] == 'Ready' }
     {
       namespace: pod.dig('metadata', 'namespace'),
       name: pod.dig('metadata', 'name'),
       phase: pod.dig('status', 'phase'),
-      ready: statuses.all? { |status| status['ready'] },
+      ready: ready_condition ? ready_condition['status'] == 'True' : false,
       restarts: statuses.sum { |status| status['restartCount'].to_i },
       started_at: pod.dig('status', 'startTime')
     }
@@ -922,11 +998,7 @@ class RepoHealthCollector
     ]
     while windows.length < TREND_WINDOW_COUNT
       end_time = windows.last.fetch(:start)
-      start_time = with_timezone do
-        time = Time.at(end_time.to_i - window_seconds)
-        time.getlocal(time.utc_offset)
-      end
-      windows << { start: start_time, end: end_time }
+      windows << { start: default_window_start(end_time), end: end_time }
     end
     windows
   end
@@ -1086,11 +1158,20 @@ class RepoHealthCollector
   end
 
   def http_response(uri, request)
-    http = Net::HTTP.new(uri.host, uri.port)
-    http.use_ssl = true
-    http.open_timeout = HTTP_TIMEOUT_SECONDS
-    http.read_timeout = HTTP_TIMEOUT_SECONDS
-    http.request(request)
+    attempt = 0
+    begin
+      attempt += 1
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.open_timeout = HTTP_TIMEOUT_SECONDS
+      http.read_timeout = HTTP_TIMEOUT_SECONDS
+      http.request(request)
+    rescue *TRANSIENT_HTTP_ERRORS
+      raise if attempt >= HTTP_RETRY_MAX_ATTEMPTS
+
+      sleep(HTTP_RETRY_BASE_DELAY_SECONDS * attempt)
+      retry
+    end
   end
 
   def kubectl_json(*)
@@ -1099,6 +1180,19 @@ class RepoHealthCollector
 
   def gh_json(*)
     JSON.parse(capture('gh', *))
+  end
+
+  def gh_pr_list(*args)
+    limit = GITHUB_PR_PAGE_LIMIT
+    loop do
+      results = gh_json(*args, '--limit', limit.to_s)
+      return results if results.length < limit
+      if limit >= GITHUB_PR_PAGE_LIMIT_MAX
+        raise "gh pr list saturated at --limit #{limit} without proving completeness: #{args.join(' ')}"
+      end
+
+      limit *= 2
+    end
   end
 
   def git_root
@@ -1121,13 +1215,18 @@ class RepoHealthCollector
              .sub(%r{\Aorigin/}, '')
     return branch unless branch.empty?
 
-    if command_available?('gh')
-      branch = gh_json('repo', 'view', owner_repo, '--json', 'defaultBranchRef')
-               .dig('defaultBranchRef', 'name')
-      return branch if branch && !branch.empty?
-    end
+    branch = github_default_branch(owner_repo)
+    return branch if branch && !branch.empty?
 
     git('branch', '--show-current').strip
+  end
+
+  def github_default_branch(owner_repo)
+    return nil unless command_available?('gh')
+
+    gh_json('repo', 'view', owner_repo, '--json', 'defaultBranchRef').dig('defaultBranchRef', 'name')
+  rescue StandardError
+    nil
   end
 
   def capture(*args, allow_failure: false)

--- a/test/skills/repo-health
+++ b/test/skills/repo-health
@@ -1,56 +1,277 @@
 #!/usr/bin/env bash
-# Exercise the documented repo-health collector CLI against isolated local Git data.
+# Exercise the documented repo-health collector CLI end-to-end against isolated
+# fixtures. Each scenario_* function owns one self-contained collector run so
+# per-issue fixtures (stubbed gh/kubectl) do not entangle with each other.
 
 set -eo pipefail
 
 root="$(cd "$(dirname "$0")/../.." && pwd)"
-fixture="$(mktemp -d)"
-commands="$fixture/commands"
-report="$fixture/report.json"
+git_command="$(command -v git)"
 ruby_command="$(command -v ruby)"
+cleanup_dirs=()
 
 cleanup() {
-  rm -rf "$fixture"
+  local dir
+
+  for dir in "${cleanup_dirs[@]}"; do
+    rm -rf "$dir"
+  done
+}
+
+trap cleanup EXIT
+
+new_fixture() {
+  local fixture
+
+  fixture="$(mktemp -d)"
+  cleanup_dirs+=("$fixture")
+  mkdir "$fixture/commands"
+  ln -s "$git_command" "$fixture/commands/git"
+  ln -s "$ruby_command" "$fixture/commands/ruby"
+  printf '%s\n' "$fixture"
+}
+
+init_repo() {
+  local fixture="$1"
+
+  git init -q "$fixture"
+  git -C "$fixture" checkout -qb master
+  git -C "$fixture" config user.email repo-health@example.test
+  git -C "$fixture" config user.name 'Repo Health Test'
+  git -C "$fixture" remote add origin https://github.com/example/repo-health-fixture.git
 }
 
 commit() {
-  local date="$1"
-  local subject="$2"
+  local fixture="$1"
+  local date="$2"
+  local subject="$3"
 
   printf '%s\n' "$subject" >> "$fixture/changes"
   git -C "$fixture" add changes
   GIT_AUTHOR_DATE="$date" GIT_COMMITTER_DATE="$date" git -C "$fixture" commit -qm "$subject"
 }
 
-trap cleanup EXIT
+# Writes a fake `gh` that serves PR fixtures from gh-prs.json (array of
+# {number,state,createdAt,mergedAt,closedAt,url,reviews}) and applies the same
+# --state/--search/--limit semantics `collect_github` relies on, so
+# pagination, UTC-search-window, and completeness behavior can be exercised
+# without real GitHub access. A `gh-saturate` marker file makes every call
+# fill the requested --limit so callers can observe unprovable-completeness
+# behavior.
+stub_gh() {
+  local fixture="$1"
 
-mkdir "$commands"
-ln -s "$(command -v git)" "$commands/git"
-ln -s "$ruby_command" "$commands/ruby"
+  cat > "$fixture/commands/gh" <<'RUBY'
+#!/usr/bin/env ruby
+require 'json'
+require 'time'
+require 'date'
 
-git init -q "$fixture"
-git -C "$fixture" checkout -qb master
-git -C "$fixture" config user.email repo-health@example.test
-git -C "$fixture" config user.name 'Repo Health Test'
-git -C "$fixture" remote add origin https://github.com/example/repo-health-fixture.git
+fixture_root = File.expand_path(File.join(__dir__, '..'))
+args = ARGV
 
-commit '2025-01-01T00:00:00+00:00' 'Initial release'
-GIT_COMMITTER_DATE='2025-01-02T00:00:00+00:00' git -C "$fixture" tag -am 'Release v1.0.0' v1.0.0
-commit '2026-07-12T10:00:00+02:00' 'Previous window change'
-commit '2026-07-20T10:00:00+02:00' 'Current window change one'
-commit '2026-07-22T10:00:00+02:00' 'Current window change two'
+def flag(args, name)
+  index = args.index(name)
+  index && args[index + 1]
+end
 
-unset CIRCLE_TOKEN CIRCLECI_TOKEN
-TZ=UTC CIRCLECI_CLI_CONFIG="$fixture/missing-circleci-config.yml" PATH="$commands" \
-  "$ruby_command" "$root/skills/repo-health/scripts/collect.rb" \
-  --repo "$fixture" \
-  --timezone Europe/Berlin \
-  --current-start '2026-07-18 00:00:00 +02:00' \
-  --current-end '2026-07-25 00:00:00 +02:00' \
-  --previous-start '2026-07-11 00:00:00 +02:00' \
-  --branch master > "$report"
+File.open(File.join(fixture_root, 'gh-calls.log'), 'a') { |f| f.puts(JSON.generate(args)) }
 
-"$ruby_command" -rjson - "$report" <<'RUBY'
+limit = (flag(args, '--limit') || '30').to_i
+
+if File.exist?(File.join(fixture_root, 'gh-saturate'))
+  # Shaped per requested --state so every real call site (open PRs, merged
+  # PRs, closed-unmerged PRs) gets a well-formed item for whatever fields it
+  # reads, regardless of which code path is under test; a caller must never
+  # crash for an unrelated reason and mask whether saturation was genuinely
+  # detected.
+  state = flag(args, '--state')
+  anchor = '2026-01-01T00:00:00Z'
+  fields = case state
+           when 'merged' then { 'mergedAt' => anchor, 'closedAt' => anchor }
+           when 'closed' then { 'mergedAt' => nil, 'closedAt' => anchor }
+           else { 'mergedAt' => nil, 'closedAt' => nil }
+           end
+  puts JSON.generate(Array.new(limit) { |i|
+    { 'number' => i + 1, 'title' => "PR #{i + 1}", 'createdAt' => anchor, 'updatedAt' => anchor,
+      'url' => "https://github.com/example/repo-health-fixture/pull/#{i + 1}", 'reviews' => [] }.merge(fields)
+  })
+  exit 0
+end
+
+if args[0] == 'repo' && args[1] == 'view'
+  puts JSON.generate('defaultBranchRef' => { 'name' => 'master' })
+  exit 0
+end
+
+prs_path = File.join(fixture_root, 'gh-prs.json')
+prs = File.exist?(prs_path) ? JSON.parse(File.read(prs_path)) : []
+
+state = flag(args, '--state')
+candidates = state && state != 'all' ? prs.select { |pr| pr['state'] == state } : prs
+
+search = flag(args, '--search')
+FIELD_BY_QUALIFIER = { 'merged' => 'mergedAt', 'created' => 'createdAt', 'closed' => 'closedAt' }.freeze
+
+def date_matcher(expr)
+  if expr.include?('..')
+    from_date, to_date = expr.split('..', 2).map { |value| Date.parse(value) }
+    return ->(date) { date.between?(from_date, to_date) }
+  end
+
+  operator = expr[/\A(<=|>=|<|>)/, 1] || '=='
+  bound = Date.parse(expr.delete_prefix(operator))
+  ->(date) { date.public_send(operator, bound) }
+end
+
+search.to_s.split(' ').each do |token|
+  negate = token.start_with?('-')
+  token = token[1..] if negate
+  qualifier, expr = token.split(':', 2)
+  field = FIELD_BY_QUALIFIER.fetch(qualifier)
+  matcher = date_matcher(expr)
+
+  candidates = candidates.select do |pr|
+    value = pr[field]
+    matched = value && matcher.call(Time.parse(value).utc.to_date)
+    negate ? !matched : matched
+  end
+end
+
+puts JSON.generate(candidates.first(limit))
+RUBY
+  chmod +x "$fixture/commands/gh"
+}
+
+# Writes a fake `kubectl` that serves `kubectl-deployments.json` and
+# `kubectl-pods.json` fixtures for `get deployments -A -o json` and
+# `get pods -n NS -l SELECTOR -o json`, so Pod readiness logic can be
+# exercised without a real cluster.
+stub_kubectl() {
+  local fixture="$1"
+
+  cat > "$fixture/commands/kubectl" <<'RUBY'
+#!/usr/bin/env ruby
+require 'json'
+
+fixture_root = File.expand_path(File.join(__dir__, '..'))
+args = ARGV
+
+if args[0] == 'config' && args[1] == 'current-context'
+  puts 'test-context'
+  exit 0
+end
+
+fixture_name = args[1] == 'deployments' ? 'kubectl-deployments.json' : 'kubectl-pods.json'
+path = File.join(fixture_root, fixture_name)
+puts File.exist?(path) ? File.read(path) : '{"items":[]}'
+RUBY
+  chmod +x "$fixture/commands/kubectl"
+}
+
+run_collector() {
+  local fixture="$1"
+  shift
+
+  unset CIRCLE_TOKEN CIRCLECI_TOKEN
+  TZ=UTC CIRCLECI_CLI_CONFIG="$fixture/missing-circleci-config.yml" PATH="$fixture/commands" \
+    "$ruby_command" "$root/skills/repo-health/scripts/collect.rb" --repo "$fixture" "$@"
+}
+
+# Writes a minimal .circleci/config.yml plus a CLI config file with a fake
+# token, so collect_circleci attempts real collection instead of skipping.
+stub_circleci_config() {
+  local fixture="$1"
+
+  mkdir -p "$fixture/.circleci"
+  cat > "$fixture/.circleci/config.yml" <<'YAML'
+version: 2.1
+jobs:
+  build:
+    docker:
+      - image: cimg/base:stable
+workflows:
+  main:
+    jobs:
+      - build
+YAML
+  cat > "$fixture/circleci-cli.yml" <<'YAML'
+token: fake-test-token
+YAML
+}
+
+# Writes a Net::HTTP#request monkey-patch, loaded via RUBYOPT before
+# collect.rb, that fakes transient CircleCI failures without touching a real
+# network. `net_http_fault_mode` is "recover" (fail the first call, then
+# always return a canned success) or "persistent" (always fail). This is the
+# in-process equivalent of stubbing an external command on PATH: Net::HTTP is
+# an in-process dependency, so it is faked at its own call boundary instead.
+stub_net_http_fault() {
+  local fixture="$1"
+
+  cat > "$fixture/net_http_fault.rb" <<'RUBY'
+require 'net/http'
+require 'openssl'
+
+class Net::HTTP
+  def request(req, *rest, &blk)
+    state_path = ENV.fetch('NET_HTTP_FAULT_STATE')
+    mode = ENV.fetch('NET_HTTP_FAULT_MODE')
+    attempts = File.exist?(state_path) ? File.read(state_path).to_i : 0
+    attempts += 1
+    File.write(state_path, attempts.to_s)
+
+    if mode == 'persistent' || (mode == 'recover' && attempts == 1)
+      raise OpenSSL::SSL::SSLError, 'SSL_read: unexpected eof while reading'
+    end
+
+    response = Net::HTTPOK.new('1.1', '200', 'OK')
+    response.instance_variable_set(:@read, true)
+    response.instance_variable_set(:@body, File.read(ENV.fetch('NET_HTTP_FAULT_BODY')))
+    response
+  end
+end
+RUBY
+  printf '{"items":[],"next_page_token":null,"total_flaky_tests":0,"flaky_tests":[]}' \
+    > "$fixture/net-http-fault-body.json"
+}
+
+run_collector_with_net_http_fault() {
+  local fixture="$1"
+  local mode="$2"
+  shift 2
+
+  unset CIRCLE_TOKEN CIRCLECI_TOKEN
+  TZ=UTC \
+    CIRCLECI_CLI_CONFIG="$fixture/circleci-cli.yml" \
+    RUBYOPT="-r$fixture/net_http_fault.rb" \
+    NET_HTTP_FAULT_STATE="$fixture/net-http-fault-attempts" \
+    NET_HTTP_FAULT_MODE="$mode" \
+    NET_HTTP_FAULT_BODY="$fixture/net-http-fault-body.json" \
+    PATH="$fixture/commands" \
+    "$ruby_command" "$root/skills/repo-health/scripts/collect.rb" --repo "$fixture" "$@"
+}
+
+scenario_baseline() {
+  local fixture report
+  fixture="$(new_fixture)"
+  report="$fixture/report.json"
+
+  init_repo "$fixture"
+  commit "$fixture" '2025-01-01T00:00:00+00:00' 'Initial release'
+  GIT_COMMITTER_DATE='2025-01-02T00:00:00+00:00' git -C "$fixture" tag -am 'Release v1.0.0' v1.0.0
+  commit "$fixture" '2026-07-12T10:00:00+02:00' 'Previous window change'
+  commit "$fixture" '2026-07-20T10:00:00+02:00' 'Current window change one'
+  commit "$fixture" '2026-07-22T10:00:00+02:00' 'Current window change two'
+
+  run_collector "$fixture" \
+    --branch master \
+    --timezone Europe/Berlin \
+    --current-start '2026-07-18 00:00:00 +02:00' \
+    --current-end '2026-07-25 00:00:00 +02:00' \
+    --previous-start '2026-07-11 00:00:00 +02:00' > "$report"
+
+  "$ruby_command" -rjson - "$report" <<'RUBY'
 report = JSON.parse(File.read(ARGV.fetch(0)))
 
 def assert_equal(expected, actual, label)
@@ -101,3 +322,462 @@ assert_equal 'Release', report.dig('top_bottleneck', 'area'), 'top bottleneck ar
 assert_equal 'P2', report.dig('action_queue', 0, 'priority'), 'first action priority'
 assert_equal 'Release', report.dig('action_queue', 0, 'area'), 'first action area'
 RUBY
+}
+
+# ISSUE-1: open PRs and period PRs must be counted completely even when the
+# provider would return more than a single naive page.
+scenario_github_pr_pagination() {
+  local fixture report
+  fixture="$(new_fixture)"
+  report="$fixture/report.json"
+
+  init_repo "$fixture"
+  commit "$fixture" '2026-07-01T00:00:00+00:00' 'Initial change'
+  stub_gh "$fixture"
+  "$ruby_command" -rjson -e '
+    open = Array.new(150) { |i| { number: i + 1, state: "open", createdAt: "2026-07-20T00:00:00Z", updatedAt: "2026-07-20T00:00:00Z" } }
+    merged = Array.new(350) { |i|
+      { number: 1_000 + i, state: "merged", createdAt: "2026-07-19T00:00:00Z",
+        mergedAt: "2026-07-20T00:00:00Z", closedAt: "2026-07-20T00:00:00Z" }
+    }
+    puts JSON.generate(open + merged)
+  ' > "$fixture/gh-prs.json"
+
+  run_collector "$fixture" \
+    --branch master \
+    --timezone UTC \
+    --current-start '2026-07-18 00:00:00 +00:00' \
+    --current-end '2026-07-25 00:00:00 +00:00' \
+    --previous-start '2026-07-11 00:00:00 +00:00' > "$report"
+
+  "$ruby_command" -rjson - "$report" <<'RUBY'
+report = JSON.parse(File.read(ARGV.fetch(0)))
+
+def assert_equal(expected, actual, label)
+  return if expected == actual
+
+  abort "#{label}: expected #{expected.inspect}, got #{actual.inspect}"
+end
+
+assert_equal 'used', report.dig('sources', 'github', 'status'), 'GitHub source status'
+assert_equal 150, report.dig('delivery_flow', 'open_pr_count'), 'open PR count beyond a single page'
+assert_equal 350, report.dig('delivery_flow', 'current', 'pr_merged'), 'merged PR count beyond a single page'
+RUBY
+}
+
+# ISSUE-1: when completeness cannot be proven even after escalating the page
+# size, the GitHub source must be marked unavailable rather than silently
+# capped.
+scenario_github_pr_pagination_unavailable() {
+  local fixture report
+  fixture="$(new_fixture)"
+  report="$fixture/report.json"
+
+  init_repo "$fixture"
+  commit "$fixture" '2026-07-01T00:00:00+00:00' 'Initial change'
+  stub_gh "$fixture"
+  : > "$fixture/gh-saturate"
+
+  run_collector "$fixture" \
+    --branch master \
+    --timezone UTC \
+    --current-start '2026-07-18 00:00:00 +00:00' \
+    --current-end '2026-07-25 00:00:00 +00:00' \
+    --previous-start '2026-07-11 00:00:00 +00:00' > "$report"
+
+  "$ruby_command" -rjson - "$report" <<'RUBY'
+report = JSON.parse(File.read(ARGV.fetch(0)))
+
+status = report.dig('sources', 'github', 'status')
+abort "GitHub source status: expected unavailable, got #{status.inspect}" unless status == 'unavailable'
+RUBY
+}
+
+# ISSUE-2: a PR merged in the last local hours of the window's UTC-preceding
+# day must still be counted, even though its own UTC calendar date falls
+# outside the local-only date search.
+scenario_github_pr_utc_boundary() {
+  local fixture report
+  fixture="$(new_fixture)"
+  report="$fixture/report.json"
+
+  init_repo "$fixture"
+  commit "$fixture" '2026-07-01T00:00:00+00:00' 'Initial change'
+  stub_gh "$fixture"
+  "$ruby_command" -rjson -e '
+    merged = [{ number: 1, state: "merged", createdAt: "2026-07-20T00:00:00Z",
+                mergedAt: "2026-07-24T23:09:34Z", closedAt: "2026-07-24T23:09:34Z" }]
+    puts JSON.generate(merged)
+  ' > "$fixture/gh-prs.json"
+
+  run_collector "$fixture" \
+    --branch master \
+    --timezone Europe/Berlin \
+    --current-start '2026-07-25 00:00:00 +02:00' \
+    --current-end '2026-07-26 00:00:00 +02:00' \
+    --previous-start '2026-07-18 00:00:00 +02:00' > "$report"
+
+  "$ruby_command" -rjson - "$report" <<'RUBY'
+report = JSON.parse(File.read(ARGV.fetch(0)))
+
+def assert_equal(expected, actual, label)
+  return if expected == actual
+
+  abort "#{label}: expected #{expected.inspect}, got #{actual.inspect}"
+end
+
+assert_equal 1, report.dig('delivery_flow', 'current', 'pr_merged'), 'PR merged near the local-midnight UTC boundary'
+RUBY
+
+grep -q -- '--search","merged:2026-07-24..2026-07-25"' "$fixture/gh-calls.log" || {
+  echo "gh was not searched with the UTC-widened merged date range; calls:" >&2
+  cat "$fixture/gh-calls.log" >&2
+  exit 1
+}
+}
+
+# ISSUE-2: a negative-offset zone can push the local window's final hours
+# into the UTC-following day, which must still be searched and counted.
+scenario_github_pr_utc_boundary_negative_offset() {
+  local fixture report
+  fixture="$(new_fixture)"
+  report="$fixture/report.json"
+
+  init_repo "$fixture"
+  commit "$fixture" '2026-07-01T00:00:00+00:00' 'Initial change'
+  stub_gh "$fixture"
+  "$ruby_command" -rjson -e '
+    merged = [{ number: 1, state: "merged", createdAt: "2026-07-18T00:00:00Z",
+                mergedAt: "2026-07-19T02:00:00Z", closedAt: "2026-07-19T02:00:00Z" }]
+    puts JSON.generate(merged)
+  ' > "$fixture/gh-prs.json"
+
+  run_collector "$fixture" \
+    --branch master \
+    --timezone Etc/GMT+5 \
+    --current-start '2026-07-18 00:00:00 -05:00' \
+    --current-end '2026-07-19 00:00:00 -05:00' \
+    --previous-start '2026-07-17 00:00:00 -05:00' > "$report"
+
+  "$ruby_command" -rjson - "$report" <<'RUBY'
+report = JSON.parse(File.read(ARGV.fetch(0)))
+
+def assert_equal(expected, actual, label)
+  return if expected == actual
+
+  abort "#{label}: expected #{expected.inspect}, got #{actual.inspect}"
+end
+
+assert_equal 1, report.dig('delivery_flow', 'current', 'pr_merged'),
+             'PR merged past local midnight into the UTC-following day'
+RUBY
+
+grep -q -- '--search","merged:2026-07-18..2026-07-19"' "$fixture/gh-calls.log" || {
+  echo "gh was not searched with the UTC-widened merged date range; calls:" >&2
+  cat "$fixture/gh-calls.log" >&2
+  exit 1
+}
+}
+
+# ISSUE-3: open PRs must reflect state as of the requested historical
+# current-period end, not the live queue at collection time.
+scenario_github_historical_open_prs() {
+  local fixture report
+  fixture="$(new_fixture)"
+  report="$fixture/report.json"
+
+  init_repo "$fixture"
+  commit "$fixture" '2026-07-01T00:00:00+00:00' 'Initial change'
+  stub_gh "$fixture"
+  "$ruby_command" -rjson -e '
+    prs = [
+      # Open at the 2026-07-08 boundary (created before it, closed after it),
+      # but already closed by collection time.
+      { number: 1, state: "closed", createdAt: "2026-06-01T00:00:00Z",
+        updatedAt: "2026-07-15T00:00:00Z", closedAt: "2026-07-15T00:00:00Z" },
+      # Created after the 2026-07-08 boundary, so not open at that boundary,
+      # but still open (and live) at collection time.
+      { number: 2, state: "open", createdAt: "2026-07-10T00:00:00Z",
+        updatedAt: "2026-07-10T00:00:00Z", closedAt: nil },
+      { number: 3, state: "open", createdAt: "2026-07-12T00:00:00Z",
+        updatedAt: "2026-07-12T00:00:00Z", closedAt: nil },
+      # Open at the boundary and still open (live) at collection time.
+      { number: 4, state: "open", createdAt: "2026-06-15T00:00:00Z",
+        updatedAt: "2026-07-02T00:00:00Z", closedAt: nil }
+    ]
+    puts JSON.generate(prs)
+  ' > "$fixture/gh-prs.json"
+
+  run_collector "$fixture" \
+    --branch master \
+    --timezone UTC \
+    --current-start '2026-07-01 00:00:00 +00:00' \
+    --current-end '2026-07-08 00:00:00 +00:00' \
+    --previous-start '2026-06-24 00:00:00 +00:00' > "$report"
+
+  "$ruby_command" -rjson - "$report" <<'RUBY'
+report = JSON.parse(File.read(ARGV.fetch(0)))
+
+def assert_equal(expected, actual, label)
+  return if expected == actual
+
+  abort "#{label}: expected #{expected.inspect}, got #{actual.inspect}"
+end
+
+assert_equal 2, report.dig('delivery_flow', 'open_pr_count'),
+             'open PR count as of the historical current-period end, not the live queue'
+assert_equal nil, report.dig('delivery_flow', 'stale_pr_count'),
+             'stale state must be unavailable, not derived from live updatedAt'
+RUBY
+}
+
+# ISSUE-4: default complete-day windows must stay at local midnight across a
+# spring-forward daylight-saving transition (Europe/Berlin, 2026-03-29).
+scenario_default_windows_across_dst() {
+  local fixture report
+  fixture="$(new_fixture)"
+  report="$fixture/report.json"
+
+  init_repo "$fixture"
+  commit "$fixture" '2026-01-01T00:00:00+00:00' 'Initial change'
+
+  run_collector "$fixture" \
+    --branch master \
+    --timezone Europe/Berlin \
+    --current-end '2026-03-30 00:00:00' > "$report"
+
+  "$ruby_command" -rjson - "$report" <<'RUBY'
+report = JSON.parse(File.read(ARGV.fetch(0)))
+
+def assert_equal(expected, actual, label)
+  return if expected == actual
+
+  abort "#{label}: expected #{expected.inspect}, got #{actual.inspect}"
+end
+
+assert_equal(
+  { 'start' => '2026-03-23T00:00:00+01:00', 'end' => '2026-03-30T00:00:00+02:00' },
+  report['window'],
+  'current window stays at local midnight across the spring-forward transition'
+)
+assert_equal(
+  { 'start' => '2026-03-16T00:00:00+01:00', 'end' => '2026-03-23T00:00:00+01:00' },
+  report['comparison_window'],
+  'comparison window stays at local midnight'
+)
+assert_equal(
+  ['2026-03-02T00:00:00+01:00', '2026-03-09T00:00:00+01:00'],
+  [report.dig('trend_context', 'windows', 3, 'start'), report.dig('trend_context', 'windows', 3, 'end')],
+  'oldest trend window stays at local midnight'
+)
+RUBY
+}
+
+# ISSUE-4: default complete-day windows must stay at local midnight across a
+# fall-back daylight-saving transition (Europe/Berlin, 2026-10-25).
+scenario_default_windows_across_dst_fall_back() {
+  local fixture report
+  fixture="$(new_fixture)"
+  report="$fixture/report.json"
+
+  init_repo "$fixture"
+  commit "$fixture" '2026-01-01T00:00:00+00:00' 'Initial change'
+
+  run_collector "$fixture" \
+    --branch master \
+    --timezone Europe/Berlin \
+    --current-end '2026-11-01 00:00:00' > "$report"
+
+  "$ruby_command" -rjson - "$report" <<'RUBY'
+report = JSON.parse(File.read(ARGV.fetch(0)))
+
+def assert_equal(expected, actual, label)
+  return if expected == actual
+
+  abort "#{label}: expected #{expected.inspect}, got #{actual.inspect}"
+end
+
+assert_equal(
+  { 'start' => '2026-10-25T00:00:00+02:00', 'end' => '2026-11-01T00:00:00+01:00' },
+  report['window'],
+  'current window stays at local midnight across the fall-back transition'
+)
+assert_equal(
+  { 'start' => '2026-10-18T00:00:00+02:00', 'end' => '2026-10-25T00:00:00+02:00' },
+  report['comparison_window'],
+  'comparison window stays at local midnight'
+)
+RUBY
+}
+
+# ISSUE-5: a failing `gh` during optional default-branch discovery (no
+# origin/HEAD, no --branch) must not abort local collection.
+scenario_branch_discovery_gh_failure() {
+  local fixture report
+  fixture="$(new_fixture)"
+  report="$fixture/report.json"
+
+  init_repo "$fixture"
+  commit "$fixture" '2026-07-01T00:00:00+00:00' 'Initial change'
+  git -C "$fixture" checkout -qb topic-branch
+  printf '#!/usr/bin/env ruby\nexit 1\n' > "$fixture/commands/gh"
+  chmod +x "$fixture/commands/gh"
+
+  run_collector "$fixture" --timezone UTC \
+    --current-start '2026-07-11 00:00:00 +00:00' \
+    --current-end '2026-07-18 00:00:00 +00:00' \
+    --previous-start '2026-07-04 00:00:00 +00:00' > "$report"
+
+  "$ruby_command" -rjson - "$report" <<'RUBY'
+report = JSON.parse(File.read(ARGV.fetch(0)))
+
+def assert_equal(expected, actual, label)
+  return if expected == actual
+
+  abort "#{label}: expected #{expected.inspect}, got #{actual.inspect}"
+end
+
+assert_equal 'topic-branch', report['branch'], 'branch falls back to the local branch when gh fails'
+assert_equal 'used', report.dig('sources', 'local', 'status'), 'local source status'
+assert_equal 'unavailable', report.dig('sources', 'github', 'status'), 'GitHub source status'
+RUBY
+}
+
+# ISSUE-6: Pod readiness must come from the Kubernetes Ready condition, not
+# from container statuses alone.
+scenario_kubernetes_pod_readiness() {
+  local fixture report
+  fixture="$(new_fixture)"
+  report="$fixture/report.json"
+
+  init_repo "$fixture"
+  commit "$fixture" '2026-07-01T00:00:00+00:00' 'Initial change'
+  touch "$fixture/.cd"
+  stub_kubectl "$fixture"
+
+  "$ruby_command" -rjson -e '
+    deployments = [{
+      metadata: { name: "app", namespace: "repo-health-fixture" },
+      spec: { replicas: 1, selector: { matchLabels: { app: "web" } },
+              template: { spec: { containers: [{ image: "web:1" }] } } },
+      status: {}
+    }]
+    puts JSON.generate(items: deployments)
+  ' > "$fixture/kubectl-deployments.json"
+
+  "$ruby_command" -rjson -e '
+    pods = [
+      # Pending, no container statuses: must not be ready.
+      { metadata: { name: "pod-pending", namespace: "repo-health-fixture" },
+        status: { phase: "Pending" } },
+      # All containers ready, but the Pod Ready condition is False: must not
+      # be ready.
+      { metadata: { name: "pod-not-ready", namespace: "repo-health-fixture" },
+        status: { phase: "Running", containerStatuses: [{ ready: true, restartCount: 0 }],
+                   conditions: [{ type: "Ready", status: "False" }] } },
+      # Pod Ready condition is True: must be ready.
+      { metadata: { name: "pod-ready", namespace: "repo-health-fixture" },
+        status: { phase: "Running", containerStatuses: [{ ready: true, restartCount: 0 }],
+                   conditions: [{ type: "Ready", status: "True" }] } }
+    ]
+    puts JSON.generate(items: pods)
+  ' > "$fixture/kubectl-pods.json"
+
+  run_collector "$fixture" --branch master --timezone UTC \
+    --current-start '2026-07-11 00:00:00 +00:00' \
+    --current-end '2026-07-18 00:00:00 +00:00' \
+    --previous-start '2026-07-04 00:00:00 +00:00' > "$report"
+
+  "$ruby_command" -rjson - "$report" <<'RUBY'
+report = JSON.parse(File.read(ARGV.fetch(0)))
+
+def assert_equal(expected, actual, label)
+  return if expected == actual
+
+  abort "#{label}: expected #{expected.inspect}, got #{actual.inspect}"
+end
+
+assert_equal 'used', report.dig('sources', 'kubernetes', 'status'), 'Kubernetes source status'
+assert_equal 3, report.dig('service_reliability', 'kubernetes', 'pod_count'), 'pod count'
+assert_equal 1, report.dig('service_reliability', 'kubernetes', 'ready_pod_count'),
+             'only the Pod with Ready=True is counted ready'
+RUBY
+}
+
+# REL-1: a single transient Net::HTTP failure during CircleCI collection must
+# be retried and recovered, not abort the whole source.
+scenario_circleci_transient_failure_recovers() {
+  local fixture report
+  fixture="$(new_fixture)"
+  report="$fixture/report.json"
+
+  init_repo "$fixture"
+  commit "$fixture" '2026-07-01T00:00:00+00:00' 'Initial change'
+  stub_circleci_config "$fixture"
+  stub_net_http_fault "$fixture"
+
+  run_collector_with_net_http_fault "$fixture" recover --branch master --timezone UTC \
+    --current-start '2026-07-18 00:00:00 +00:00' \
+    --current-end '2026-07-25 00:00:00 +00:00' \
+    --previous-start '2026-07-11 00:00:00 +00:00' > "$report"
+
+  "$ruby_command" -rjson - "$report" <<'RUBY'
+report = JSON.parse(File.read(ARGV.fetch(0)))
+
+status = report.dig('sources', 'circleci', 'status')
+abort "CircleCI source status: expected used, got #{status.inspect}" unless status == 'used'
+RUBY
+}
+
+# REL-1: a persistent Net::HTTP failure must still report the source
+# unavailable within a bounded number of attempts, not hang or crash.
+scenario_circleci_persistent_failure_reports_unavailable() {
+  local fixture report
+  fixture="$(new_fixture)"
+  report="$fixture/report.json"
+
+  init_repo "$fixture"
+  commit "$fixture" '2026-07-01T00:00:00+00:00' 'Initial change'
+  stub_circleci_config "$fixture"
+  stub_net_http_fault "$fixture"
+
+  run_collector_with_net_http_fault "$fixture" persistent --branch master --timezone UTC \
+    --current-start '2026-07-18 00:00:00 +00:00' \
+    --current-end '2026-07-25 00:00:00 +00:00' \
+    --previous-start '2026-07-11 00:00:00 +00:00' > "$report"
+
+  "$ruby_command" -rjson - "$report" <<'RUBY'
+report = JSON.parse(File.read(ARGV.fetch(0)))
+
+status = report.dig('sources', 'circleci', 'status')
+notes = report.dig('sources', 'circleci', 'notes')
+abort "CircleCI source status: expected unavailable, got #{status.inspect}" unless status == 'unavailable'
+abort "CircleCI notes: expected the SSL error, got #{notes.inspect}" unless notes.to_s.include?('SSL_read')
+RUBY
+
+  # Must match collect.rb's HTTP_RETRY_MAX_ATTEMPTS; a loose upper bound
+  # would also pass for a broken retry count.
+  attempts=$(cat "$fixture/net-http-fault-attempts")
+  if (( attempts != 3 )); then
+    echo "expected exactly 3 attempts (HTTP_RETRY_MAX_ATTEMPTS), got $attempts" >&2
+    exit 1
+  fi
+}
+
+all_scenarios=(
+  scenario_baseline scenario_github_pr_pagination scenario_github_pr_pagination_unavailable
+  scenario_github_pr_utc_boundary scenario_github_pr_utc_boundary_negative_offset
+  scenario_github_historical_open_prs scenario_default_windows_across_dst
+  scenario_default_windows_across_dst_fall_back scenario_branch_discovery_gh_failure
+  scenario_kubernetes_pod_readiness scenario_circleci_transient_failure_recovers
+  scenario_circleci_persistent_failure_reports_unavailable
+)
+
+# An optional scenario name argument runs only that scenario, for fast
+# feedback while developing; a bare invocation runs the full suite.
+scenarios=("${all_scenarios[@]}")
+[[ $# -gt 0 ]] && scenarios=("$@")
+
+for scenario in "${scenarios[@]}"; do
+  "$scenario"
+done


### PR DESCRIPTION
## What

- Reconstruct GitHub open-PR state as of the historical period boundary instead of the live queue, and report the stale-PR count as unavailable when pre-boundary activity evidence can't prove staleness.
- Fetch complete GitHub PR pages by escalating `--limit` instead of a fixed cap, and mark the GitHub source unavailable if completeness still can't be proven.
- Search GitHub merged/created/closed date ranges using UTC calendar dates so PRs merged or created near local midnight are no longer dropped at the timezone boundary.
- Keep default trend windows anchored to local midnight across daylight-saving transitions (spring-forward and fall-back) instead of drifting by fixed elapsed-second subtraction.
- Retry CircleCI/DigitalOcean/UptimeRobot HTTP calls up to three times on transient network errors (SSL, EOF, timeout, connection reset) before marking a source unavailable.
- Determine Kubernetes pod readiness from the Pod's `Ready` condition instead of container statuses alone, and fall back to the local branch when `gh repo view` fails during branch discovery.
- Document the stale-PR-unavailable behavior in `metrics.md` and rewrite the collector's executable test into independent per-scenario fixtures, one per fix.

## Why

- The live open-PR queue and fixed page/date-range assumptions produced historically wrong or silently truncated delivery-flow numbers for any repository with more than one page of PRs or activity near a timezone boundary, undermining the report's core trust signal.
- Elapsed-second window math drifted trend windows off local midnight across DST transitions, and transient network blips or partial Kubernetes readiness data could mask real reliability signals or abort collection outright.

## Testing

- `make lint` - passed
- `make scripts-lint` - passed
- `make skills-lint` - passed
- `./test/skills/repo-health` - passed; 12 scenarios cover pagination completeness and unprovable-completeness fallback, UTC boundary widening in both offset directions, historical open-PR reconstruction, DST spring-forward/fall-back window anchoring, `gh` failure fallback during branch discovery, Kubernetes `Ready`-condition readiness, and transient/persistent HTTP retry behavior.
- Manually traced each new code path (pagination escalation, historical open-PR reconstruction, stale-unavailable guard, DST day arithmetic, HTTP retry attempt count) against its test scenario's assertions; sub-agent review was not requested for this change, so this was a local challenge pass rather than independent review. No blocking findings.
