### PR TITLE
feat(skills): bound incident accounting to reporting windows

### DIFF
--- a/skills/repo-health/SKILL.md
+++ b/skills/repo-health/SKILL.md
@@ -42,6 +42,16 @@ reporting period and comparison period, not necessarily a local folder.
    available. It performs the local, GitHub, CircleCI,
    DigitalOcean/Kubernetes, and UptimeRobot read-only collection in one command
    and returns report-ready JSON with metrics and source summaries.
+   - Run one collector process for each report. Do not run one process per
+     metric or source.
+   - Redirect its standard output to a unique temporary file created with
+     `mktemp`; never let concurrent collector processes write to the same path.
+   - Wait for the collector process to finish before parsing its output. Check
+     that the file is non-empty, validate it with `jq empty`, and confirm that
+     it contains exactly one JSON object before using it.
+   - If that validation fails, retry the collector exactly once with a newly
+     created temporary output path. Validate the retry before parsing it; do
+     not parse either invalid output.
 7. Collect evidence manually only for requested scope that `scripts/collect.rb`
    cannot cover or when Ruby is unavailable. Keep the manual collection as
    narrow as possible, and state why the collector was insufficient before

--- a/skills/repo-health/agents/openai.yaml
+++ b/skills/repo-health/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Repo Health"
   short_description: "Summarize repository health and trends"
-  default_prompt: "Use $repo-health to produce a daily or weekly repository health report with delivery, CI, release, reliability, trend, and action evidence."
+  default_prompt: "Use $repo-health to produce a daily or weekly repository health report with safely collected and validated delivery, CI, release, reliability, trend, and action evidence."

--- a/skills/repo-health/references/sources.md
+++ b/skills/repo-health/references/sources.md
@@ -22,12 +22,23 @@ Use the bundled collector as the default collection path when Ruby is
 available:
 
 ```bash
-ruby <skill-dir>/scripts/collect.rb --repo <repo-path>
+report_output="$(mktemp "${TMPDIR:-/tmp}/repo-health.XXXXXX")"
+ruby <skill-dir>/scripts/collect.rb --repo <repo-path> > "$report_output"
+test -s "$report_output"
+jq empty "$report_output"
+jq -e -s 'length == 1 and (.[0] | type == "object")' "$report_output" >/dev/null
 ```
 
-The collector returns report-ready metrics and source summaries. Use the manual
-commands below only for requested scope that the collector cannot cover or when
-Ruby is unavailable; state that collector gap before relying on manual evidence.
+The collector returns report-ready metrics and source summaries. Run exactly
+one collector process for a report, wait for it to exit, then run the checks
+above before parsing `report_output`. Each invocation must use its own `mktemp`
+path; concurrent processes must never write to the same path. If validation
+fails, create a fresh temporary output path and retry once. Validate that retry
+before parsing it, and do not parse either invalid output.
+
+Use the manual commands below only for requested scope that the collector cannot
+cover or when Ruby is unavailable; state that collector gap before relying on
+manual evidence.
 
 Useful local commands include:
 

--- a/skills/repo-health/scripts/collect.rb
+++ b/skills/repo-health/scripts/collect.rb
@@ -1023,23 +1023,50 @@ class RepoHealthCollector
   end
 
   def incident_logs(logs, start_time, end_time)
-    Array(logs).select do |log|
-      timestamp = log['datetime'] && Time.at(log.fetch('datetime').to_i)
-      timestamp && within?(timestamp, start_time, end_time) && incident_log?(log)
-    end
+    Array(logs).select { |log| incident_log?(log) && incident_overlaps?(log, start_time, end_time) }
   end
 
   def incident_log?(log)
-    log['type'].to_i == 1 || log['duration'].to_i.positive?
+    log['type'].to_i == 1
+  end
+
+  def incident_overlaps?(log, start_time, end_time)
+    outage_start = incident_start(log)
+    return false unless outage_start
+
+    duration = incident_duration(log)
+    return within?(outage_start, start_time, end_time) unless duration.positive?
+
+    outage_start < end_time && outage_start + duration > start_time
+  end
+
+  def incident_start(log)
+    datetime = log['datetime']
+    datetime && Time.at(datetime.to_i)
+  end
+
+  def incident_duration(log)
+    log['duration'].to_i
   end
 
   def downtime_seconds(logs, start_time, end_time)
-    incident_logs(logs, start_time, end_time).sum { |log| log['duration'].to_i }
+    incident_logs(logs, start_time, end_time).sum do |log|
+      incident_downtime_seconds(log, start_time, end_time)
+    end
+  end
+
+  def incident_downtime_seconds(log, start_time, end_time)
+    duration = incident_duration(log)
+    return 0 unless duration.positive?
+
+    outage_start = incident_start(log)
+    outage_end = outage_start + duration
+    [[outage_end, end_time].min - [outage_start, start_time].max, 0].max
   end
 
   def mttr_seconds(logs, start_time, end_time)
     median(incident_logs(logs, start_time, end_time).filter_map do |log|
-      duration = log['duration'].to_i
+      duration = incident_duration(log)
       duration if duration.positive?
     end)
   end


### PR DESCRIPTION
## What

- Make repository-health collection safer by requiring unique temporary output, a completed collector process, and validated JSON before report parsing.
- Count only UptimeRobot downtime events and clip overlapping outages to each reporting window so incident and downtime metrics remain period-accurate.

## Why

- Concurrent or malformed collector output can produce untrustworthy health reports, while events outside a requested window can overstate current reliability impact.

## Testing

- `make dep` - passed
- `make skills-lint` - passed
- `make lint` - passed
- `make sec` - passed
- `ruby skills/repo-health/scripts/collect.rb --repo . --timezone Europe/Berlin` with temporary-output JSON validation - passed; exercises the documented collector workflow for this repository.
- UptimeRobot incident overlap handling has no deterministic fixture or configured service monitor in this repository, so that provider-specific path remains for CI or service-repository validation.

AI-assisted-by: [Codex](https://openai.com/codex/)
