### PR TITLE
feat(skills): validate diagnostic collector results

### DIFF
--- a/skills/diagnose-issue/SKILL.md
+++ b/skills/diagnose-issue/SKILL.md
@@ -34,12 +34,23 @@ folder.
    - `references/ci.md` for CI and PR diagnosis.
    - `references/deployment.md` for deployment and runtime diagnosis.
    - `references/output.md` before writing the final answer.
-3. Use `scripts/collect.rb` as the default collection path when Ruby is
+3. Use `scripts/collect` as the default collection path when Ruby and `jq` are
    available; the mode references contain the exact commands and options.
-4. Collect manually only for missing evidence or a narrower user request that
-   the script cannot cover. State why the collector was insufficient before
-   relying on manual `gh`, CircleCI, `kubectl`, DigitalOcean, UptimeRobot, or
-   local-git commands.
+   - Run it in the runtime's persistent session and wait for it to exit before
+     parsing its standard output. The wrapper runs one collector process per
+     attempt, validates a completed run's output, and retries once only after a
+     completed run fails validation.
+   - Redirect the wrapper's standard output to a unique `mktemp` file. Before
+     parsing, require a zero `rc`, non-empty output, valid JSON, and exactly one
+     JSON object.
+   - Do not retry an interruption or timeout: a session without a completed
+     exit code and final output is an invocation failure, not source data. A
+     completed valid JSON result may still contain unavailable source evidence;
+     report that source gap rather than retrying it.
+4. Collect manually only for missing evidence, a narrower user request that the
+   script cannot cover, or an unavailable Ruby or `jq` command. State why the
+   collector was insufficient before relying on manual `gh`, CircleCI,
+   `kubectl`, DigitalOcean, UptimeRobot, or local-git commands.
 5. Separate facts from inference. Label source gaps, stale data, partial
    windows, missing credentials, and collection-time Kubernetes state.
 6. Give fixes as ordered suggestions. Prefer the smallest likely fix first, and

--- a/skills/diagnose-issue/references/ci.md
+++ b/skills/diagnose-issue/references/ci.md
@@ -8,8 +8,8 @@ questions.
 Run the collector from the repository being diagnosed:
 
 ```bash
-ruby <skill-dir>/scripts/collect.rb --mode ci --repo <repo-path>
-ruby <skill-dir>/scripts/collect.rb --mode ci --pipeline <circleci-pipeline-number> --repo <repo-path>
+<skill-dir>/scripts/collect --mode ci --repo <repo-path>
+<skill-dir>/scripts/collect --mode ci --pipeline <circleci-pipeline-number> --repo <repo-path>
 ```
 
 CI mode defaults to the latest CircleCI pipeline on the current branch. Use

--- a/skills/diagnose-issue/references/deployment.md
+++ b/skills/diagnose-issue/references/deployment.md
@@ -9,8 +9,8 @@ version questions.
 Run the collector from the repository being diagnosed:
 
 ```bash
-ruby <skill-dir>/scripts/collect.rb --mode deployment --repo <repo-path>
-ruby <skill-dir>/scripts/collect.rb --mode deployment --version <version-tag> --repo <repo-path>
+<skill-dir>/scripts/collect --mode deployment --repo <repo-path>
+<skill-dir>/scripts/collect --mode deployment --version <version-tag> --repo <repo-path>
 ```
 
 Deployment mode defaults to the latest local version tag. Use `--version` when

