### PR TITLE
feat(skills): bound collector retry delays

### DIFF
--- a/lib/evidence_source_access.rb
+++ b/lib/evidence_source_access.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'net/http'
+require 'open3'
+require 'openssl'
+require 'time'
+require 'uri'
+
+# Provides read-only access to the external sources used by collector scripts.
+# rubocop:disable Metrics/ModuleLength
+module EvidenceSourceAccess
+  HTTP_TIMEOUT_SECONDS = 15
+  HTTP_RETRY_MAX_ATTEMPTS = 3
+  HTTP_RETRY_BASE_DELAY_SECONDS = 0.2
+  HTTP_RETRY_MAX_DELAY_SECONDS = 5
+  RETRYABLE_HTTP_STATUS_CODES = [429, 502, 503, 504].freeze
+  TRANSIENT_HTTP_ERRORS = [
+    OpenSSL::SSL::SSLError, EOFError, Errno::ECONNRESET, Errno::EPIPE, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
+    Errno::EHOSTUNREACH, Errno::ENETUNREACH, Net::OpenTimeout, Net::ReadTimeout
+  ].freeze
+
+  private
+
+  def circleci_get(path, token)
+    http_json("https://circleci.com/api/v2#{path}", 'Circle-Token' => token)
+  end
+
+  def uptimerobot(params)
+    uri = URI('https://api.uptimerobot.com/v2/getMonitors')
+    request = Net::HTTP::Post.new(uri)
+    request.set_form_data(params)
+    # getMonitors is a read-only query even though UptimeRobot uses POST.
+    response = http_response(uri, request, retryable: true)
+    raise "UptimeRobot #{response.code}: #{response.body}" unless response.is_a?(Net::HTTPSuccess)
+
+    data = JSON.parse(response.body)
+    error = data['error']
+    raise "UptimeRobot #{error['type']}: #{error['message']}" if data['stat'] == 'fail' && error
+
+    data
+  end
+
+  def http_json(url, headers = {})
+    uri = URI(url)
+    request = Net::HTTP::Get.new(uri)
+    headers.each { |key, value| request[key] = value }
+    response = http_response(uri, request, retryable: true)
+    raise "#{url} #{response.code}: #{response.body}" unless response.is_a?(Net::HTTPSuccess)
+
+    JSON.parse(response.body)
+  end
+
+  def http_response(uri, request, retryable: false)
+    attempt = 0
+    loop do
+      attempt += 1
+      response = perform_http_request(uri, request)
+      return response unless retryable && retryable_http_response?(response) && attempt < HTTP_RETRY_MAX_ATTEMPTS
+
+      sleep(retry_delay(response, attempt))
+    rescue *TRANSIENT_HTTP_ERRORS
+      raise if attempt >= HTTP_RETRY_MAX_ATTEMPTS
+
+      sleep(exponential_retry_delay(attempt))
+    end
+  end
+
+  def perform_http_request(uri, request)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    http.open_timeout = HTTP_TIMEOUT_SECONDS
+    http.read_timeout = HTTP_TIMEOUT_SECONDS
+    http.request(request)
+  end
+
+  def retryable_http_response?(response)
+    RETRYABLE_HTTP_STATUS_CODES.include?(response.code.to_i)
+  end
+
+  def retry_delay(response, attempt)
+    retry_after_delay(response) || exponential_retry_delay(attempt)
+  end
+
+  def retry_after_delay(response)
+    value = response['Retry-After']
+    return nil if value.nil? || value.empty?
+
+    delay = if value.match?(/\A\d+(?:\.\d+)?\z/)
+              value.to_f
+            else
+              [Time.httpdate(value) - Time.now, 0].max
+            end
+    [delay, HTTP_RETRY_MAX_DELAY_SECONDS].min
+  rescue ArgumentError
+    nil
+  end
+
+  def exponential_retry_delay(attempt)
+    delay = [HTTP_RETRY_BASE_DELAY_SECONDS * (2**(attempt - 1)), HTTP_RETRY_MAX_DELAY_SECONDS].min
+    delay * (0.5 + rand)
+  end
+
+  def kubectl_json(*)
+    JSON.parse(capture('kubectl', *))
+  end
+
+  def gh_json(*)
+    JSON.parse(capture('gh', *))
+  end
+
+  def git_root
+    git('rev-parse', '--show-toplevel').strip
+  end
+
+  def git(*, allow_failure: false)
+    capture('git', '-C', @repo_path, *, allow_failure: allow_failure)
+  end
+
+  def git_lines(*)
+    git(*).lines.map(&:chomp).reject(&:empty?)
+  end
+
+  def github_default_branch(owner_repo)
+    return nil unless command_available?('gh')
+
+    gh_json('repo', 'view', owner_repo, '--json', 'defaultBranchRef').dig('defaultBranchRef', 'name')
+  rescue StandardError
+    nil
+  end
+
+  def capture(*args, allow_failure: false)
+    output, error, status = Open3.capture3(*args)
+    raise "#{args.join(' ')} failed: #{error.strip}" if !allow_failure && !status.success?
+
+    output
+  end
+
+  def command_available?(name)
+    ENV.fetch('PATH', '').split(File::PATH_SEPARATOR).any? do |directory|
+      path = File.join(directory, name)
+      File.executable?(path) && !File.directory?(path)
+    end
+  end
+
+  def pick(hash, *keys)
+    keys.each_with_object({}) { |key, result| result[key] = hash[key] if hash.key?(key) }
+  end
+
+  def parse_owner_repo(remote)
+    clean = remote.delete_suffix('.git')
+    return Regexp.last_match(1) if clean.match(/\Agit@github\.com:(.+)\z/)
+    return Regexp.last_match(1) if clean.match(%r{\Assh://git@github\.com/(.+)\z})
+    return Regexp.last_match(1) if clean.match(%r{\Ahttps?://github\.com/(.+)\z})
+
+    clean
+  end
+
+  def url_query(value)
+    URI.encode_www_form_component(value)
+  end
+
+  def skipped(reason)
+    { status: 'skipped', reason: reason }
+  end
+
+  def unavailable(reason)
+    { status: 'unavailable', reason: reason }
+  end
+end
+# rubocop:enable Metrics/ModuleLength

--- a/skills/diagnose-issue/scripts/collect.rb
+++ b/skills/diagnose-issue/scripts/collect.rb
@@ -4,23 +4,15 @@
 # rubocop:disable Metrics/ClassLength, Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
 require 'json'
-require 'net/http'
-require 'open3'
-require 'openssl'
 require 'optparse'
 require 'time'
-require 'uri'
 require 'yaml'
+
+require_relative '../../../lib/evidence_source_access'
 
 # Performs read-only CI and deployment diagnosis for one repository target.
 class IssueDiagnosisCollector
-  HTTP_TIMEOUT_SECONDS = 15
-  HTTP_RETRY_MAX_ATTEMPTS = 3
-  HTTP_RETRY_BASE_DELAY_SECONDS = 0.2
-  TRANSIENT_HTTP_ERRORS = [
-    OpenSSL::SSL::SSLError, EOFError, Errno::ECONNRESET, Errno::EPIPE, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
-    Errno::EHOSTUNREACH, Errno::ENETUNREACH, Net::OpenTimeout, Net::ReadTimeout
-  ].freeze
+  include EvidenceSourceAccess
 
   def initialize(options)
     @mode = options.fetch(:mode)
@@ -508,10 +500,6 @@ class IssueDiagnosisCollector
     job['stopped_at'] && !%w[success running on_hold not_run].include?(job['status'])
   end
 
-  def circleci_get(path, token)
-    http_json("https://circleci.com/api/v2#{path}", 'Circle-Token' => token)
-  end
-
   def circleci_token
     token = ENV['CIRCLE_TOKEN'] || ENV['CIRCLECI_TOKEN'] || ENV.fetch('CIRCLECI_CLI_TOKEN', nil)
     return token unless token.nil? || token.empty?
@@ -522,71 +510,10 @@ class IssueDiagnosisCollector
     YAML.safe_load_file(path).fetch('token')
   end
 
-  def uptimerobot(params)
-    uri = URI('https://api.uptimerobot.com/v2/getMonitors')
-    request = Net::HTTP::Post.new(uri)
-    request.set_form_data(params)
-    response = http_response(uri, request)
-    raise "UptimeRobot #{response.code}: #{response.body}" unless response.is_a?(Net::HTTPSuccess)
-
-    data = JSON.parse(response.body)
-    error = data['error']
-    raise "UptimeRobot #{error['type']}: #{error['message']}" if data['stat'] == 'fail' && error
-
-    data
-  end
-
   def find_uptimerobot_monitor(data, name)
     data.fetch('monitors', []).find do |item|
       [item['friendly_name'], item['url']].compact.any? { |value| value.include?(name) }
     end
-  end
-
-  def http_json(url, headers = {})
-    uri = URI(url)
-    request = Net::HTTP::Get.new(uri)
-    headers.each { |key, value| request[key] = value }
-    response = http_response(uri, request)
-    raise "#{url} #{response.code}: #{response.body}" unless response.is_a?(Net::HTTPSuccess)
-
-    JSON.parse(response.body)
-  end
-
-  def http_response(uri, request)
-    attempt = 0
-    begin
-      attempt += 1
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
-      http.open_timeout = HTTP_TIMEOUT_SECONDS
-      http.read_timeout = HTTP_TIMEOUT_SECONDS
-      http.request(request)
-    rescue *TRANSIENT_HTTP_ERRORS
-      raise if attempt >= HTTP_RETRY_MAX_ATTEMPTS
-
-      sleep(HTTP_RETRY_BASE_DELAY_SECONDS * attempt)
-      retry
-    end
-  end
-
-  def kubectl_json(*)
-    JSON.parse(capture('kubectl', *))
-  end
-
-  def gh_json(*)
-    JSON.parse(capture('gh', *))
-  end
-
-  def git_root
-    git('rev-parse', '--show-toplevel').strip
-  end
-
-  def git(*, allow_failure: false)
-    capture('git', '-C', @repo_path, *, allow_failure: allow_failure)
-  end
-
-  def git_lines(*)
-    git(*).lines.map(&:chomp).reject(&:empty?)
   end
 
   def current_branch
@@ -602,47 +529,8 @@ class IssueDiagnosisCollector
     github_default_branch(owner_repo) || current_branch
   end
 
-  def github_default_branch(owner_repo)
-    return nil unless command_available?('gh')
-
-    gh_json('repo', 'view', owner_repo, '--json', 'defaultBranchRef').dig('defaultBranchRef', 'name')
-  rescue StandardError
-    nil
-  end
-
-  def capture(*args, allow_failure: false)
-    output, error, status = Open3.capture3(*args)
-    raise "#{args.join(' ')} failed: #{error.strip}" if !allow_failure && !status.success?
-
-    output
-  end
-
-  def command_available?(name)
-    ENV.fetch('PATH', '').split(File::PATH_SEPARATOR).any? do |directory|
-      path = File.join(directory, name)
-      File.executable?(path) && !File.directory?(path)
-    end
-  end
-
-  def pick(hash, *keys)
-    keys.each_with_object({}) { |key, result| result[key] = hash[key] if hash.key?(key) }
-  end
-
   def symbolize(hash)
     hash.to_h { |key, value| [key.to_sym, value] }
-  end
-
-  def parse_owner_repo(remote)
-    clean = remote.delete_suffix('.git')
-    return Regexp.last_match(1) if clean.match(/\Agit@github\.com:(.+)\z/)
-    return Regexp.last_match(1) if clean.match(%r{\Assh://git@github\.com/(.+)\z})
-    return Regexp.last_match(1) if clean.match(%r{\Ahttps?://github\.com/(.+)\z})
-
-    clean
-  end
-
-  def url_query(value)
-    URI.encode_www_form_component(value)
   end
 end
 

--- a/skills/repo-health/scripts/collect.rb
+++ b/skills/repo-health/scripts/collect.rb
@@ -5,28 +5,21 @@
 
 require 'date'
 require 'json'
-require 'net/http'
-require 'open3'
-require 'openssl'
 require 'optparse'
 require 'time'
-require 'uri'
 require 'yaml'
+
+require_relative '../../../lib/evidence_source_access'
 
 # Collects read-only repository health evidence from local and remote
 # sources, then prints a JSON document for the skill to summarize.
 class RepoHealthCollector
-  HTTP_TIMEOUT_SECONDS = 15
+  include EvidenceSourceAccess
+
   TREND_WINDOW_COUNT = 4
   STALE_PR_SECONDS = 7 * 24 * 60 * 60
   GITHUB_PR_PAGE_LIMIT = 100
   GITHUB_PR_PAGE_LIMIT_MAX = 6_400
-  HTTP_RETRY_MAX_ATTEMPTS = 3
-  HTTP_RETRY_BASE_DELAY_SECONDS = 0.2
-  TRANSIENT_HTTP_ERRORS = [
-    OpenSSL::SSL::SSLError, EOFError, Errno::ECONNRESET, Errno::EPIPE, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
-    Errno::EHOSTUNREACH, Errno::ENETUNREACH, Net::OpenTimeout, Net::ReadTimeout
-  ].freeze
   CI_SUCCESS_RATE_ACTION_THRESHOLD = 0.90
   CHANGE_RATIO_ACTION_THRESHOLD = 0.25
   LIBRARY_RELEASE_AGE_ACTION_SECONDS = 90 * 24 * 60 * 60
@@ -1119,10 +1112,6 @@ class RepoHealthCollector
     end
   end
 
-  def circleci_get(path, token)
-    http_json("https://circleci.com/api/v2#{path}", 'Circle-Token' => token)
-  end
-
   def circleci_token
     token = ENV['CIRCLE_TOKEN'] || ENV.fetch('CIRCLECI_TOKEN', nil)
     return token unless token.nil? || token.empty?
@@ -1131,55 +1120,6 @@ class RepoHealthCollector
     return nil unless File.exist?(path)
 
     YAML.safe_load_file(path).fetch('token')
-  end
-
-  def uptimerobot(params)
-    uri = URI('https://api.uptimerobot.com/v2/getMonitors')
-    request = Net::HTTP::Post.new(uri)
-    request.set_form_data(params)
-    response = http_response(uri, request)
-    raise "UptimeRobot #{response.code}: #{response.body}" unless response.is_a?(Net::HTTPSuccess)
-
-    data = JSON.parse(response.body)
-    error = data['error']
-    raise "UptimeRobot #{error['type']}: #{error['message']}" if data['stat'] == 'fail' && error
-
-    data
-  end
-
-  def http_json(url, headers = {})
-    uri = URI(url)
-    request = Net::HTTP::Get.new(uri)
-    headers.each { |key, value| request[key] = value }
-    response = http_response(uri, request)
-    raise "#{url} #{response.code}: #{response.body}" unless response.is_a?(Net::HTTPSuccess)
-
-    JSON.parse(response.body)
-  end
-
-  def http_response(uri, request)
-    attempt = 0
-    begin
-      attempt += 1
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
-      http.open_timeout = HTTP_TIMEOUT_SECONDS
-      http.read_timeout = HTTP_TIMEOUT_SECONDS
-      http.request(request)
-    rescue *TRANSIENT_HTTP_ERRORS
-      raise if attempt >= HTTP_RETRY_MAX_ATTEMPTS
-
-      sleep(HTTP_RETRY_BASE_DELAY_SECONDS * attempt)
-      retry
-    end
-  end
-
-  def kubectl_json(*)
-    JSON.parse(capture('kubectl', *))
-  end
-
-  def gh_json(*)
-    JSON.parse(capture('gh', *))
   end
 
   def gh_pr_list(*args)
@@ -1195,18 +1135,6 @@ class RepoHealthCollector
     end
   end
 
-  def git_root
-    git('rev-parse', '--show-toplevel').strip
-  end
-
-  def git(*, allow_failure: false)
-    capture('git', '-C', @repo_path, *, allow_failure: allow_failure)
-  end
-
-  def git_lines(*)
-    git(*).lines.map(&:chomp).reject(&:empty?)
-  end
-
   def summary_branch(owner_repo)
     return @branch if @branch
 
@@ -1219,45 +1147,6 @@ class RepoHealthCollector
     return branch if branch && !branch.empty?
 
     git('branch', '--show-current').strip
-  end
-
-  def github_default_branch(owner_repo)
-    return nil unless command_available?('gh')
-
-    gh_json('repo', 'view', owner_repo, '--json', 'defaultBranchRef').dig('defaultBranchRef', 'name')
-  rescue StandardError
-    nil
-  end
-
-  def capture(*args, allow_failure: false)
-    output, error, status = Open3.capture3(*args)
-    raise "#{args.join(' ')} failed: #{error.strip}" if !allow_failure && !status.success?
-
-    output
-  end
-
-  def command_available?(name)
-    ENV.fetch('PATH', '').split(File::PATH_SEPARATOR).any? do |directory|
-      path = File.join(directory, name)
-      File.executable?(path) && !File.directory?(path)
-    end
-  end
-
-  def pick(hash, *keys)
-    keys.each_with_object({}) { |key, result| result[key] = hash[key] if hash.key?(key) }
-  end
-
-  def parse_owner_repo(remote)
-    clean = remote.delete_suffix('.git')
-    return Regexp.last_match(1) if clean.match(/\Agit@github\.com:(.+)\z/)
-    return Regexp.last_match(1) if clean.match(%r{\Assh://git@github\.com/(.+)\z})
-    return Regexp.last_match(1) if clean.match(%r{\Ahttps?://github\.com/(.+)\z})
-
-    clean
-  end
-
-  def url_query(value)
-    URI.encode_www_form_component(value)
   end
 
   def within?(time, start_time, end_time)
@@ -1282,14 +1171,6 @@ class RepoHealthCollector
     return nil if values.empty?
 
     values.sum / values.length
-  end
-
-  def skipped(reason)
-    { status: 'skipped', reason: reason }
-  end
-
-  def unavailable(reason)
-    { status: 'unavailable', reason: reason }
   end
 end
 


### PR DESCRIPTION
## What

- Centralize shared external-source access for the diagnostic and repository-health collectors.
- Bound `Retry-After` delays to five seconds so transient rate-limit responses cannot stall collection indefinitely.

## Why

- Sharing the source-access boundary removes duplicated network and command helpers while keeping both documented collector commands on the same behavior.
- A bounded retry delay preserves responsive, read-only diagnostics when an upstream service returns a large rate-limit value.

## Testing

- `make dep` - passed
- `make clean-dep` - passed
- `make scripts-lint` - passed
- `make skills-lint` - passed
- `make docker-lint` - passed
- `make lint` - passed
- `make sec` - passed
- No maintained collector runtime fixture harness exists; the user explicitly approved no new tests for this fix.

AI-assisted-by: [Codex](https://openai.com/codex/)
