### PR TITLE
feat(skills): collect independent evidence concurrently

### DIFF
--- a/lib/skills.rb
+++ b/lib/skills.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'date'
+require 'json'
+require 'net/http'
+require 'optparse'
+require 'open3'
+require 'openssl'
+require 'time'
+require 'uri'
+require 'yaml'
+
+require 'skills/evidence_sources'

--- a/lib/skills/evidence_sources.rb
+++ b/lib/skills/evidence_sources.rb
@@ -1,15 +1,9 @@
 # frozen_string_literal: true
 
-require 'json'
-require 'net/http'
-require 'open3'
-require 'openssl'
-require 'time'
-require 'uri'
-
 # Provides read-only access to the external sources used by collector scripts.
 # rubocop:disable Metrics/ModuleLength
-module EvidenceSourceAccess
+module EvidenceSources
+  MAX_CONCURRENT_SOURCES = 4
   HTTP_TIMEOUT_SECONDS = 15
   HTTP_RETRY_MAX_ATTEMPTS = 3
   HTTP_RETRY_BASE_DELAY_SECONDS = 0.2
@@ -21,6 +15,34 @@ module EvidenceSourceAccess
   ].freeze
 
   private
+
+  # Runs independent source collectors with bounded concurrency while preserving result order.
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def collect_sources(sources)
+    queue = Queue.new
+    sources.each_with_index { |source, index| queue << [index, *source] }
+
+    workers = Array.new([sources.length, MAX_CONCURRENT_SOURCES].min) do
+      Thread.new do
+        results = []
+        loop do
+          source = begin
+            queue.pop(true)
+          rescue ThreadError
+            nil
+          end
+          break unless source
+
+          index, name, collect = source
+          results << [index, name, collect.call]
+        end
+        results
+      end
+    end
+
+    workers.flat_map(&:value).sort_by(&:first).to_h { |_, name, result| [name, result] }
+  end
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   def circleci_get(path, token)
     http_json("https://circleci.com/api/v2#{path}", 'Circle-Token' => token)

--- a/skills/diagnose-issue/scripts/collect.rb
+++ b/skills/diagnose-issue/scripts/collect.rb
@@ -3,16 +3,14 @@
 
 # rubocop:disable Metrics/ClassLength, Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
