### PR TITLE
feat(skills): deduplicate collector retry logic and shared kubernetes/digitalocean helpers

### DIFF
--- a/lib/skills/collector.sh
+++ b/lib/skills/collector.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+# Shared retry/validation wrapper for skill collector scripts.
+
+# Runs a skill's Ruby collector with completed-run validation and one bounded
+# retry, printing the validated JSON to standard output.
+# Usage: run_skill_collector <label> <collector_script> [collector_args...]
+run_skill_collector() {
+  local label="$1"
+  local collector_script="$2"
+  shift 2
+
+  local max_attempts=2
+  local attempt=1
+  local output=""
+
+  cleanup() { [[ -z $output ]] || rm -f "$output"; }
+  interrupted() {
+    printf '%s: collector invocation interrupted; output was discarded\n' "$label" >&2
+    exit 130
+  }
+  trap cleanup EXIT
+  trap interrupted HUP INT TERM
+
+  if ! command -v ruby >/dev/null 2>&1; then
+    printf '%s: ruby is required to run the collector\n' "$label" >&2
+    exit 127
+  fi
+
+  for argument in "$@"; do
+    if [[ $argument == '--help' || $argument == '-h' ]]; then
+      exec ruby "$collector_script" "$@"
+    fi
+  done
+
+  if ! command -v jq >/dev/null 2>&1; then
+    printf '%s: jq is required to validate collector output\n' "$label" >&2
+    exit 127
+  fi
+
+  while ((attempt <= max_attempts)); do
+    output="$(mktemp "${TMPDIR:-/tmp}/${label}.XXXXXX")"
+
+    set +e
+    ruby "$collector_script" "$@" >"$output"
+    rc=$?
+    set -e
+
+    local validation_error=""
+    if ((rc != 0)); then
+      validation_error="collector completed with exit code $rc"
+    elif ! test -s "$output"; then
+      validation_error='collector completed without JSON output'
+    elif ! jq empty "$output" >/dev/null 2>&1; then
+      validation_error='collector completed with invalid JSON output'
+    elif ! jq -e -s 'length == 1 and (.[0] | type == "object")' "$output" >/dev/null; then
+      validation_error='collector completed without exactly one JSON object'
+    fi
+
+    if [[ -z $validation_error ]]; then
+      cat "$output"
+      return 0
+    fi
+
+    if ((attempt == max_attempts)); then
+      printf '%s: %s after retry\n' "$label" "$validation_error" >&2
+      ((rc == 0)) && rc=1
+      exit "$rc"
+    fi
+
+    printf '%s: %s; retrying once\n' "$label" "$validation_error" >&2
+    rm -f "$output"
+    output=""
+    ((attempt += 1))
+  done
+}

--- a/lib/skills/evidence_sources.rb
+++ b/lib/skills/evidence_sources.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Provides read-only access to the external sources used by collector scripts.
-# rubocop:disable Metrics/ModuleLength
+# rubocop:disable Metrics/ModuleLength, Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 module EvidenceSources
   MAX_CONCURRENT_SOURCES = 4
   SOURCE_TIMEOUT_SECONDS = 30
@@ -273,6 +273,95 @@ module EvidenceSources
     keys.each_with_object({}) { |key, result| result[key] = hash[key] if hash.key?(key) }
   end
 
