### PR TITLE
feat(skills): avoid unrelated revision ci results

### DIFF
--- a/skills/diagnose-issue/scripts/collect.rb
+++ b/skills/diagnose-issue/scripts/collect.rb
@@ -177,6 +177,8 @@ class IssueDiagnosisCollector
     if pipeline.nil?
       pipeline = if @pipeline
                    circleci_pipeline_target(owner_repo, @pipeline, token)
+                 elsif @revision
+                   nil
                  else
                    latest_circleci_pipeline(owner_repo, branch, token)
                  end


### PR DESCRIPTION
## What

- Prevent revision-scoped CI diagnosis from selecting an unrelated latest branch pipeline when CircleCI has no matching revision pipeline.
- Preserve the existing commit-status fallback and revision-specific unavailable result.

## Why

- A requested commit could be reported as healthy using another commit's pipeline, hiding its actual failure or lack of CI evidence.

## Testing

- `make lint` - passed
- `make skills-lint` - passed
- `ruby -c skills/diagnose-issue/scripts/collect.rb` - passed
- No dedicated behavioral test was added because this repository has no collector test harness; an interaction test would assert internal provider fallback order rather than a supported repository-owned boundary.
