### PR TITLE
feat(git): enable isolated branch checkouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,36 @@ Projects that use the shared git workflow can include it separately:
 include bin/build/make/git.mak
 ```
 
+### Git Worktrees
+
+The git fragment can create local worktrees for independently checked-out
+feature branches. Keep the primary checkout on `master`, then create and work
+from a sibling directory:
+
+```bash
+make add-feature-worktree name=login worktree=../app-login
+cd ../app-login
+make review msg="add login flow" desc="..."
+```
+
+This fetches `origin`, creates a branch named
+`<username>-<random>/feat/login` from `origin/master`, and initializes
+submodules in the new worktree. `add-worktree` is also available when you need
+to provide a branch prefix directly:
+
+```bash
+make add-worktree branch=fix/login worktree=../app-login-fix
+```
+
+List and remove worktrees from the primary checkout. Removal refuses a dirty
+worktree and does not delete its branch:
+
+```bash
+make list-worktrees
+make remove-worktree worktree=../app-login
+make prune-worktrees
+```
+
 Consuming repositories choose which fragments to include and remain responsible
 for project-specific configuration such as service code, image names, release
 version files, and environment-specific settings.

--- a/build/git/worktree
+++ b/build/git/worktree
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Manage local Git worktrees for the shared Make targets.
+
+set -eo pipefail
+
+readonly action="${1:-}"
+
+case "$action" in
+add)
+  readonly worktree="${2:-}"
+  readonly branch="${3:-}"
+  readonly user="${4:-}"
+
+  if [[ -z $worktree ]]; then
+    printf '%s\n' 'bin: worktree is required (set worktree=<path>)' >&2
+    exit 2
+  fi
+
+  if [[ -z $branch ]]; then
+    printf '%s\n' 'bin: branch is required (set branch=<branch>)' >&2
+    exit 2
+  fi
+
+  readonly full_branch="$user/$branch"
+
+  if ! git check-ref-format --branch "$full_branch" >/dev/null 2>&1; then
+    printf '%s\n' 'bin: branch is invalid' >&2
+    exit 2
+  fi
+
+  git fetch origin
+  git worktree add -b "$full_branch" -- "$worktree" origin/master
+  git -C "$worktree" submodule sync
+  git -C "$worktree" submodule update --init
+  printf "bin: added worktree '%s' on branch '%s'\n" "$worktree" "$full_branch"
+  ;;
+list)
+  git worktree list
+  ;;
+remove)
+  readonly worktree="${2:-}"
+
+  if [[ -z $worktree ]]; then
+    printf '%s\n' 'bin: worktree is required (set worktree=<path>)' >&2
+    exit 2
+  fi
+
+  git worktree remove -- "$worktree"
+  ;;
+prune)
+  git worktree prune
+  ;;
+*)
+  printf '%s\n' 'usage: worktree {add <path> <branch> <user>|list|remove <path>|prune}' >&2
+  exit 2
+  ;;
+esac

--- a/build/make/claude.mak
+++ b/build/make/claude.mak
@@ -1,5 +1,3 @@
-.PHONY: claude-init
-
 BIN_ROOT ?= $(abspath $(dir $(lastword $(MAKEFILE_LIST)))../..)
 
 # Wire this repository for Claude Code using the shared bin skills.

--- a/build/make/codex.mak
+++ b/build/make/codex.mak
@@ -1,5 +1,3 @@
-.PHONY: codex-init
-
 BIN_ROOT ?= $(abspath $(dir $(lastword $(MAKEFILE_LIST)))../..)
 
 # Wire this repository for Codex using shared skills, permissions, and rules.

--- a/build/make/git.mak
+++ b/build/make/git.mak
@@ -3,11 +3,9 @@
 BIN_ROOT ?= $(abspath $(dir $(lastword $(MAKEFILE_LIST)))../..)
 
 USER:=$(shell $(BIN_ROOT)/build/git/user)
-BRANCH:=$(shell git branch --show-current)
-export BRANCH
+export BRANCH := $(shell git branch --show-current)
 NEW_BRANCH:=$(subst $() ,-,$(name))
-PREFIX:=$(shell $(BIN_ROOT)/build/git/prefix)
-export PREFIX
+export PREFIX := $(shell $(BIN_ROOT)/build/git/prefix)
 
 override export msg := $(value msg)
 override export desc := $(value desc)
@@ -84,6 +82,50 @@ new-refactor: new-branch
 # Start a new release branch (name=<branch>, runs latest first).
 new-release: branch=release/$(NEW_BRANCH)
 new-release: new-branch
+
+# Add a worktree on a new username-random/$(branch) branch from origin/master (set branch and worktree).
+add-worktree:
+	@$(BIN_ROOT)/build/git/worktree add "$(worktree)" "$(branch)" "$(USER)"
+
+# Add a feature worktree (name=<branch>, worktree=<path>).
+add-feature-worktree: branch=feat/$(NEW_BRANCH)
+add-feature-worktree: add-worktree
+
+# Add a fix worktree (name=<branch>, worktree=<path>).
+add-fix-worktree: branch=fix/$(NEW_BRANCH)
+add-fix-worktree: add-worktree
+
+# Add a build worktree (name=<branch>, worktree=<path>).
+add-build-worktree: branch=build/$(NEW_BRANCH)
+add-build-worktree: add-worktree
+
+# Add a test worktree (name=<branch>, worktree=<path>).
+add-test-worktree: branch=test/$(NEW_BRANCH)
+add-test-worktree: add-worktree
+
+# Add a docs worktree (name=<branch>, worktree=<path>).
+add-docs-worktree: branch=docs/$(NEW_BRANCH)
+add-docs-worktree: add-worktree
+
+# Add a refactor worktree (name=<branch>, worktree=<path>).
+add-refactor-worktree: branch=refactor/$(NEW_BRANCH)
+add-refactor-worktree: add-worktree
+
+# Add a release worktree (name=<branch>, worktree=<path>).
+add-release-worktree: branch=release/$(NEW_BRANCH)
+add-release-worktree: add-worktree
+
+# List registered worktrees.
+list-worktrees:
+	@$(BIN_ROOT)/build/git/worktree list
+
+# Remove a clean worktree without deleting its branch (set worktree=<path>).
+remove-worktree:
+	@$(BIN_ROOT)/build/git/worktree remove "$(worktree)"
+
+# Prune stale worktree metadata.
+prune-worktrees:
+	@$(BIN_ROOT)/build/git/worktree prune
 
 # Delete the current branch.
 delete:


### PR DESCRIPTION
## What

- Add documented Make targets for creating, listing, removing, and pruning local Git worktrees, with a shared helper that creates namespaced branches from `origin/master` and initializes submodules.
- Keep the agent bootstrap targets non-phony, matching the repository's selective `.PHONY` policy.

## Why

- Contributors can now work on isolated feature branches without manual Git worktree setup while preserving the shared branch naming, remote base, and submodule initialization conventions.
- The README gives downstream users a supported workflow and explains cleanup boundaries: dirty worktrees are refused and removing a worktree keeps its branch.

## Testing

- `make scripts-lint && make skills-lint && make docker-lint && make lint && make sec` - passed.
- Isolated local Git fixture invoking `add-feature-worktree`, `list-worktrees`, `remove-worktree`, and `prune-worktrees` - passed; it also verified that a missing worktree argument fails safely.
- No new automated test harness exists for these Make and shell command flows; the public commands were exercised through their downstream-style entrypoints.

AI-assisted-by: [Codex](https://openai.com/codex/)