+  def collect_digitalocean
+    token = ENV.fetch('DIGITALOCEAN_ACCESS_TOKEN', nil)
+    return unavailable('DIGITALOCEAN_ACCESS_TOKEN is not set') if token.nil? || token.empty?
+
+    data = http_json('https://api.digitalocean.com/v2/kubernetes/clusters', 'Authorization' => "Bearer #{token}")
+    { status: 'used', clusters: data.fetch('kubernetes_clusters', []).map do |cluster|
+      pick(cluster, 'name', 'region', 'version', 'status', 'created_at')
+    end }
+  rescue StandardError => e
+    unavailable_for_error(e)
+  end
+
+  def collect_kubernetes(name)
+    return unavailable('kubectl is not installed') unless command_available?('kubectl')
+
+    context = capture('kubectl', 'config', 'current-context', allow_failure: true).strip
+    deployments = kubectl_json('get', 'deployments', '-A', '-o', 'json').fetch('items', []).select do |item|
+      item.dig('metadata', 'name')&.include?(name) || item.dig('metadata', 'namespace')&.include?(name)
+    end
+    pods = deployments.flat_map { |deployment| deployment_pods(deployment) }
+
+    {
+      status: 'used',
+      context: context,
+      deployments: deployments.map { |deployment| deployment_summary(deployment) },
+      pods: pods.map { |pod| pod_summary(pod) }
+    }
+  rescue StandardError => e
+    unavailable_for_error(e)
+  end
+
+  def deployment_pods(deployment)
+    namespace = deployment.dig('metadata', 'namespace')
+    labels = deployment.dig('spec', 'selector', 'matchLabels') || {}
+    selector = labels.map { |key, value| "#{key}=#{value}" }.join(',')
+    return [] if selector.empty?
+
+    kubectl_json('get', 'pods', '-n', namespace, '-l', selector, '-o', 'json').fetch('items', [])
+  end
+
+  def deployment_summary(deployment)
+    status = deployment.fetch('status', {})
+    spec = deployment.fetch('spec', {})
+    container = deployment.dig('spec', 'template', 'spec', 'containers', 0) || {}
+    {
+      namespace: deployment.dig('metadata', 'namespace'),
+      name: deployment.dig('metadata', 'name'),
+      desired_replicas: spec['replicas'],
+      ready_replicas: status['readyReplicas'] || 0,
+      available_replicas: status['availableReplicas'] || 0,
+      updated_replicas: status['updatedReplicas'] || 0,
+      image: container['image']
+    }
+  end
+
+  def pod_summary(pod)
+    statuses = pod.dig('status', 'containerStatuses') || []
+    conditions = pod.dig('status', 'conditions') || []
+    ready_condition = conditions.find { |condition| condition['type'] == 'Ready' }
+    {
+      namespace: pod.dig('metadata', 'namespace'),
+      name: pod.dig('metadata', 'name'),
+      phase: pod.dig('status', 'phase'),
+      ready: ready_condition ? ready_condition['status'] == 'True' : false,
+      restarts: statuses.sum { |status| status['restartCount'].to_i },
+      started_at: pod.dig('status', 'startTime')
+    }
+  end
+
+  def find_uptimerobot_monitor(data, name)
+    data.fetch('monitors', []).find do |item|
+      [item['friendly_name'], item['url']].compact.any? { |value| value.include?(name) }
+    end
+  end
+
+  def unavailable_source?(value)
+    value.is_a?(Hash) && %w[skipped unavailable].include?(value[:status])
+  end
+
+  def circleci_token
+    token = ENV['CIRCLE_TOKEN'] || ENV['CIRCLECI_TOKEN'] || ENV.fetch('CIRCLECI_CLI_TOKEN', nil)
+    return token unless token.nil? || token.empty?
+
+    path = ENV['CIRCLECI_CLI_CONFIG'] || File.join(Dir.home, '.circleci', 'cli.yml')
+    return nil unless File.exist?(path)
+
+    YAML.safe_load_file(path).fetch('token')
+  end
+
   def parse_owner_repo(remote)
     clean = remote.delete_suffix('.git')
     return Regexp.last_match(1) if clean.match(/\Agit@github\.com:(.+)\z/)
@@ -294,4 +383,4 @@ module EvidenceSources
     { status: 'unavailable', reason: reason }
   end
 end
-# rubocop:enable Metrics/ModuleLength
+# rubocop:enable Metrics/ModuleLength, Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/skills/diagnose-issue/scripts/collect
+++ b/skills/diagnose-issue/scripts/collect
@@ -1,75 +1,10 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC1091
 # Runs the diagnose-issue collector with completed-run validation and one bounded retry.
 
 set -eo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-max_attempts=2
