### PR TITLE
feat(skills): surface bounded collector progress

### DIFF
--- a/lib/skills/evidence_sources.rb
+++ b/lib/skills/evidence_sources.rb
@@ -21,35 +21,103 @@ module EvidenceSources
   class SourceTimeout < Timeout::Error
   end
 
+  # Marks an intentional, safe collection limit for report output.
+  class SourceLimit < StandardError
+  end
+
   private
 
   # Runs independent source collectors with bounded concurrency while preserving result order.
-  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-  def collect_sources(sources)
-    queue = Queue.new
-    sources.each_with_index { |source, index| queue << [index, *source] }
+  def collect_sources(sources, overall_timeout_seconds: nil, on_start: nil, on_finish: nil)
+    collection = { started_at: monotonic_time, results: {}, lock: Mutex.new, cancelled: false }
+    queue = source_queue(sources)
+    workers = source_workers(sources, queue, collection, on_start, on_finish)
 
-    workers = Array.new([sources.length, MAX_CONCURRENT_SOURCES].min) do
-      Thread.new do
-        results = []
-        loop do
-          source = begin
-            queue.pop(true)
-          rescue ThreadError
-            nil
-          end
-          break unless source
-
-          index, name, collect = source
-          results << [index, name, collect_source(name, collect)]
-        end
-        results
-      end
+    wait_for_sources(workers, overall_timeout_seconds)
+    if workers.any?(&:alive?)
+      mark_overall_timeout_sources(sources, collection, on_finish, overall_timeout_seconds)
+    else
+      workers.each(&:join)
     end
-
-    workers.flat_map(&:value).sort_by(&:first).to_h { |_, name, result| [name, result] }
+    sources.to_h { |name, _| [name, collection.fetch(:results).fetch(name)] }
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+  def source_queue(sources)
+    Queue.new.tap { |queue| sources.each { |source| queue << source } }
+  end
+
+  def source_workers(sources, queue, collection, on_start, on_finish)
+    Array.new([sources.length, MAX_CONCURRENT_SOURCES].min) do
+      Thread.new { collect_queued_sources(queue, collection, on_start, on_finish) }
+    end
+  end
+
+  def collect_queued_sources(queue, collection, on_start, on_finish)
+    loop do
+      break if collection_cancelled?(collection)
+
+      source = queue.pop(true)
+      collect_queued_source(source, collection, on_start, on_finish)
+    rescue ThreadError
+      break
+    end
+  end
+
+  def collect_queued_source(source, collection, on_start, on_finish)
+    name, collect = source
+    source_started_at = monotonic_time
+    on_start&.call(name)
+    result = collect_source(name, collect)
+    return if collection_cancelled?(collection)
+
+    collection.fetch(:lock).synchronize { collection.fetch(:results)[name] = result }
+    on_finish&.call(name, result, monotonic_time - source_started_at)
+  end
+
+  def wait_for_sources(workers, overall_timeout_seconds)
+    return workers.each(&:join) unless overall_timeout_seconds
+
+    deadline = monotonic_time + overall_timeout_seconds
+    workers.each do |worker|
+      remaining_seconds = deadline - monotonic_time
+      break unless remaining_seconds.positive?
+
+      worker.join(remaining_seconds)
+    end
+  end
+
+  def mark_overall_timeout_sources(sources, collection, on_finish, overall_timeout_seconds)
+    collection.fetch(:lock).synchronize { collection[:cancelled] = true }
+    missing_source_names(sources, collection).each do |name|
+      mark_overall_timeout_source(name, collection, on_finish, overall_timeout_seconds)
+    end
+  end
+
+  def missing_source_names(sources, collection)
+    sources.map(&:first).reject { |name| collection_result(collection, name) }
+  end
+
+  def mark_overall_timeout_source(name, collection, on_finish, overall_timeout_seconds)
+    result = unavailable("overall collection timed out after #{overall_timeout_seconds} seconds")
+    store_collection_result(collection, name, result)
+    on_finish&.call(name, result, monotonic_time - collection.fetch(:started_at))
+  end
+
+  def collection_result(collection, name)
+    collection.fetch(:lock).synchronize { collection.fetch(:results)[name] }
+  end
+
+  def store_collection_result(collection, name, result)
+    collection.fetch(:lock).synchronize { collection.fetch(:results)[name] = result }
+  end
+
+  def monotonic_time
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+
+  def collection_cancelled?(collection)
+    collection.fetch(:lock).synchronize { collection[:cancelled] }
+  end
 
   def collect_source(name, collect)
     timeout_seconds = source_timeout_seconds(name)
@@ -70,7 +138,7 @@ module EvidenceSources
   end
 
   def source_error_reason(error)
