### PR TITLE
feat(skills): bound external collection and sanitize failures

### DIFF
--- a/lib/skills.rb
+++ b/lib/skills.rb
@@ -7,6 +7,7 @@ require 'optparse'
 require 'open3'
 require 'openssl'
 require 'time'
+require 'timeout'
 require 'uri'
 require 'yaml'
 

--- a/lib/skills/evidence_sources.rb
+++ b/lib/skills/evidence_sources.rb
@@ -4,6 +4,9 @@
 # rubocop:disable Metrics/ModuleLength
 module EvidenceSources
   MAX_CONCURRENT_SOURCES = 4
+  SOURCE_TIMEOUT_SECONDS = 30
+  CIRCLECI_SOURCE_TIMEOUT_SECONDS = 180
+  GITHUB_SOURCE_TIMEOUT_SECONDS = 180
   HTTP_TIMEOUT_SECONDS = 15
   HTTP_RETRY_MAX_ATTEMPTS = 3
   HTTP_RETRY_BASE_DELAY_SECONDS = 0.2
@@ -13,6 +16,10 @@ module EvidenceSources
     OpenSSL::SSL::SSLError, EOFError, Errno::ECONNRESET, Errno::EPIPE, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
     Errno::EHOSTUNREACH, Errno::ENETUNREACH, Net::OpenTimeout, Net::ReadTimeout
   ].freeze
+
+  # Marks a collector deadline with a fixed, safe message for report output.
+  class SourceTimeout < Timeout::Error
+  end
 
   private
 
@@ -34,7 +41,7 @@ module EvidenceSources
           break unless source
 
           index, name, collect = source
-          results << [index, name, collect.call]
+          results << [index, name, collect_source(name, collect)]
         end
         results
       end
@@ -43,6 +50,35 @@ module EvidenceSources
     workers.flat_map(&:value).sort_by(&:first).to_h { |_, name, result| [name, result] }
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+  def collect_source(name, collect)
+    timeout_seconds = source_timeout_seconds(name)
+    Timeout.timeout(timeout_seconds, SourceTimeout, timeout_reason(timeout_seconds)) { collect.call }
+  rescue StandardError => e
+    unavailable_for_error(e)
+  end
+
+  def source_timeout_seconds(name = nil)
+    return CIRCLECI_SOURCE_TIMEOUT_SECONDS if name == :circleci
+    return GITHUB_SOURCE_TIMEOUT_SECONDS if name == :github
+
+    SOURCE_TIMEOUT_SECONDS
+  end
+
+  def unavailable_for_error(error)
+    unavailable(source_error_reason(error))
+  end
+
+  def source_error_reason(error)
+    return error.message if error.is_a?(SourceTimeout)
+    return timeout_reason(source_timeout_seconds) if error.is_a?(Timeout::Error)
+
+    "source collection failed (#{error.class})"
+  end
+
+  def timeout_reason(seconds)
+    "source collection timed out after #{seconds} seconds"
+  end
 
   def circleci_get(path, token)
     http_json("https://circleci.com/api/v2#{path}", 'Circle-Token' => token)

--- a/skills/diagnose-issue/scripts/collect.rb
+++ b/skills/diagnose-issue/scripts/collect.rb
@@ -125,7 +125,7 @@ class IssueDiagnosisCollector
 
     collect_circleci_pipeline(owner_repo, pipeline, token)
   rescue StandardError => e
-    unavailable(e.message)
+    unavailable_for_error(e)
   end
 
   def collect_circleci_deployment(owner_repo, version)
@@ -142,7 +142,7 @@ class IssueDiagnosisCollector
 
     collect_circleci_pipeline(owner_repo, pipeline, token).merge(version: version, revision: revision)
   rescue StandardError => e
-    unavailable(e.message)
+    unavailable_for_error(e)
   end
 
   def collect_circleci_pipeline(owner_repo, pipeline, token)
@@ -329,7 +329,7 @@ class IssueDiagnosisCollector
       'executor' => details['executor']
     )
   rescue StandardError => e
-    enriched.merge('details_error' => e.message)
+    enriched.merge('details_error' => source_error_reason(e))
   end
 
   def enrich_circleci_job_url(owner_repo, job)
@@ -347,7 +347,7 @@ class IssueDiagnosisCollector
       pick(cluster, 'name', 'region', 'version', 'status', 'created_at')
     end }
   rescue StandardError => e