-attempt=1
-diagnosis_output=""
+source "$script_dir/../../../lib/skills/collector.sh"
 
-cleanup() {
-  [[ -z $diagnosis_output ]] || rm -f "$diagnosis_output"
-}
-
-interrupted() {
-  printf 'diagnose-issue: collector invocation interrupted; output was discarded\n' >&2
-  exit 130
-}
-
-trap cleanup EXIT
-trap interrupted HUP INT TERM
-
-if ! command -v ruby >/dev/null 2>&1; then
-  printf 'diagnose-issue: ruby is required to run the collector\n' >&2
-  exit 127
-fi
-
-for argument in "$@"; do
-  if [[ $argument == '--help' || $argument == '-h' ]]; then
-    exec ruby "$script_dir/collect.rb" "$@"
-  fi
-done
-
-if ! command -v jq >/dev/null 2>&1; then
-  printf 'diagnose-issue: jq is required to validate collector output\n' >&2
-  exit 127
-fi
-
-while ((attempt <= max_attempts)); do
-  diagnosis_output="$(mktemp "${TMPDIR:-/tmp}/diagnose-issue.XXXXXX")"
-
-  set +e
-  ruby "$script_dir/collect.rb" "$@" > "$diagnosis_output"
-  rc=$?
-  set -e
-
-  validation_error=""
-  if ((rc != 0)); then
-    validation_error="collector completed with exit code $rc"
-  elif ! test -s "$diagnosis_output"; then
-    validation_error='collector completed without JSON output'
-  elif ! jq empty "$diagnosis_output" >/dev/null 2>&1; then
-    validation_error='collector completed with invalid JSON output'
-  elif ! jq -e -s 'length == 1 and (.[0] | type == "object")' "$diagnosis_output" >/dev/null; then
-    validation_error='collector completed without exactly one JSON object'
-  fi
-
-  if [[ -z $validation_error ]]; then
-    cat "$diagnosis_output"
-    exit 0
-  fi
-
-  if ((attempt == max_attempts)); then
-    printf 'diagnose-issue: %s after retry\n' "$validation_error" >&2
-    if ((rc == 0)); then
-      rc=1
-    fi
-    exit "$rc"
-  fi
-
-  printf 'diagnose-issue: %s; retrying once\n' "$validation_error" >&2
-  rm -f "$diagnosis_output"
-  diagnosis_output=""
-  ((attempt += 1))
-done
+run_skill_collector 'diagnose-issue' "$script_dir/collect.rb" "$@"

--- a/skills/diagnose-issue/scripts/collect.rb
+++ b/skills/diagnose-issue/scripts/collect.rb
@@ -897,46 +897,6 @@ class IssueDiagnosisCollector
     status && !%w[success running on_hold not_run].include?(status)
   end
 
-  def collect_digitalocean
-    token = ENV.fetch('DIGITALOCEAN_ACCESS_TOKEN', nil)
-    return unavailable('DIGITALOCEAN_ACCESS_TOKEN is not set') if token.nil? || token.empty?
-
-    data = http_json('https://api.digitalocean.com/v2/kubernetes/clusters', 'Authorization' => "Bearer #{token}")
-    { status: 'used', clusters: data.fetch('kubernetes_clusters', []).map do |cluster|
-      pick(cluster, 'name', 'region', 'version', 'status', 'created_at')
-    end }
-  rescue StandardError => e
-    unavailable_for_error(e)
-  end
-
-  def collect_kubernetes(name)
-    return unavailable('kubectl is not installed') unless command_available?('kubectl')
-
-    context = capture('kubectl', 'config', 'current-context', allow_failure: true).strip
-    deployments = kubectl_json('get', 'deployments', '-A', '-o', 'json').fetch('items', []).select do |item|
-      item.dig('metadata', 'name')&.include?(name) || item.dig('metadata', 'namespace')&.include?(name)
-    end
-    pods = deployments.flat_map { |deployment| deployment_pods(deployment) }
-
-    {
-      status: 'used',
-      context: context,
-      deployments: deployments.map { |deployment| deployment_summary(deployment) },
-      pods: pods.map { |pod| pod_summary(pod) }
-    }
-  rescue StandardError => e
-    unavailable_for_error(e)
-  end
-
-  def deployment_pods(deployment)
-    namespace = deployment.dig('metadata', 'namespace')
-    labels = deployment.dig('spec', 'selector', 'matchLabels') || {}
-    selector = labels.map { |key, value| "#{key}=#{value}" }.join(',')
-    return [] if selector.empty?
-
-    kubectl_json('get', 'pods', '-n', namespace, '-l', selector, '-o', 'json').fetch('items', [])
-  end
-
   def collect_uptimerobot(name)
     key = ENV.fetch('UPTIMEROBOT_API_KEY', '').strip
     return unavailable('UPTIMEROBOT_API_KEY is not set') if key.empty?
