### PR TITLE
feat(go): permit concurrent linter runs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,12 +13,12 @@ GEM
     prism (1.9.0)
     racc (1.8.1)
     rainbow (3.1.1)
-    rbs (4.1.1)
+    rbs (4.1.2)
       logger
       prism (>= 1.6.0)
       tsort
     regexp_parser (2.12.0)
-    rubocop (1.88.2)
+    rubocop (1.89.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)

--- a/build/make/go.mak
+++ b/build/make/go.mak
@@ -66,7 +66,7 @@ fix-field-alignment:
 
 # Run golangci-lint. Set package=internal/foo, not ./internal/foo, for one package.
 golangci-lint:
-	@$(BIN_ROOT)/build/go/lint run --timeout 5m
+	@$(BIN_ROOT)/build/go/lint run --allow-parallel-runners --timeout 5m
 
 # Auto-fix golangci-lint. Set package=internal/foo, not ./internal/foo.
 fix-golangci-lint:


### PR DESCRIPTION
## What

- Allow concurrent standard `golangci-lint` runs in downstream projects that include the shared Go Make fragment.

## Why

- Avoid file-lock failures when overlapping development or automation workflows invoke the shared lint target.

## Testing

- `make scripts-lint` - passed
- `make sec` - passed
- `make golangci-lint` - passed in an isolated downstream-style Go module, including two concurrent invocations.

AI-assisted-by: [Codex](https://openai.com/codex/)