--- a/skills/diagnose-issue/scripts/collect
+++ b/skills/diagnose-issue/scripts/collect
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Runs the diagnose-issue collector with completed-run validation and one bounded retry.
+
+set -eo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+max_attempts=2
+attempt=1
+diagnosis_output=""
+
+cleanup() {
+  [[ -z $diagnosis_output ]] || rm -f "$diagnosis_output"
+}
+
+interrupted() {
+  printf 'diagnose-issue: collector invocation interrupted; output was discarded\n' >&2
+  exit 130
+}
+
+trap cleanup EXIT
+trap interrupted HUP INT TERM
+
+if ! command -v ruby >/dev/null 2>&1; then
+  printf 'diagnose-issue: ruby is required to run the collector\n' >&2
+  exit 127
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'diagnose-issue: jq is required to validate collector output\n' >&2
+  exit 127
+fi
+
+while ((attempt <= max_attempts)); do
+  diagnosis_output="$(mktemp "${TMPDIR:-/tmp}/diagnose-issue.XXXXXX")"
+
+  set +e
+  ruby "$script_dir/collect.rb" "$@" > "$diagnosis_output"
+  rc=$?
+  set -e
+
+  validation_error=""
+  if ((rc != 0)); then
+    validation_error="collector completed with exit code $rc"
+  elif ! test -s "$diagnosis_output"; then
+    validation_error='collector completed without JSON output'
+  elif ! jq empty "$diagnosis_output" >/dev/null 2>&1; then
+    validation_error='collector completed with invalid JSON output'
+  elif ! jq -e -s 'length == 1 and (.[0] | type == "object")' "$diagnosis_output" >/dev/null; then
+    validation_error='collector completed without exactly one JSON object'
+  fi
+
+  if [[ -z $validation_error ]]; then
+    cat "$diagnosis_output"
+    exit 0
+  fi
+
+  if ((attempt == max_attempts)); then
+    printf 'diagnose-issue: %s after retry\n' "$validation_error" >&2
+    if ((rc == 0)); then
+      rc=1
+    fi
+    exit "$rc"
+  fi
+
+  printf 'diagnose-issue: %s; retrying once\n' "$validation_error" >&2
+  rm -f "$diagnosis_output"
+  diagnosis_output=""
+  ((attempt += 1))
+done

--- a/test/skills/lint
+++ b/test/skills/lint
@@ -245,6 +245,28 @@ PATTERNS
 
 reject_pattern skills/repo-health/scripts/collect 'status='
 
+# Diagnose-issue collector invocation contract.
+require_patterns skills/diagnose-issue/SKILL.md <<'PATTERNS'
+scripts/collect
+persistent session
+completed run
+interruption or timeout
+PATTERNS
+
+require_pattern_in_files 'scripts/collect' \
+  skills/diagnose-issue/references/ci.md \
+  skills/diagnose-issue/references/deployment.md
+
+require_patterns skills/diagnose-issue/scripts/collect <<'PATTERNS'
+collect.rb
+rc=$?
+test -s
+jq empty
+length == 1 and (.[0] | type == "object")
+PATTERNS
+
+reject_pattern skills/diagnose-issue/scripts/collect 'status='
+
 # Testing and language-standard contracts.
 require_patterns skills/testing-standards/SKILL.md <<'PATTERNS'
 ## Mandatory Stop Gates


### PR DESCRIPTION
## What

- Add a diagnosis collector wrapper that accepts only a completed, single JSON object and retries one failed completed invocation.
- Route CI and deployment diagnosis commands through the wrapper and document the persistent-session and evidence-handling contract.
- Extend shared skill checks to protect the collector invocation and validation contract.

## Why

- Prevent incomplete, malformed, or failed collection output from being interpreted as CI or deployment evidence while preserving valid unavailable-source results.
- Make interrupted collection an invocation failure instead of silently falling back to unrelated manual evidence.

## Testing

- `make dep` - passed
- `make clean-dep` - passed
- `make scripts-lint` - passed
- `make skills-lint` - passed
- `make docker-lint` - passed
- `make lint` - passed
- `make sec` - passed
- `skills/diagnose-issue/scripts/collect --mode unsupported --repo . | jq -e -s 'length == 1 and (.[0] | type == "object")' >/dev/null` - passed with exactly one JSON object.
- `skills/diagnose-issue/scripts/collect --invalid-option` - passed as a failure-path check: retried once and exited non-zero after the completed second failure.

AI-assisted-by: [Codex](https://openai.com/codex/)
