### PR TITLE
feat(skills): validate completed collector output

### DIFF
--- a/build/codex/config.toml
+++ b/build/codex/config.toml
@@ -3,6 +3,9 @@ approval_policy = "on-request"
 approvals_reviewer = "user"
 default_permissions = "shared-development"
 
+# Allow persistent command polls through repo-health's 240-second deadline.
+background_terminal_max_timeout = 300000
+
 [permissions.shared-development]
 description = "Autonomous workspace development with host credentials and internet access."
 extends = ":workspace"

--- a/skills/repo-health/SKILL.md
+++ b/skills/repo-health/SKILL.md
@@ -38,24 +38,36 @@ reporting period and comparison period, not necessarily a local folder.
 3. Read `references/sources.md` before collecting data.
 4. Read `references/metrics.md` before calculating or naming metrics.
 5. Read `references/output.md` before writing the final summary.
-6. Use `scripts/collect.rb` as the default collection path when Ruby is
+6. Use `scripts/collect` as the default collection path when Ruby is
    available. It performs the local, GitHub, CircleCI,
    DigitalOcean/Kubernetes, and UptimeRobot read-only collection in one command
    and returns report-ready JSON with metrics and source summaries.
-   - Run one collector process for each report. Do not run one process per
-     metric or source. The collector writes machine-readable JSON only to
-     standard output and progress to standard error.
+   - Run it in the runtime's persistent command session. The wrapper runs one
+     collector process per attempt, validates its completed output, and retries
+     exactly once only after a completed run fails validation. Do not run one
+     process per metric or source. The collector writes machine-readable JSON
+     only to standard output and progress to standard error.
    - Use `--sources local,github` to limit collection when the report needs a
-     subset, or `--timeout SECONDS` to override the 240-second overall deadline.
-   - Redirect its standard output to a unique temporary file created with
-     `mktemp`; never let concurrent collector processes write to the same path.
-   - Wait for the collector process to finish before parsing its output. Check
-     that the file is non-empty, validate it with `jq empty`, and confirm that
-     it contains exactly one JSON object before using it.
-   - If that validation fails, retry the collector exactly once with a newly
-     created temporary output path. Validate the retry before parsing it; do
-     not parse either invalid output.
-7. Collect evidence manually only for requested scope that `scripts/collect.rb`
+    subset, or `--timeout SECONDS` to override the 240-second overall deadline.
+   - Full collection can take time, especially when CircleCI is selected. After
+     starting it, poll the same persistent session until it exits; do not use a
+     30-second command wait as the session lifetime. Agents must not kill,
+     cancel, or switch to manual fallback because a poll returns before the
+     collector exits. Allow at least the configured 240-second timeout plus
+     final-output time before declaring the invocation timed out. Record the
+     completed process exit code in `rc`, never `status`: `status` is read-only
+     in zsh.
+   - Redirect the wrapper's standard output to a unique temporary file created
+     with `mktemp`; never let concurrent collector processes write to the same
+     path. After the session exits, require `rc` to be zero, the file to be
+     non-empty, `jq empty` to succeed, and `jq -e -s 'length == 1 and (.[0] |
+     type == "object")'` to succeed before parsing it.
+   - Do not retry an interruption or timeout: a session without a completed exit
+     code or final output is an invocation failure, not source data. A completed
+     zero-exit valid JSON result with an unavailable source is a
+     collector-generated unavailable source and must be reported as such, not
+     retried.
+7. Collect evidence manually only for requested scope that `scripts/collect`
    cannot cover or when Ruby is unavailable. Keep the manual collection as
    narrow as possible, and state why the collector was insufficient before
    relying on local repository facts, authenticated source APIs, or CLIs.
@@ -75,7 +87,7 @@ reporting period and comparison period, not necessarily a local folder.
 
 ## References
 
-- Run `scripts/collect.rb --repo PATH` first for report-ready metrics and
+- Run `scripts/collect --repo PATH` first for report-ready metrics and
   source summaries.
 - Read `references/sources.md` for source priority, credential names, and
   collection boundaries.

--- a/skills/repo-health/references/sources.md
+++ b/skills/repo-health/references/sources.md
@@ -23,18 +23,34 @@ available:
 
 ```bash
 report_output="$(mktemp "${TMPDIR:-/tmp}/repo-health.XXXXXX")"
-ruby <skill-dir>/scripts/collect.rb --repo <repo-path> > "$report_output"
+<skill-dir>/scripts/collect --repo <repo-path> > "$report_output"
+rc=$?
+test "$rc" -eq 0
 test -s "$report_output"
 jq empty "$report_output"
 jq -e -s 'length == 1 and (.[0] | type == "object")' "$report_output" >/dev/null
 ```
 
-The collector returns report-ready metrics and source summaries. Run exactly
-one collector process for a report, wait for it to exit, then run the checks
-above before parsing `report_output`. Each invocation must use its own `mktemp`
-path; concurrent processes must never write to the same path. If validation
-fails, create a fresh temporary output path and retry once. Validate that retry
-before parsing it, and do not parse either invalid output.
+Full collection can take time, especially when CircleCI is selected. Start this
+command in the runtime's persistent session, then poll that same session until
+it exits. A 30-second tool wait is only a poll interval, not a collector
+deadline: agents must not kill, cancel, or switch to manual fallback because a
+poll returns before the collector exits. Allow the configured 240 seconds (or
+the supplied `--timeout`) plus final-output time. Record the completed command's
+exit code as `rc`; do not use `status`, which is read-only in zsh.
+
+`collect` runs exactly one collector process per attempt, writes its standard
+output to a fresh internal `mktemp` file, validates the completed run, and
+retries once only when that completed run has a non-zero exit code, empty output,
+invalid JSON, or anything other than exactly one JSON object. The outer
+`report_output` must still pass the checks above before parsing. Concurrent
+invocations must never write to the same output path.
+
+Do not retry when the persistent session is interrupted or timed out before it
+returns a completed `rc` and final output: classify that as `interrupted or
+timed out`, not as unavailable source data. In contrast, a completed zero-exit
+result with valid JSON may contain a collector-generated unavailable source;
+retain and report that source state rather than retrying the invocation.
 
 Use the manual commands below only for requested scope that the collector cannot
 cover or when Ruby is unavailable; state that collector gap before relying on

