### PR TITLE
feat(make): standardize test config extension to yaml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    json (2.21.1)
+    json (2.21.2)
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     logger (1.7.0)

--- a/build/go/dev
+++ b/build/go/dev
@@ -5,4 +5,4 @@ set -eo pipefail
 
 name="${1:?name is required}"
 
-air -c /dev/null --build.cmd "make dep build" --build.full_bin "cd test && ../$name server -config file:.config/server.yml" --build.exclude_dir "assets,bin,vendor,test"
+air -c /dev/null --build.cmd "make dep build" --build.full_bin "cd test && ../$name server -config file:.config/server.yaml" --build.exclude_dir "assets,bin,vendor,test"

--- a/build/make/_service.mak
+++ b/build/make/_service.mak
@@ -216,7 +216,7 @@ release-docker: build-docker trivy-image push-docker
 manifest-docker:
 	@$(BIN_ROOT)/build/docker/manifest "$${NAME}"
 
-# Base64-encode test/$(kind).yml as a single line.
+# Base64-encode test/$(kind).yaml as a single line.
 encode-config:
 	@$(BIN_ROOT)/build/test/encode-config
 

--- a/build/make/go.mak
+++ b/build/make/go.mak
@@ -134,7 +134,7 @@ trivy-repo:
 # Run security checks.
 sec: govulncheck trivy-repo
 
-# Base64-encode test/$(kind).yml as a single line.
+# Base64-encode test/$(kind).yaml as a single line.
 encode-config:
 	@$(BIN_ROOT)/build/test/encode-config
 

--- a/build/test/encode-config
+++ b/build/test/encode-config
@@ -9,4 +9,4 @@ validate_config
 
 readonly kind_value="${kind:-}"
 
-base64 -w 0 "test/$kind_value.yml"
+base64 -w 0 "test/$kind_value.yaml"


### PR DESCRIPTION
## What

- Rename the downstream test configuration file convention from `test/$(kind).yml` to `test/$(kind).yaml` in `build/make/_service.mak`, `build/make/go.mak`, and `build/test/encode-config` (the script behind `make encode-config`).
- Update `build/go/dev` (used by `make dev`) to read the local dev server config from `.config/server.yaml` instead of `.config/server.yml`.
- Compatibility note: consuming repositories that vendor this project as `./bin` must rename their `test/<kind>.yml` files and `test/.config/server.yml` to the `.yaml` extension, or `make encode-config` and `make dev` will fail to find the config file.

## Why

- Standardizes the shared tooling on a single `.yaml` extension for test configuration files instead of a mixed `.yml`/`.yaml` convention.

## Testing

- `make scripts-lint` - passed
- `git diff --check` - passed
- No Go or Ruby behavior changed; the edits are literal string updates in shell scripts and Make comments, so no new automated test coverage applies.
- Did not verify against a live downstream consumer repository from within this repo; the required consumer-side config rename is called out above for the reviewer to confirm before merging.