-    return error.message if error.is_a?(SourceTimeout)
+    return error.message if error.is_a?(SourceTimeout) || error.is_a?(SourceLimit)
     return timeout_reason(source_timeout_seconds) if error.is_a?(Timeout::Error)
 
     "source collection failed (#{error.class})"

--- a/skills/repo-health/SKILL.md
+++ b/skills/repo-health/SKILL.md
@@ -43,7 +43,10 @@ reporting period and comparison period, not necessarily a local folder.
    DigitalOcean/Kubernetes, and UptimeRobot read-only collection in one command
    and returns report-ready JSON with metrics and source summaries.
    - Run one collector process for each report. Do not run one process per
-     metric or source.
+     metric or source. The collector writes machine-readable JSON only to
+     standard output and progress to standard error.
+   - Use `--sources local,github` to limit collection when the report needs a
+     subset, or `--timeout SECONDS` to override the 240-second overall deadline.
    - Redirect its standard output to a unique temporary file created with
      `mktemp`; never let concurrent collector processes write to the same path.
    - Wait for the collector process to finish before parsing its output. Check

--- a/skills/repo-health/references/sources.md
+++ b/skills/repo-health/references/sources.md
@@ -40,6 +40,13 @@ Use the manual commands below only for requested scope that the collector cannot
 cover or when Ruby is unavailable; state that collector gap before relying on
 manual evidence.
 