-    unavailable(e.message)
+    unavailable_for_error(e)
   end
 
   def collect_kubernetes(name)
@@ -366,7 +366,7 @@ class IssueDiagnosisCollector
       pods: pods.map { |pod| pod_summary(pod) }
     }
   rescue StandardError => e
-    unavailable(e.message)
+    unavailable_for_error(e)
   end
 
   def deployment_pods(deployment)
@@ -398,7 +398,7 @@ class IssueDiagnosisCollector
     { status: 'used', monitor: symbolize(pick(monitor, 'id', 'friendly_name', 'url', 'status')),
       logs: monitor.fetch('logs', []) }
   rescue StandardError => e
-    unavailable(e.message)
+    unavailable_for_error(e)
   end
 
   def deployment_summary(deployment)
@@ -460,7 +460,7 @@ class IssueDiagnosisCollector
       '--json', 'number,title,url,headRefName,baseRefName,isDraft,mergeStateStatus,reviewDecision'
     ).first
   rescue StandardError => e
-    unavailable(e.message)
+    unavailable_for_error(e)
   end
 
   def latest_version

--- a/skills/repo-health/scripts/collect.rb
+++ b/skills/repo-health/scripts/collect.rb
@@ -225,8 +225,8 @@ class RepoHealthCollector
       workflows: data.fetch('workflows', {}).keys.reject { |key| key == 'version' },
       jobs: data.fetch('jobs', {}).keys
     }
-  rescue Psych::SyntaxError => e
-    { present: true, error: e.message }
+  rescue Psych::SyntaxError
+    { present: true, error: 'invalid CircleCI configuration' }
   end
 
   def collect_github(owner_repo)
@@ -245,7 +245,7 @@ class RepoHealthCollector
       stale_prs: open_state.fetch(:stale)
     }
   rescue StandardError => e
-    unavailable(e.message)
+    unavailable_for_error(e)
   end
 
   # Reconstructs which PRs were open at @current_end from complete creation
@@ -344,7 +344,7 @@ class RepoHealthCollector
       jobs_collected: jobs.length
     }
   rescue StandardError => e
-    unavailable(e.message)
+    unavailable_for_error(e)
   end
 
   def circleci_period(workflows, jobs, start_time, end_time)
@@ -408,7 +408,7 @@ class RepoHealthCollector
       pick(cluster, 'name', 'region', 'version', 'status', 'created_at')
     end }
   rescue StandardError => e
-    unavailable(e.message)
+    unavailable_for_error(e)
   end
 
   def collect_kubernetes(name)
@@ -435,7 +435,7 @@ class RepoHealthCollector
       pods: pods.map { |pod| pod_summary(pod) }
     }
   rescue StandardError => e
-    unavailable(e.message)
+    unavailable_for_error(e)
   end
 
   def collect_uptimerobot(name)
@@ -482,7 +482,7 @@ class RepoHealthCollector
       response_time_average_ms_by_period: response_averages
     }
   rescue StandardError => e
-    unavailable(e.message)
+    unavailable_for_error(e)
   end
 
   def deployment_summary(deployment)


### PR DESCRIPTION
## What

- Bound concurrent external evidence collection by source and return safe unavailable results instead of propagating raw collector failures.
- Preserve the diagnose-issue and repo-health command interfaces and report shapes while making timeout and parsing errors stable for users.

## Why

- A stalled remote source should not indefinitely delay a diagnostic or repository-health report, and raw third-party failures can expose noisy or sensitive implementation details.

## Testing

- `make scripts-lint` - passed
- `make skills-lint` - passed
- `make docker-lint` - passed
- `make lint` - passed
- `make sec` - passed
- `ruby skills/diagnose-issue/scripts/collect.rb --help` and `ruby skills/repo-health/scripts/collect.rb --help` - passed
- `ruby skills/repo-health/scripts/collect.rb --repo . --timezone Europe/Berlin` - passed; collected local, GitHub, and CircleCI evidence.
- `ruby skills/diagnose-issue/scripts/collect.rb --mode ci --repo .` - passed; retained its unavailable-CircleCI result shape when the branch had no pipeline.
- No deterministic timeout or source-failure fixture harness exists; those failure paths remain a validation gap.

AI-assisted-by: [Codex](https://openai.com/codex/)
