### PR TITLE
feat(skills): verify intended compatibility changes during review

### DIFF
--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -38,6 +38,14 @@ These rules remain mandatory:
   `make review` while blocking findings remain unless the human explicitly says
   to open a draft PR with those findings unresolved; in that case, call them out
   in the PR summary.
+- For an apparent breaking change, establish whether it is intended before
+  treating it as a blocking finding or changing the reviewed work. Compare the
+  request and PR context with the changed contract, documentation, tests, and
+  supported usage. Do not undo, revert, discard, or replace changes merely to
+  clear the finding. If intent remains unclear, stop and ask the human, stating
+  the impact and practical remedies. If the break is intentional, preserve it
+  and document its compatibility and migration implications; if it is
+  unintended, present the proposed fix and get approval before editing.
 - If `$code-review` reports security findings or security validation gaps, resolve them or document them in the PR summary before `make review`.
 - Treat `$style-review` notes as non-blocking unless the user explicitly asks to resolve them before opening the PR.
 - Draft the `msg` and `desc` from `references/summary-format.md`. Keep `msg`

--- a/skills/review-pr/agents/openai.yaml
+++ b/skills/review-pr/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Review PR"
-  short_description: "Prepare a portable approved review PR flow"
-  default_prompt: "Use $review-pr for the current repository's full review PR workflow: validate and review changes, commit, force-push, and open a draft PR. Maintain its active plan, use runtime goals only when authorized, ask before replacing an existing PR description, use a fresh review gate for substantial changes, include review-time documentation judgment through $doc-standards, create a portable desc_file without asking me for it, request Make-owned cleanup with cleanup_desc_file=true, and put the guarded Make review target before its variable assignments."
+  short_description: "Prepare a safe review PR flow"
+  default_prompt: "Use $review-pr to validate and review local changes, verify whether an apparent breaking change is intentional before proposing a fix, then commit, force-push, and open a draft PR."

--- a/skills/review-pr/references/plan.md
+++ b/skills/review-pr/references/plan.md
@@ -60,16 +60,24 @@ repository root and keep `bin/` as shared guidance.
    review.
 10. Run `$style-review` only when the human explicitly asked for non-blocking
    polish.
-11. Resolve blocking review findings or get explicit approval to open the draft
-    PR with unresolved findings documented.
-12. Read `references/summary-format.md`.
-13. Draft the lowercase, unprefixed `msg` and multiline Markdown `desc`.
-14. Create `desc_file` yourself with
+11. Investigate review findings. For an apparent breaking change,
+    establish intent from the request and PR context, changed contract,
+    documentation, tests, and supported usage before treating it as blocking or
+    modifying the reviewed work. Do not undo, revert, discard, or replace
+    changes merely to clear the finding. If intent is unclear, stop and ask the
+    human with the impact and practical remedies. If intentional, preserve the
+    change and document compatibility and migration implications; if
+    unintended, present the proposed fix and get approval before editing.
+12. Resolve confirmed blocking review findings or get explicit approval to open
+    the draft PR with unresolved findings documented.
+13. Read `references/summary-format.md`.
+14. Draft the lowercase, unprefixed `msg` and multiline Markdown `desc`.
+15. Create `desc_file` yourself with
     `mktemp "${TMPDIR:-/tmp}/review-pr.XXXXXX"`; never ask the user for the path
     or file contents. Capture the returned path and write `desc` to it.
-15. Substitute the returned path directly into
+16. Substitute the returned path directly into
     `make review cleanup_desc_file=true msg="..." desc_file="/returned/path/review-pr.ABC123"`.
-16. Rely on `make review` to remove the opted-in temporary `desc_file`,
+17. Rely on `make review` to remove the opted-in temporary `desc_file`,
     including when commit, push, or draft creation fails.
-17. Read `references/output-format.md`.
-18. Report the result in the required output format.
+18. Read `references/output-format.md`.
+19. Report the result in the required output format.


### PR DESCRIPTION
## What

- Require review PRs to verify whether an apparent breaking change is intended before treating it as blocking or changing reviewed work.
- Preserve intentional changes with compatibility and migration notes, and require approval before correcting unintended changes.

## Why

- Prevent review follow-up from undoing deliberate contract changes without first confirming their intent.

## Testing

- `make skills-lint` - passed
- `git diff --check` - passed
- No automated behavior test applies; repository skill validation covers frontmatter, metadata, and policy markers.

AI-assisted-by: [Codex](https://openai.com/codex/)