+The collector sends progress lines to standard error and emits exactly one JSON
+object to standard output when collection succeeds or degrades gracefully. Its
+default source set is local, GitHub, CircleCI, DigitalOcean, Kubernetes, and
+UptimeRobot. Limit a report to specific sources with `--sources local,github`,
+or set the 240-second overall deadline with `--timeout SECONDS`; sources
+unfinished at that deadline are reported as unavailable in the JSON output.
+
 Useful local commands include:
 
 ```bash

--- a/skills/repo-health/scripts/collect.rb
+++ b/skills/repo-health/scripts/collect.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ClassLength, Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+# rubocop:disable Metrics/ClassLength, Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/BlockLength
 
 lib = File.expand_path('../../../lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
@@ -15,8 +15,10 @@ class RepoHealthCollector
 
   TREND_WINDOW_COUNT = 4
   STALE_PR_SECONDS = 7 * 24 * 60 * 60
-  GITHUB_PR_PAGE_LIMIT = 100
-  GITHUB_PR_PAGE_LIMIT_MAX = 6_400
+  SOURCE_NAMES = %i[local github circleci digitalocean kubernetes uptimerobot].freeze
+  DEFAULT_OVERALL_TIMEOUT_SECONDS = 240
+  GITHUB_PR_RESULT_LIMIT = 6_400
+  CIRCLECI_PAGE_LIMIT = 10
   CI_SUCCESS_RATE_ACTION_THRESHOLD = 0.90
   CHANGE_RATIO_ACTION_THRESHOLD = 0.25
   LIBRARY_RELEASE_AGE_ACTION_SECONDS = 90 * 24 * 60 * 60
@@ -26,6 +28,8 @@ class RepoHealthCollector
     @timezone = options.fetch(:timezone)
     @branch = options[:branch]
     @include_jobs = options.fetch(:include_jobs)
+    @source_names = source_names(options.fetch(:source_names))
+    @overall_timeout_seconds = options.fetch(:overall_timeout_seconds)
     @now = options[:now] ? parse_time(options[:now]) : Time.now
     @current_end = options[:current_end] ? parse_time(options[:current_end]) : day_start(@now)
     @current_start =
@@ -35,33 +39,36 @@ class RepoHealthCollector
   end
 
   def call
+    started_at = monotonic_time
+    progress('collector started')
     root = git_root
     owner_repo = parse_owner_repo(git('remote', 'get-url', 'origin').strip)
-    branch = summary_branch(owner_repo)
+    branch = summary_branch(owner_repo, @source_names.include?(:github))
     mode = File.exist?(File.join(root, '.cd')) ? 'service' : 'library'
     period = window_seconds <= 24 * 60 * 60 ? 'daily' : 'weekly'
-    sources = collect_sources([
-                                [:local, -> { collect_local(root) }],
-                                [:github, -> { collect_github(owner_repo) }],
-                                [:circleci, -> { collect_circleci(owner_repo, branch, mode, root) }],
-                                [:digitalocean, lambda do
-                                  mode == 'service' ? collect_digitalocean : skipped('not a service repo')
-                                end],
-                                [:kubernetes, lambda do
-                                  if mode == 'service'
-                                    collect_kubernetes(owner_repo.split('/').last)
-                                  else
-                                    skipped('not a service repo')
-                                  end
-                                end],
-                                [:uptimerobot, lambda do
-                                  if mode == 'service'
-                                    collect_uptimerobot(owner_repo.split('/').last)
-                                  else
-                                    skipped('not a service repo')
-                                  end
-                                end]
-                              ])
+    source_definitions = [
+      [:local, -> { collect_local(root) }],
+      [:github, -> { collect_github(owner_repo) }],
+      [:circleci, -> { collect_circleci(owner_repo, branch, mode, root) }],
+      [:digitalocean, lambda do
+        mode == 'service' ? collect_digitalocean : skipped('not a service repo')
+      end],
+      [:kubernetes, lambda do
+        if mode == 'service'
+          collect_kubernetes(owner_repo.split('/').last)
+        else
+          skipped('not a service repo')
+        end
+      end],
+      [:uptimerobot, lambda do
+        if mode == 'service'
+          collect_uptimerobot(owner_repo.split('/').last)
+        else
+          skipped('not a service repo')
+        end
+      end]
+    ]
+    sources = collect_selected_sources(source_definitions)
 
     result = {
       repository: owner_repo,
@@ -80,12 +87,60 @@ class RepoHealthCollector
     }
 
     JSON.pretty_generate(summary_result(result))
+  ensure
+    progress("collector completed after #{format_elapsed(monotonic_time - started_at)}") if started_at
   end
 
   private
 
   def parse_time(value)
     with_timezone { Time.parse(value) }
+  end
+
+  def source_names(names)
+    unknown_names = names - SOURCE_NAMES
+    raise ArgumentError, "unknown sources: #{unknown_names.join(', ')}" unless unknown_names.empty?
+    raise ArgumentError, 'at least one source must be selected' if names.empty?
+
+    names
+  end
+
+  def collect_selected_sources(definitions)
+    selected = definitions.to_h.slice(*@source_names).to_a
+    collected = collect_sources(
+      selected,
+      overall_timeout_seconds: @overall_timeout_seconds,
+      on_start: method(:progress_source_start),
+      on_finish: method(:progress_source_finish)
+    )
+    definitions.to_h do |name, _|
+      [name, collected.fetch(name, skipped('not selected'))]
+    end
+  end
+
+  def progress_source_start(name)
+    progress("source #{name} started")
+  end
+
+  def progress_source_finish(name, result, elapsed_seconds)
+    status = result.is_a?(Hash) && result[:status] ? result[:status] : 'used'
+    detail = result.is_a?(Hash) ? result[:reason] : nil
+    message = "source #{name} completed after #{format_elapsed(elapsed_seconds)} with status #{status}"
+    progress(detail ? "#{message}: #{detail}" : message)
+  end
+
+  def progress(message)
+    @progress_lock ||= Mutex.new
+    @progress_lock.synchronize do
+      warn("repo-health: #{message}")
+      $stderr.flush
+    end
+  rescue Errno::EPIPE
+    nil
+  end
+
+  def format_elapsed(seconds)
+    format('%.3fs', seconds)
   end
 
   def day_start(time)
@@ -1128,22 +1183,27 @@ class RepoHealthCollector
   def circleci_pipelines(owner_repo, branch, token)
     pipelines = []
     page_token = nil
+    pages = 0
+    oldest_window_start = period_windows.last.fetch(:start)
     loop do
+      raise SourceLimit, 'CircleCI pipeline pagination reached its configured limit' if pages >= CIRCLECI_PAGE_LIMIT
+
       path = "/project/gh/#{owner_repo}/pipeline?branch=#{url_query(branch)}"
       path += "&page-token=#{URI.encode_www_form_component(page_token)}" if page_token
       data = circleci_get(path, token)
       items = data.fetch('items', [])
-      pipelines.concat(items)
+      pages += 1
+      pipelines.concat(items.select { |pipeline| Time.parse(pipeline.fetch('created_at')) >= oldest_window_start })
       oldest = items.filter_map { |pipeline| Time.parse(pipeline.fetch('created_at')) }.min
       page_token = data['next_page_token']
-      break if items.empty? || page_token.nil? || (oldest && oldest < period_windows.last.fetch(:start))
+      break if items.empty? || page_token.nil? || (oldest && oldest < oldest_window_start)
     end
     pipelines
   end
 
   def circleci_workflows(pipelines, token)
     pipelines.flat_map do |pipeline|
-      circleci_get("/pipeline/#{pipeline.fetch('id')}/workflow", token).fetch('items', []).map do |workflow|
+      circleci_paginated("/pipeline/#{pipeline.fetch('id')}/workflow", token).map do |workflow|
         workflow.merge('pipeline_created_at' => pipeline.fetch('created_at'),
                        'pipeline_number' => pipeline.fetch('number'))
       end
@@ -1152,7 +1212,7 @@ class RepoHealthCollector
 
   def circleci_jobs(workflows, token)
     workflows.flat_map do |workflow|
-      circleci_get("/workflow/#{workflow.fetch('id')}/job", token).fetch('items', []).map do |job|
+      circleci_paginated("/workflow/#{workflow.fetch('id')}/job", token).map do |job|
         job.merge('workflow_id' => workflow.fetch('id'), 'workflow_created_at' => workflow.fetch('created_at'))
       end
     end
@@ -1168,20 +1228,31 @@ class RepoHealthCollector
     YAML.safe_load_file(path).fetch('token')
   end
 
-  def gh_pr_list(*args)
-    limit = GITHUB_PR_PAGE_LIMIT
-    loop do
-      results = gh_json(*args, '--limit', limit.to_s)
-      return results if results.length < limit
-      if limit >= GITHUB_PR_PAGE_LIMIT_MAX
-        raise "gh pr list saturated at --limit #{limit} without proving completeness: #{args.join(' ')}"
-      end
+  def gh_pr_list(*)
+    results = gh_json(*, '--limit', GITHUB_PR_RESULT_LIMIT.to_s)
+    return results if results.length < GITHUB_PR_RESULT_LIMIT
 
-      limit *= 2
-    end
+    raise SourceLimit, 'GitHub pull request query reached its configured result limit'
   end
 
-  def summary_branch(owner_repo)
+  def circleci_paginated(path, token)
+    items = []
+    page_token = nil
+    pages = 0
+    loop do
+      raise SourceLimit, 'CircleCI pagination reached its configured limit' if pages >= CIRCLECI_PAGE_LIMIT
+
+      request_path = page_token ? "#{path}?page-token=#{URI.encode_www_form_component(page_token)}" : path
+      data = circleci_get(request_path, token)
+      items.concat(data.fetch('items', []))
+      pages += 1
+      page_token = data['next_page_token']
+      break unless page_token
+    end
+    items
+  end
+
+  def summary_branch(owner_repo, github_selected)
     return @branch if @branch
 
     branch = git('symbolic-ref', '--quiet', '--short', 'refs/remotes/origin/HEAD', allow_failure: true)
@@ -1189,7 +1260,7 @@ class RepoHealthCollector
              .sub(%r{\Aorigin/}, '')
     return branch unless branch.empty?
 
-    branch = github_default_branch(owner_repo)
+    branch = github_default_branch(owner_repo) if github_selected
     return branch if branch && !branch.empty?
 
     git('branch', '--show-current').strip
@@ -1223,7 +1294,9 @@ end
 options = {
   repo_path: Dir.pwd,
   timezone: ENV.fetch('TZ', 'Europe/Berlin'),
-  include_jobs: false
+  include_jobs: false,
+  source_names: RepoHealthCollector::SOURCE_NAMES,
+  overall_timeout_seconds: RepoHealthCollector::DEFAULT_OVERALL_TIMEOUT_SECONDS
 }
 
 OptionParser.new do |parser|
@@ -1248,8 +1321,17 @@ OptionParser.new do |parser|
     options[:branch] = value
   end
   parser.on('--include-jobs', 'Collect CircleCI job-level data for library repos.') { options[:include_jobs] = true }
+  parser.on('--sources NAMES',
+            'Comma-separated sources: local, github, circleci, digitalocean, kubernetes, uptimerobot.') do |value|
+    options[:source_names] = value.split(',').map(&:strip).reject(&:empty?).map(&:to_sym)
+  end
+  parser.on('--timeout SECONDS', Float, 'Overall collection timeout in seconds. Defaults to 240.') do |value|
+    raise OptionParser::InvalidArgument, 'timeout must be greater than zero' unless value.positive?
+
+    options[:overall_timeout_seconds] = value
+  end
 end.parse!
 
 puts RepoHealthCollector.new(options).call
 
-# rubocop:enable Metrics/ClassLength, Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+# rubocop:enable Metrics/ClassLength, Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/BlockLength


### PR DESCRIPTION
## What

- Make repo-health collection observable through stderr progress while retaining a single final JSON object on stdout.
- Add bounded overall collection deadlines, source selection, and safe pagination limits without changing report metrics or source schema.

## Why

- Long-running GitHub, CircleCI, and service-source collection previously appeared to callers as an empty or failed command until every source completed.
- The collector now returns safe partial data when a deadline expires instead of requiring a caller to retry an empty stdout result.

## Testing

- `make dep` - passed
- `make lint` - passed
- `make skills-lint` - passed
- `make sec` - passed (Trivy reported zero Bundler vulnerabilities and no scanned secrets)
- `ruby skills/repo-health/scripts/collect.rb --repo "$PWD" --sources local --timeout 5` - passed with one JSON object and stderr progress
- Bounded downstream smoke checks against Bezeichner and Standort - passed with valid JSON and visible source progress at a 20-second deadline
- No automated regression test was added by request; the configured Cucumber harness is not present in this repository.

AI-assisted-by: [Codex](https://openai.com/codex/)