-require 'json'
-require 'optparse'
-require 'time'
-require 'yaml'
+lib = File.expand_path('../../../lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require_relative '../../../lib/evidence_source_access'
+require 'skills'
 
 # Performs read-only CI and deployment diagnosis for one repository target.
 class IssueDiagnosisCollector
-  include EvidenceSourceAccess
+  include EvidenceSources
 
   def initialize(options)
     @mode = options.fetch(:mode)
@@ -33,10 +31,12 @@ class IssueDiagnosisCollector
              when 'deployment'
                diagnose_deployment(root, owner_repo)
              else
-               base_result(root, owner_repo).merge(findings: [
-                                                     finding('error', 'mode', "Unsupported mode: #{@mode}.",
-                                                             'Use --mode ci or --mode deployment.')
-                                                   ])
+               diagnosis_metadata(root, owner_repo).merge(
+                 findings: [
+                   finding('error', 'mode', "Unsupported mode: #{@mode}.",
+                           'Use --mode ci or --mode deployment.')
+                 ]
+               )
              end
 
     JSON.pretty_generate(result)
@@ -52,7 +52,7 @@ class IssueDiagnosisCollector
     findings = ci_findings(target_branch, circleci)
     current_pull_request = github_current_pull_request(owner_repo, target_branch)
 
-    base_result(root, owner_repo).merge(
+    diagnosis_metadata(root, owner_repo).merge(
       target: { type: @pipeline ? 'pipeline' : @target, branch: target_branch, pipeline: @pipeline },
       sources: source_summary(github: current_pull_request, circleci: circleci),
       findings: findings,
@@ -63,28 +63,47 @@ class IssueDiagnosisCollector
   def diagnose_deployment(root, owner_repo)
     service = File.exist?(File.join(root, '.cd'))
     version = @version || latest_version&.fetch(:tag, nil)
-    circleci = service ? collect_circleci_deployment(owner_repo, version) : skipped('not a service repo')
-    digitalocean = service ? collect_digitalocean : skipped('not a service repo')
-    kubernetes = service ? collect_kubernetes(owner_repo.split('/').last) : skipped('not a service repo')
-    uptimerobot = service ? collect_uptimerobot(owner_repo.split('/').last) : skipped('not a service repo')
+    evidence = collect_sources([
+                                 [:circleci, lambda do
+                                   if service
+                                     collect_circleci_deployment(owner_repo, version)
+                                   else
+                                     skipped('not a service repo')
+                                   end
+                                 end],
+                                 [:digitalocean, lambda do
+                                   service ? collect_digitalocean : skipped('not a service repo')
+                                 end],
+                                 [:kubernetes, lambda do
+                                   if service
+                                     collect_kubernetes(owner_repo.split('/').last)
+                                   else
+                                     skipped('not a service repo')
+                                   end
+                                 end],
+                                 [:uptimerobot, lambda do
+                                   if service
+                                     collect_uptimerobot(owner_repo.split('/').last)
+                                   else
+                                     skipped('not a service repo')
+                                   end
+                                 end]
+                               ])
+    circleci = evidence.fetch(:circleci)
+    kubernetes = evidence.fetch(:kubernetes)
+    uptimerobot = evidence.fetch(:uptimerobot)
 
     findings = deployment_findings(service, version, circleci, kubernetes, uptimerobot)
 
-    base_result(root, owner_repo).merge(
+    diagnosis_metadata(root, owner_repo).merge(
       target: { type: @version ? 'version' : @target, version: version, latest_version: latest_version },
-      sources: source_summary(circleci: circleci, digitalocean: digitalocean, kubernetes: kubernetes,
-                              uptimerobot: uptimerobot),
+      sources: source_summary(evidence),
       findings: findings,
-      evidence: {
-        circleci: circleci,
-        digitalocean: digitalocean,
-        kubernetes: kubernetes,
-        uptimerobot: uptimerobot
-      }
+      evidence: evidence
     )
   end
 
-  def base_result(root, owner_repo)
+  def diagnosis_metadata(root, owner_repo)
     {
       repository: owner_repo,
       repo_path: root,

--- a/skills/repo-health/scripts/collect.rb
+++ b/skills/repo-health/scripts/collect.rb
@@ -3,18 +3,15 @@
 
 # rubocop:disable Metrics/ClassLength, Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
-require 'date'
-require 'json'
-require 'optparse'
-require 'time'
-require 'yaml'
+lib = File.expand_path('../../../lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require_relative '../../../lib/evidence_source_access'
+require 'skills'
 
 # Collects read-only repository health evidence from local and remote
 # sources, then prints a JSON document for the skill to summarize.
 class RepoHealthCollector
-  include EvidenceSourceAccess
+  include EvidenceSources
 
   TREND_WINDOW_COUNT = 4
   STALE_PR_SECONDS = 7 * 24 * 60 * 60
@@ -43,6 +40,28 @@ class RepoHealthCollector
     branch = summary_branch(owner_repo)
     mode = File.exist?(File.join(root, '.cd')) ? 'service' : 'library'
     period = window_seconds <= 24 * 60 * 60 ? 'daily' : 'weekly'
+    sources = collect_sources([
+                                [:local, -> { collect_local(root) }],
+                                [:github, -> { collect_github(owner_repo) }],
+                                [:circleci, -> { collect_circleci(owner_repo, branch, mode, root) }],
+                                [:digitalocean, lambda do
+                                  mode == 'service' ? collect_digitalocean : skipped('not a service repo')
+                                end],
+                                [:kubernetes, lambda do
+                                  if mode == 'service'
+                                    collect_kubernetes(owner_repo.split('/').last)
+                                  else
+                                    skipped('not a service repo')
+                                  end
+                                end],
+                                [:uptimerobot, lambda do
+                                  if mode == 'service'
+                                    collect_uptimerobot(owner_repo.split('/').last)
+                                  else
+                                    skipped('not a service repo')
+                                  end
+                                end]
+                              ])
 
     result = {
       repository: owner_repo,
@@ -52,12 +71,12 @@ class RepoHealthCollector
       timezone: @timezone,
       window: window_hash(@current_start, @current_end),
       comparison_window: window_hash(@previous_start, @previous_end),
-      local: collect_local(root),
-      github: collect_github(owner_repo),
-      circleci: collect_circleci(owner_repo, branch, mode, root),
-      digitalocean: mode == 'service' ? collect_digitalocean : skipped('not a service repo'),
-      kubernetes: mode == 'service' ? collect_kubernetes(owner_repo.split('/').last) : skipped('not a service repo'),
-      uptimerobot: mode == 'service' ? collect_uptimerobot(owner_repo.split('/').last) : skipped('not a service repo')
+      local: sources.fetch(:local),
+      github: sources.fetch(:github),
+      circleci: sources.fetch(:circleci),
+      digitalocean: sources.fetch(:digitalocean),
+      kubernetes: sources.fetch(:kubernetes),
+      uptimerobot: sources.fetch(:uptimerobot)
     }
 
     JSON.pretty_generate(summary_result(result))


### PR DESCRIPTION
## What

- Collect diagnostic and health evidence sources through a shared, bounded-concurrency library while preserving the collectors' command interfaces and output shapes.

## Why

- Independent remote evidence sources no longer wait on one another, reducing the time needed to produce diagnostic and repository-health summaries.

## Testing

- `make lint` - passed
- `make scripts-lint skills-lint docker-lint` - passed
- `make sec` - passed
- `ruby skills/diagnose-issue/scripts/collect.rb --help` and `ruby skills/repo-health/scripts/collect.rb --help` - passed
- `ruby skills/repo-health/scripts/collect.rb --repo . --timezone Europe/Berlin` - passed; exercised concurrent local, GitHub, and CircleCI collection.
- No maintained fixture harness covers source failures or service-only source collection; those paths remain CI/manual coverage gaps.

AI-assisted-by: [Codex](https://openai.com/codex/)