--- a/skills/repo-health/scripts/collect
+++ b/skills/repo-health/scripts/collect
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Runs the repo-health collector with completed-run validation and one bounded retry.
+
+set -eo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+max_attempts=2
+attempt=1
+report_output=""
+
+cleanup() {
+  [[ -z $report_output ]] || rm -f "$report_output"
+}
+
+interrupted() {
+  printf 'repo-health: collector invocation interrupted; output was discarded\n' >&2
+  exit 130
+}
+
+trap cleanup EXIT
+trap interrupted HUP INT TERM
+
+if ! command -v ruby >/dev/null 2>&1; then
+  printf 'repo-health: ruby is required to run the collector\n' >&2
+  exit 127
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'repo-health: jq is required to validate collector output\n' >&2
+  exit 127
+fi
+
+while ((attempt <= max_attempts)); do
+  report_output="$(mktemp "${TMPDIR:-/tmp}/repo-health.XXXXXX")"
+
+  set +e
+  ruby "$script_dir/collect.rb" "$@" > "$report_output"
+  rc=$?
+  set -e
+
+  validation_error=""
+  if ((rc != 0)); then
+    validation_error="collector completed with exit code $rc"
+  elif ! test -s "$report_output"; then
+    validation_error='collector completed without JSON output'
+  elif ! jq empty "$report_output" >/dev/null 2>&1; then
+    validation_error='collector completed with invalid JSON output'
+  elif ! jq -e -s 'length == 1 and (.[0] | type == "object")' "$report_output" >/dev/null; then
+    validation_error='collector completed without exactly one JSON object'
+  fi
+
+  if [[ -z $validation_error ]]; then
+    cat "$report_output"
+    exit 0
+  fi
+
+  if ((attempt == max_attempts)); then
+    printf 'repo-health: %s after retry\n' "$validation_error" >&2
+    if ((rc == 0)); then
+      rc=1
+    fi
+    exit "$rc"
+  fi
+
+  printf 'repo-health: %s; retrying once\n' "$validation_error" >&2
+  rm -f "$report_output"
+  report_output=""
+  ((attempt += 1))
+done

--- a/test/shell/lint
+++ b/test/shell/lint
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Run ShellCheck over Bash scripts and sourced shell libraries.
+# Run ShellCheck over Bash scripts and sourced shell libraries, including skills.
 
 set -eo pipefail
 
@@ -12,7 +12,7 @@ while IFS= read -r -d '' file; do
   if [[ $first_line == "#!/usr/bin/env bash" || $first_line == "#!/bin/bash" ]]; then
     files+=("$file")
   fi
-done < <(find build quality lib test -type f -print0)
+done < <(find build quality lib test skills -type f -print0)
 
 if ((${#files[@]} > 0)); then
   shellcheck "${files[@]}"

--- a/test/skills/lint
+++ b/test/skills/lint
@@ -210,6 +210,41 @@ PATTERNS
 
 reject_pattern skills/change-validation/references/check-selection.md "zsh -"
 
+# Repo-health collector invocation contract.
+require_patterns skills/repo-health/SKILL.md <<'PATTERNS'
+persistent session
+poll
+240-second timeout
+can take time
+must not kill
+`rc`
+interruption or timeout
+collector-generated unavailable
+PATTERNS
+
+require_patterns skills/repo-health/references/sources.md <<'PATTERNS'
+scripts/collect
+persistent session
+poll
+240 seconds
+can take time
+must not kill
+exit code
+exactly one JSON object
+interrupted or timed out
+collector-generated unavailable
+PATTERNS
+
+require_patterns skills/repo-health/scripts/collect <<'PATTERNS'
+collect.rb
+rc=$?
+test -s
+jq empty
+length == 1 and (.[0] | type == "object")
+PATTERNS
+
+reject_pattern skills/repo-health/scripts/collect 'status='
+
 # Testing and language-standard contracts.
 require_patterns skills/testing-standards/SKILL.md <<'PATTERNS'
 ## Mandatory Stop Gates


### PR DESCRIPTION
## What

- Add a validated repo-health collector wrapper that preserves a single JSON result, retries one completed invalid invocation, and makes long-running collection progress safe to poll.
- Extend shared shell and skill checks to cover the wrapper, and set the shared Codex terminal-poll window explicitly for the documented 240-second collection deadline.

## Why

- A completed collector run with malformed, empty, or failed output must not be parsed into an engineering-health report, while a still-running collection must not be mistaken for a failed one.
- The wrapper makes that boundary consistent for reusable repo-health consumers without changing the underlying collector’s source schema or read-only collection behavior.

## Testing

- `make scripts-lint` - passed
- `make skills-lint` - passed
- `make lint` - passed
- `make docker-lint` - passed
- `make sec` - passed
- `skills/repo-health/scripts/collect --repo . --sources local --timeout 5` - passed with one valid JSON object.
- `skills/repo-health/scripts/collect --repo . --sources invalid` - passed as a failure-path check: retried once and exited non-zero after the completed second failure.

AI-assisted-by: [Codex](https://openai.com/codex/)