@@ -957,35 +917,6 @@ class IssueDiagnosisCollector
     { status: 'used', monitor: symbolize(pick(monitor, 'id', 'friendly_name', 'status')) }
   rescue StandardError => e
     unavailable_for_error(e)
-  end
-
-  def deployment_summary(deployment)
-    status = deployment.fetch('status', {})
-    spec = deployment.fetch('spec', {})
-    container = deployment.dig('spec', 'template', 'spec', 'containers', 0) || {}
-    {
-      namespace: deployment.dig('metadata', 'namespace'),
-      name: deployment.dig('metadata', 'name'),
-      desired_replicas: spec['replicas'],
-      ready_replicas: status['readyReplicas'] || 0,
-      available_replicas: status['availableReplicas'] || 0,
-      updated_replicas: status['updatedReplicas'] || 0,
-      image: container['image']
-    }
-  end
-
-  def pod_summary(pod)
-    statuses = pod.dig('status', 'containerStatuses') || []
-    conditions = pod.dig('status', 'conditions') || []
-    ready_condition = conditions.find { |condition| condition['type'] == 'Ready' }
-    {
-      namespace: pod.dig('metadata', 'namespace'),
-      name: pod.dig('metadata', 'name'),
-      phase: pod.dig('status', 'phase'),
-      ready: ready_condition ? ready_condition['status'] == 'True' : false,
-      restarts: statuses.sum { |status| status['restartCount'].to_i },
-      started_at: pod.dig('status', 'startTime')
-    }
   end
 
   def pipeline_summary(pipeline)
@@ -1177,10 +1108,6 @@ class IssueDiagnosisCollector
     "; failed step #{step['name']} is #{step['status']}#{suffix}"
   end
 
-  def unavailable_source?(value)
-    value.is_a?(Hash) && %w[skipped unavailable].include?(value[:status])
-  end
-
   def failed_circleci_job?(job)
     job['stopped_at'] && !%w[success running on_hold not_run].include?(job['status'])
   end
@@ -1207,22 +1134,6 @@ class IssueDiagnosisCollector
     return "No CircleCI pipeline found for revision #{@revision}." if @revision
 
     "No CircleCI pipeline found for #{branch}."
-  end
-
-  def circleci_token
-    token = ENV['CIRCLE_TOKEN'] || ENV['CIRCLECI_TOKEN'] || ENV.fetch('CIRCLECI_CLI_TOKEN', nil)
-    return token unless token.nil? || token.empty?
-
-    path = ENV['CIRCLECI_CLI_CONFIG'] || File.join(Dir.home, '.circleci', 'cli.yml')
-    return nil unless File.exist?(path)
-
-    YAML.safe_load_file(path).fetch('token')
-  end
-
-  def find_uptimerobot_monitor(data, name)
-    data.fetch('monitors', []).find do |item|
-      [item['friendly_name'], item['url']].compact.any? { |value| value.include?(name) }
-    end
   end
 
   def current_branch

--- a/skills/repo-health/SKILL.md
+++ b/skills/repo-health/SKILL.md
@@ -42,11 +42,12 @@ reporting period and comparison period, not necessarily a local folder.
    available. It performs the local, GitHub, CircleCI,
    DigitalOcean/Kubernetes, and UptimeRobot read-only collection in one command
    and returns report-ready JSON with metrics and source summaries.
-   - Run it in the runtime's persistent command session. The wrapper runs one
-     collector process per attempt, validates its completed output, and retries
-     exactly once only after a completed run fails validation. Do not run one
-     process per metric or source. The collector writes machine-readable JSON
-     only to standard output and progress to standard error.
+   - Run it in the runtime's persistent command session; do not run one process
+     per metric or source. `scripts/collect` itself runs one collector attempt,
+     validates the completed output, and retries exactly once only after a
+     completed run fails validation, writing progress to standard error and
+     validated JSON to standard output. Record its exit code in `rc`, never
+     `status`: `status` is read-only in zsh.
    - Use `--sources local,github` to limit collection when the report needs a
     subset, or `--timeout SECONDS` to override the 240-second overall deadline.
    - Full collection can take time, especially when CircleCI is selected. After
@@ -54,14 +55,7 @@ reporting period and comparison period, not necessarily a local folder.
      30-second command wait as the session lifetime. Agents must not kill,
      cancel, or switch to manual fallback because a poll returns before the
      collector exits. Allow at least the configured 240-second timeout plus
-     final-output time before declaring the invocation timed out. Record the
-     completed process exit code in `rc`, never `status`: `status` is read-only
-     in zsh.
-   - Redirect the wrapper's standard output to a unique temporary file created
-     with `mktemp`; never let concurrent collector processes write to the same
-     path. After the session exits, require `rc` to be zero, the file to be
-     non-empty, `jq empty` to succeed, and `jq -e -s 'length == 1 and (.[0] |
-     type == "object")'` to succeed before parsing it.
+     final-output time before declaring the invocation timed out.
    - Do not retry an interruption or timeout: a session without a completed exit
      code or final output is an invocation failure, not source data. A completed
      zero-exit valid JSON result with an unavailable source is a

--- a/skills/repo-health/references/sources.md
+++ b/skills/repo-health/references/sources.md
@@ -22,14 +22,15 @@ Use the bundled collector as the default collection path when Ruby is
 available:
 
 ```bash
-report_output="$(mktemp "${TMPDIR:-/tmp}/repo-health.XXXXXX")"
-<skill-dir>/scripts/collect --repo <repo-path> > "$report_output"
+<skill-dir>/scripts/collect --repo <repo-path>
 rc=$?
-test "$rc" -eq 0
-test -s "$report_output"
-jq empty "$report_output"
-jq -e -s 'length == 1 and (.[0] | type == "object")' "$report_output" >/dev/null
 ```
+
+`scripts/collect` already runs exactly one collector process per attempt,
+validates the completed run's exit code, output, and JSON shape (non-empty,
+`jq empty`, exactly one JSON object), and retries once before giving up; trust
+its own validated `rc` and standard output directly instead of re-validating
+them.
 
 Full collection can take time, especially when CircleCI is selected. Start this
 command in the runtime's persistent session, then poll that same session until
@@ -38,13 +39,6 @@ deadline: agents must not kill, cancel, or switch to manual fallback because a
 poll returns before the collector exits. Allow the configured 240 seconds (or
 the supplied `--timeout`) plus final-output time. Record the completed command's
 exit code as `rc`; do not use `status`, which is read-only in zsh.
-
-`collect` runs exactly one collector process per attempt, writes its standard
-output to a fresh internal `mktemp` file, validates the completed run, and
-retries once only when that completed run has a non-zero exit code, empty output,
-invalid JSON, or anything other than exactly one JSON object. The outer
-`report_output` must still pass the checks above before parsing. Concurrent
-invocations must never write to the same output path.
 
 Do not retry when the persistent session is interrupted or timed out before it
 returns a completed `rc` and final output: classify that as `interrupted or
@@ -146,9 +140,10 @@ Common environment variables:
 
 - `CIRCLE_TOKEN`
 - `CIRCLECI_TOKEN`
+- `CIRCLECI_CLI_TOKEN`
 
-If neither environment variable is set, check the CircleCI CLI config at
-`${CIRCLECI_CLI_CONFIG:-$HOME/.circleci/cli.yml}` and use its `token` field
+If none of these environment variables is set, check the CircleCI CLI config
+at `${CIRCLECI_CLI_CONFIG:-$HOME/.circleci/cli.yml}` and use its `token` field
 when present. Do not print the token.
 
 The common project slug shape is `gh/<owner>/<repo>`. If the slug is ambiguous,

--- a/skills/repo-health/scripts/collect
+++ b/skills/repo-health/scripts/collect
@@ -1,69 +1,10 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC1091
 # Runs the repo-health collector with completed-run validation and one bounded retry.
 
 set -eo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-max_attempts=2
-attempt=1
-report_output=""
+source "$script_dir/../../../lib/skills/collector.sh"
 
-cleanup() {
-  [[ -z $report_output ]] || rm -f "$report_output"
-}
-
-interrupted() {
-  printf 'repo-health: collector invocation interrupted; output was discarded\n' >&2
-  exit 130
-}
-
-trap cleanup EXIT
-trap interrupted HUP INT TERM
-
-if ! command -v ruby >/dev/null 2>&1; then
-  printf 'repo-health: ruby is required to run the collector\n' >&2
-  exit 127
-fi
-
-if ! command -v jq >/dev/null 2>&1; then
-  printf 'repo-health: jq is required to validate collector output\n' >&2
-  exit 127
-fi
-
-while ((attempt <= max_attempts)); do
-  report_output="$(mktemp "${TMPDIR:-/tmp}/repo-health.XXXXXX")"
-
-  set +e
-  ruby "$script_dir/collect.rb" "$@" > "$report_output"
-  rc=$?
-  set -e
-
-  validation_error=""
-  if ((rc != 0)); then
-    validation_error="collector completed with exit code $rc"
-  elif ! test -s "$report_output"; then
-    validation_error='collector completed without JSON output'
-  elif ! jq empty "$report_output" >/dev/null 2>&1; then
-    validation_error='collector completed with invalid JSON output'
-  elif ! jq -e -s 'length == 1 and (.[0] | type == "object")' "$report_output" >/dev/null; then
-    validation_error='collector completed without exactly one JSON object'
-  fi
-
-  if [[ -z $validation_error ]]; then
-    cat "$report_output"
-    exit 0
-  fi
-
-  if ((attempt == max_attempts)); then
-    printf 'repo-health: %s after retry\n' "$validation_error" >&2
-    if ((rc == 0)); then
-      rc=1
-    fi
-    exit "$rc"
-  fi
-
-  printf 'repo-health: %s; retrying once\n' "$validation_error" >&2
-  rm -f "$report_output"
-  report_output=""
-  ((attempt += 1))
-done
+run_skill_collector 'repo-health' "$script_dir/collect.rb" "$@"

--- a/skills/repo-health/scripts/collect.rb
+++ b/skills/repo-health/scripts/collect.rb
@@ -454,45 +454,6 @@ class RepoHealthCollector
     end
   end
 
-  def collect_digitalocean
-    token = ENV.fetch('DIGITALOCEAN_ACCESS_TOKEN', nil)
-    return unavailable('DIGITALOCEAN_ACCESS_TOKEN is not set') if token.nil? || token.empty?
-
-    data = http_json('https://api.digitalocean.com/v2/kubernetes/clusters', 'Authorization' => "Bearer #{token}")
-    { status: 'used', clusters: data.fetch('kubernetes_clusters', []).map do |cluster|
-      pick(cluster, 'name', 'region', 'version', 'status', 'created_at')
-    end }
-  rescue StandardError => e
-    unavailable_for_error(e)
-  end
-
-  def collect_kubernetes(name)
-    return unavailable('kubectl is not installed') unless command_available?('kubectl')
-
-    context = capture('kubectl', 'config', 'current-context', allow_failure: true).strip
-    deployments = kubectl_json('get', 'deployments', '-A', '-o', 'json').fetch('items', []).select do |item|
-      item.dig('metadata', 'name')&.include?(name) || item.dig('metadata', 'namespace')&.include?(name)
-    end
-
-    pods = deployments.flat_map do |deployment|
-      namespace = deployment.dig('metadata', 'namespace')
-      labels = deployment.dig('spec', 'selector', 'matchLabels') || {}
-      selector = labels.map { |key, value| "#{key}=#{value}" }.join(',')
-      next [] if selector.empty?
-
-      kubectl_json('get', 'pods', '-n', namespace, '-l', selector, '-o', 'json').fetch('items', [])
-    end
-
-    {
-      status: 'used',
-      context: context,
-      deployments: deployments.map { |deployment| deployment_summary(deployment) },
-      pods: pods.map { |pod| pod_summary(pod) }
-    }
-  rescue StandardError => e
-    unavailable_for_error(e)
-  end
-
   def collect_uptimerobot(name)
     key = ENV.fetch('UPTIMEROBOT_API_KEY', '').strip
     return unavailable('UPTIMEROBOT_API_KEY is not set') if key.empty?
@@ -540,47 +501,12 @@ class RepoHealthCollector
     unavailable_for_error(e)
   end
 
-  def deployment_summary(deployment)
-    status = deployment.fetch('status', {})
-    spec = deployment.fetch('spec', {})
-    container = deployment.dig('spec', 'template', 'spec', 'containers', 0) || {}
-    {
-      namespace: deployment.dig('metadata', 'namespace'),
-      name: deployment.dig('metadata', 'name'),
-      desired_replicas: spec['replicas'],
-      ready_replicas: status['readyReplicas'] || 0,
-      available_replicas: status['availableReplicas'] || 0,
-      updated_replicas: status['updatedReplicas'] || 0,
-      image: container['image']
-    }
-  end
-
-  def pod_summary(pod)
-    statuses = pod.dig('status', 'containerStatuses') || []
-    conditions = pod.dig('status', 'conditions') || []
-    ready_condition = conditions.find { |condition| condition['type'] == 'Ready' }
-    {
-      namespace: pod.dig('metadata', 'namespace'),
-      name: pod.dig('metadata', 'name'),
-      phase: pod.dig('status', 'phase'),
-      ready: ready_condition ? ready_condition['status'] == 'True' : false,
-      restarts: statuses.sum { |status| status['restartCount'].to_i },
-      started_at: pod.dig('status', 'startTime')
-    }
-  end
-
   def response_samples(samples, start_time, end_time)
     selected = samples.select do |sample|
       timestamp = sample.fetch('datetime').to_i
       timestamp >= start_time.to_i && timestamp < end_time.to_i
     end
     selected.map { |sample| sample.fetch('value').to_f }
-  end
-
-  def find_uptimerobot_monitor(data, name)
-    data.fetch('monitors', []).find do |item|
-      [item['friendly_name'], item['url']].compact.any? { |value| value.include?(name) }
-    end
   end
 
   def summary_result(result)
@@ -1168,10 +1094,6 @@ class RepoHealthCollector
     github[key] if github.is_a?(Hash) && !github[:status]
   end
 
-  def unavailable_source?(value)
-    value.is_a?(Hash) && %w[skipped unavailable].include?(value[:status])
-  end
-
   def uptime_ranges(uptimerobot)
     uptimerobot.fetch(:uptime_ranges, '').split('-')
   end
@@ -1216,16 +1138,6 @@ class RepoHealthCollector
         job.merge('workflow_id' => workflow.fetch('id'), 'workflow_created_at' => workflow.fetch('created_at'))
       end
     end
-  end
-
-  def circleci_token
-    token = ENV['CIRCLE_TOKEN'] || ENV.fetch('CIRCLECI_TOKEN', nil)
-    return token unless token.nil? || token.empty?
-
-    path = ENV['CIRCLECI_CLI_CONFIG'] || File.join(Dir.home, '.circleci', 'cli.yml')
-    return nil unless File.exist?(path)
-
-    YAML.safe_load_file(path).fetch('token')
   end
 
   def gh_pr_list(*)

--- a/test/skills/lint
+++ b/test/skills/lint
@@ -237,10 +237,8 @@ PATTERNS
 
 require_patterns skills/repo-health/scripts/collect <<'PATTERNS'
 collect.rb
-rc=$?
-test -s
-jq empty
-length == 1 and (.[0] | type == "object")
+run_skill_collector
+lib/skills/collector.sh
 PATTERNS
 
 reject_pattern skills/repo-health/scripts/collect 'status='
@@ -259,13 +257,21 @@ require_pattern_in_files 'scripts/collect' \
 
 require_patterns skills/diagnose-issue/scripts/collect <<'PATTERNS'
 collect.rb
+run_skill_collector
+lib/skills/collector.sh
+PATTERNS
+
+reject_pattern skills/diagnose-issue/scripts/collect 'status='
+
+# Shared collector retry/validation contract sourced by both scripts/collect above.
+require_patterns lib/skills/collector.sh <<'PATTERNS'
 rc=$?
 test -s
 jq empty
 length == 1 and (.[0] | type == "object")
 PATTERNS
 
-reject_pattern skills/diagnose-issue/scripts/collect 'status='
+reject_pattern lib/skills/collector.sh 'status='
 
 # Testing and language-standard contracts.
 require_patterns skills/testing-standards/SKILL.md <<'PATTERNS'


### PR DESCRIPTION
## What

- Extracted the collector retry/validation wrapper duplicated between `skills/repo-health/scripts/collect` and `skills/diagnose-issue/scripts/collect` into a shared `run_skill_collector` function in `lib/skills/collector.sh`; both wrapper scripts now source it instead of repeating the same Bash logic.
- Moved the duplicated `collect_digitalocean`, `collect_kubernetes`, `deployment_pods`, `deployment_summary`, `pod_summary`, `find_uptimerobot_monitor`, `unavailable_source?`, and `circleci_token` helpers out of both `collect.rb` files into the shared `EvidenceSources` module (`lib/skills/evidence_sources.rb`), which both collectors already include.
- As a side effect, `skills/repo-health`'s `circleci_token` now also falls back to `CIRCLECI_CLI_TOKEN`, a fallback `skills/diagnose-issue` already had; `skills/repo-health/references/sources.md` documents the added environment variable.
- Updated `skills/repo-health/SKILL.md` and `references/sources.md` prose so the retry/validation contract is described once as owned by `scripts/collect`, instead of also asking the caller to re-validate output the wrapper already validates.
- Updated `test/skills/lint` to check both wrapper scripts source `lib/skills/collector.sh` and call `run_skill_collector`, and to check the shared library itself for the retry/validation contract markers instead of duplicating that check per wrapper.

## Why

- Both skills carried byte-identical Bash retry/validation logic and byte-identical Ruby collector methods for DigitalOcean, Kubernetes, UptimeRobot, and CircleCI token resolution. A future fix to one had to be replicated in the other by hand, risking silent drift between the two collectors.
- Consolidating into one shared shell library and one shared Ruby module removes that duplication risk and gives `skills/repo-health` the same `CIRCLECI_CLI_TOKEN` fallback `skills/diagnose-issue` already had.

## Testing

- `make scripts-lint` - passed
- `make skills-lint` - passed
- `make lint` - passed
- Ran `skills/repo-health/scripts/collect --repo . --sources local --timeout 30` and `skills/diagnose-issue/scripts/collect --mode ci --repo .` end-to-end against this repository through the new shared `run_skill_collector` path; both returned valid single-JSON-object output.
- No Ruby unit tests exist for these collector helpers before or after this change; coverage remains at the `test/skills/lint` pattern-contract layer plus the manual end-to-end runs above.
